### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Built on the [Model Context Protocol](https://modelcontextprotocol.io/), pfc-mcp
 
 ![pfc-mcp demo](https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/pfc-mcp.gif)
 
+<a href="https://glama.ai/mcp/servers/yusong652/pfc-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/yusong652/pfc-mcp/badge" alt="pfc-mcp MCP server" />
+</a>
+
 ## Tools (10)
 
 ### Documentation (5) - no bridge required


### PR DESCRIPTION
This PR adds a badge for the [pfc-mcp](https://glama.ai/mcp/servers/yusong652/pfc-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/yusong652/pfc-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/yusong652/pfc-mcp/badge" alt="pfc-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.