### PR TITLE
docs(agentic): give Step 3 the PyPI → Tsinghua mirror fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ section exists.
   offers a manual `pip install` fallback, instead of surfacing only a
   bare `exit code 2` that hid the underlying cause.
 
+### Documentation
+- The agentic bootstrap guide's Step 3 (agent-driven bridge install)
+  now documents the PyPI -> Tsinghua mirror fallback, matching the
+  fallback `addon.py` already performs. An agent installing the bridge
+  for a user on a network that blocks PyPI previously had no documented
+  retry path and would stall there.
+
 ## [0.4.0] - 2026-05-22
 
 Bridge installation path migrates from `pfc-mcp-bridge` to `itasca-mcp-bridge`.

--- a/docs/agentic/pfc-mcp-bootstrap.md
+++ b/docs/agentic/pfc-mcp-bootstrap.md
@@ -150,6 +150,14 @@ Install/upgrade:
 & "{pfc_python}" -m pip install --user --upgrade itasca-mcp-bridge
 ```
 
+If that index is unreachable (PyPI blocked behind a regional network or
+corporate proxy), retry via the Tsinghua mirror -- the same fallback
+`addon.py` performs automatically:
+
+```powershell
+& "{pfc_python}" -m pip install --user --upgrade --index-url https://pypi.tuna.tsinghua.edu.cn/simple/ --trusted-host pypi.tuna.tsinghua.edu.cn itasca-mcp-bridge
+```
+
 Verify import and version:
 
 ```powershell
@@ -167,6 +175,9 @@ If websocket dependency errors appear, install the version that matches the embe
 # PFC 9.0
 & "{pfc_python}" -m pip install --user websockets==16.0
 ```
+
+If PyPI is unreachable here too, add the same `--index-url` /
+`--trusted-host` Tsinghua-mirror flags shown above.
 
 ## Step 4 - Start Bridge in PFC GUI
 


### PR DESCRIPTION
## Why

The agentic bootstrap guide's **Step 3** has the agent install the
bridge with:

```
pip install --user --upgrade itasca-mcp-bridge
```

That uses only the default index (PyPI). Meanwhile `addon.py` already
falls back PyPI → Tsinghua mirror automatically (`DEFAULT_INDEXES`). So
the agent-driven install path was *less robust than `addon.py`* — an
agent installing the bridge for a user on a network that blocks PyPI
had no documented retry and would stall at Step 3.

## Change

Docs only — `docs/agentic/pfc-mcp-bootstrap.md` Step 3 now documents the
Tsinghua mirror retry (`--index-url` + `--trusted-host`) for both the
bridge install and the `websockets` dependency fallback, matching what
`addon.py` does on its own.

This does **not** explain the recent `addon.py exit code 1` report
(that came from `addon.py`/Step 4, which already had the fallback) — it
closes the gap on the *agent-driven* Step 3 install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
