### PR TITLE
fix(addon): harden pip bootstrap for PFC's embedded Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ section exists.
   PFC IPython console. The status banner shows URL + log path and stops.
   Ships when pfc-mcp's pin moves past `itasca-mcp-bridge` `bc68380`.
 
+### Fixed
+- `addon.py` no longer hard-codes pip's entry point to `pip.main`. That
+  symbol exists in pip <= 9 (what PFC 6.0 ships) and was later restored
+  as an internal shim, but it was absent in pip 10.0 through ~19.x -- a
+  PFC interpreter carrying a pip from that range crashed with
+  `AttributeError` instead of installing the bridge. The bootstrap now
+  probes `pip._internal.cli.main`, `pip._internal`, and `pip.main` in
+  turn, so it works regardless of which pip the embedded Python carries.
+- A failed bridge install now points at pip's real error output and
+  offers a manual `pip install` fallback, instead of surfacing only a
+  bare `exit code 2` that hid the underlying cause.
+
 ## [0.4.0] - 2026-05-22
 
 Bridge installation path migrates from `pfc-mcp-bridge` to `itasca-mcp-bridge`.

--- a/addon.py
+++ b/addon.py
@@ -62,20 +62,52 @@ def _build_install_args(index_url, trusted_hosts):
     return args
 
 
+def _resolve_pip_main():
+    """Locate pip's callable entry point.
+
+    There is no single stable location. `pip.main` exists in pip <= 9
+    (what PFC 6.0 ships), was removed in pip 10.0, and was later restored
+    as an internal-only shim; `pip._internal.main` covers pip 10 .. 19.2;
+    `pip._internal.cli.main.main` covers pip >= 19.3. The embedded PFC
+    Python may carry any pip version, so probe each location in turn
+    rather than guessing from the pip or Python version.
+    """
+    try:
+        from pip._internal.cli.main import main as pip_main  # pip >= 19.3
+
+        return pip_main
+    except Exception:
+        pass
+    try:
+        from pip._internal import main as pip_main  # pip 10 .. 19.2
+
+        return pip_main
+    except Exception:
+        pass
+    try:
+        from pip import main as pip_main  # pip <= 9 (PFC 6.0)
+
+        return pip_main
+    except Exception:
+        pass
+    return None
+
+
 def _run_pip(args):
-    if sys.version_info < (3, 10):
-        import pip
+    pip_main = _resolve_pip_main()
+    if pip_main is None:
+        raise RuntimeError(
+            "Could not locate pip's Python entry point in this PFC interpreter. "
+            "Install the bridge manually, then re-run this script:\n"
+            "    python -m pip install --user itasca-mcp-bridge"
+        )
 
-        return pip.main(args)
-
-    from pip._internal.cli.main import main as pip_main
-
-    # PFC 9 runs pip inside an IPython host; temporarily suppress logging
+    # PFC runs pip inside an IPython host; temporarily suppress logging
     # handler tracebacks that don't reflect actual installation failures.
     previous_raise_exceptions = logging.raiseExceptions
     logging.raiseExceptions = False
     try:
-        return pip_main(args)
+        return pip_main(list(args))
     finally:
         logging.raiseExceptions = previous_raise_exceptions
 
@@ -158,7 +190,14 @@ def main():
     if _prompt_for_upgrade(installed_version):
         code = _install_bridge()
         if code != 0:
-            raise RuntimeError("Bridge installation failed with exit code {}".format(code))
+            raise RuntimeError(
+                "Bridge installation failed (pip exit code {}). The real pip "
+                "error is in the output above this message -- read that, not "
+                "this line. Common causes: no network route to PyPI, or a "
+                "corporate proxy/firewall blocking the index. You can also "
+                "install manually and re-run this script:\n"
+                "    python -m pip install --user itasca-mcp-bridge".format(code)
+            )
     else:
         print("Skipping package upgrade.")
 

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -1,0 +1,235 @@
+"""Unit tests for the PFC bridge bootstrap script (``addon.py``).
+
+``addon.py`` runs inside PFC's embedded Python (3.6 on PFC 6/7), while this
+suite runs on the MCP package's interpreter (3.10+). These tests therefore
+guard the *control flow* of the bootstrap -- argument construction, the
+index-fallback loop, pip entry-point resolution, and the upgrade prompt --
+and deliberately do NOT exercise real pip behaviour or the in-PFC ``start()``
+path. Confirming the bootstrap against an actual PFC interpreter stays a
+manual step.
+"""
+
+import logging
+import sys
+import types
+
+import pytest
+
+import addon
+
+# --- _build_install_args -------------------------------------------------
+
+
+def test_build_install_args_core_structure():
+    args = addon._build_install_args("https://example.test/simple/", ())
+
+    assert args[0] == "install"
+    assert "--user" in args
+    assert "-U" in args
+    # The package to install is always the final positional argument.
+    assert args[-1] == addon.PACKAGE_NAME
+
+
+def test_build_install_args_index_url_paired_with_value():
+    url = "https://example.test/simple/"
+    args = addon._build_install_args(url, ())
+
+    assert args[args.index("--index-url") + 1] == url
+
+
+def test_build_install_args_one_trusted_host_flag_per_host():
+    hosts = ("a.example", "b.example", "c.example")
+    args = addon._build_install_args("https://example.test/simple/", hosts)
+
+    assert args.count("--trusted-host") == len(hosts)
+    for host in hosts:
+        # Every host value is introduced by its own --trusted-host flag.
+        assert args[args.index(host) - 1] == "--trusted-host"
+
+
+def test_build_install_args_no_trusted_host_when_empty():
+    args = addon._build_install_args("https://example.test/simple/", ())
+
+    assert "--trusted-host" not in args
+
+
+def test_build_install_args_progress_flags_track_python_version():
+    # The quiet-output flags are gated on the *runner* interpreter; pin that
+    # documented behaviour rather than a fixed expectation.
+    args = addon._build_install_args("https://example.test/simple/", ())
+    flags_present = "--no-warn-script-location" in args
+
+    assert flags_present is (sys.version_info >= (3, 10))
+
+
+# --- _resolve_pip_main ---------------------------------------------------
+
+
+def test_resolve_pip_main_prefers_modern_entry_point(monkeypatch):
+    # _resolve_pip_main returns the entry point opaquely, so a marker value
+    # under the `.main` attribute is enough to assert which probe won.
+    cli_mod = types.ModuleType("pip._internal.cli.main")
+    cli_mod.main = "modern-entry-point"
+    internal_mod = types.ModuleType("pip._internal")
+    internal_mod.main = "legacy-internal-entry-point"
+    monkeypatch.setitem(sys.modules, "pip._internal.cli.main", cli_mod)
+    monkeypatch.setitem(sys.modules, "pip._internal", internal_mod)
+
+    # Even with the older entry point also importable, the modern one wins.
+    assert addon._resolve_pip_main() == "modern-entry-point"
+
+
+def test_resolve_pip_main_returns_none_when_pip_absent(monkeypatch):
+    # Force every probed import to fail: a None entry in sys.modules makes
+    # `import pip` raise, and clearing the submodule cache stops an already
+    # imported `pip._internal.*` from satisfying the import behind pip's back.
+    monkeypatch.setitem(sys.modules, "pip", None)
+    for name in ("pip._internal", "pip._internal.cli", "pip._internal.cli.main"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    assert addon._resolve_pip_main() is None
+
+
+# --- _run_pip ------------------------------------------------------------
+
+
+def test_run_pip_passes_args_and_returns_code(monkeypatch):
+    received = []
+
+    def fake_pip_main(args):
+        received.append(args)
+        return 0
+
+    monkeypatch.setattr(addon, "_resolve_pip_main", lambda: fake_pip_main)
+
+    assert addon._run_pip(["install", "pkg"]) == 0
+    assert received == [["install", "pkg"]]
+
+
+def test_run_pip_raises_helpful_error_when_no_pip(monkeypatch):
+    monkeypatch.setattr(addon, "_resolve_pip_main", lambda: None)
+
+    with pytest.raises(RuntimeError, match="Could not locate pip"):
+        addon._run_pip(["install", "pkg"])
+
+
+def test_run_pip_restores_logging_raise_exceptions(monkeypatch):
+    monkeypatch.setattr(addon, "_resolve_pip_main", lambda: lambda _args: 0)
+    monkeypatch.setattr(logging, "raiseExceptions", True)
+
+    addon._run_pip(["install", "pkg"])
+
+    assert logging.raiseExceptions is True
+
+
+def test_run_pip_restores_logging_even_on_failure(monkeypatch):
+    def boom(_args):
+        raise RuntimeError("pip blew up")
+
+    monkeypatch.setattr(addon, "_resolve_pip_main", lambda: boom)
+    monkeypatch.setattr(logging, "raiseExceptions", True)
+
+    with pytest.raises(RuntimeError, match="blew up"):
+        addon._run_pip(["install", "pkg"])
+
+    assert logging.raiseExceptions is True
+
+
+# --- _install_bridge -----------------------------------------------------
+
+
+@pytest.fixture
+def clean_pip_env(monkeypatch):
+    """Neutralize the env vars `_install_bridge` reads and writes."""
+    monkeypatch.delenv("PFC_MCP_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_DISABLE_PIP_VERSION_CHECK", raising=False)
+
+
+def _stub_run_pip(monkeypatch, codes):
+    """Stub `_run_pip` to yield `codes` in order; return the call log."""
+    calls = []
+    code_iter = iter(codes)
+
+    def fake_run_pip(args):
+        calls.append(args)
+        return next(code_iter)
+
+    monkeypatch.setattr(addon, "_run_pip", fake_run_pip)
+    return calls
+
+
+def test_install_bridge_returns_zero_on_first_index(monkeypatch, clean_pip_env):
+    calls = _stub_run_pip(monkeypatch, [0])
+
+    assert addon._install_bridge() == 0
+    # Success on the primary index must not fall through to the mirror.
+    assert len(calls) == 1
+
+
+def test_install_bridge_falls_back_to_mirror(monkeypatch, clean_pip_env):
+    calls = _stub_run_pip(monkeypatch, [2, 0])
+
+    assert addon._install_bridge() == 0
+    assert len(calls) == 2
+    # The retry targets a different index than the failed first attempt.
+    first_url = calls[0][calls[0].index("--index-url") + 1]
+    second_url = calls[1][calls[1].index("--index-url") + 1]
+    assert first_url != second_url
+
+
+def test_install_bridge_returns_last_code_when_all_fail(monkeypatch, clean_pip_env):
+    calls = _stub_run_pip(monkeypatch, [2, 3])
+
+    assert addon._install_bridge() == 3
+    assert len(calls) == len(addon.DEFAULT_INDEXES)
+
+
+def test_install_bridge_honors_index_override(monkeypatch, clean_pip_env):
+    monkeypatch.setenv("PFC_MCP_PIP_INDEX_URL", "https://override.test/simple/")
+    calls = _stub_run_pip(monkeypatch, [0])
+
+    assert addon._install_bridge() == 0
+    # An explicit override collapses to a single index, no mirror fallback.
+    assert len(calls) == 1
+    assert "https://override.test/simple/" in calls[0]
+
+
+# --- _prompt_for_upgrade -------------------------------------------------
+
+
+def test_prompt_for_upgrade_true_when_not_installed():
+    # No installed version -> fresh install, no prompt shown.
+    assert addon._prompt_for_upgrade(None) is True
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", "YES", "  yes  "])
+def test_prompt_for_upgrade_accepts_affirmative(monkeypatch, answer):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": answer)
+
+    assert addon._prompt_for_upgrade("0.1.0") is True
+
+
+@pytest.mark.parametrize("answer", ["n", "no", "", "  ", "maybe"])
+def test_prompt_for_upgrade_rejects_non_affirmative(monkeypatch, answer):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": answer)
+
+    assert addon._prompt_for_upgrade("0.1.0") is False
+
+
+def test_prompt_for_upgrade_false_when_input_unavailable(monkeypatch):
+    def no_input(_prompt=""):
+        raise EOFError("no stdin in this host")
+
+    monkeypatch.setattr("builtins.input", no_input)
+
+    assert addon._prompt_for_upgrade("0.1.0") is False
+
+
+# --- DEFAULT_INDEXES config ----------------------------------------------
+
+
+def test_default_indexes_are_well_formed():
+    assert addon.DEFAULT_INDEXES  # non-empty
+    for index_url, trusted_hosts in addon.DEFAULT_INDEXES:
+        assert index_url.startswith("https://")
+        assert isinstance(trusted_hosts, tuple)


### PR DESCRIPTION
## Why

A user hit `RuntimeError: Bridge installation failed with exit code 2`
running `addon.py` in PFC3D 6.0. Tracing it surfaced two fragilities in
the bootstrap:

1. **Hard-coded pip entry point.** `_run_pip` assumed `pip.main` on
   Python < 3.10. That symbol exists in pip <= 9 (what PFC 6.0 ships)
   and was later restored as an internal shim, but it was absent in
   pip 10.0 through ~19.x — an interpreter carrying a pip from that
   range crashes with `AttributeError` instead of installing.

2. **Swallowed errors.** A failed install surfaced only a bare
   `exit code 2`, discarding pip's actual output — which is exactly
   where the real cause (network / proxy / TLS) lives.

## Changes

- `_resolve_pip_main()` probes `pip._internal.cli.main`, `pip._internal`,
  and `pip.main` in turn, so the bootstrap works regardless of which pip
  the embedded PFC Python carries.
- A failed install now raises a `RuntimeError` that points at pip's real
  output and offers a manual `pip install` fallback.
- `tests/test_addon.py` — 28 deterministic, mock-based unit tests for
  `addon.py`'s control flow (arg-building, index fallback, pip
  resolution incl. the no-pip path, upgrade prompt). pip-resolution
  tests inject `sys.modules` fakes so they pass even though uv's CI env
  ships no pip.

## Verified manually

- **PFC3D 6.0** (Python 3.6; pip 9.0.1 and upgraded to 21.3.1): fresh
  install + bridge start succeed.
- **PFC3D 9.0** (Python 3.10): MCP ↔ bridge ↔ PFC chain — `pfc_execute_code`,
  `pfc_execute_task`, `pfc_check_task_status` all behave correctly.

`addon.py` targets PFC's Python 3.6 and stays outside ruff/mypy scope by
design; the new tests run on the 3.10+ CI interpreter and guard control
flow only — real pip behaviour still needs the manual PFC checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
