### PR TITLE
bootstrap: mirror fallback, AUTO_UPGRADE, warn off program-call dat

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -8,11 +8,13 @@ Use it inside PFC in either of these ways:
 
 What it does:
 1. Detects the currently installed `itasca-mcp-bridge`, if any
-2. Lets the user decide whether to upgrade to the latest published version
-3. Installs `itasca-mcp-bridge` automatically when it is not installed yet
-4. Ensures the user site-packages directory is importable
-5. Imports `itasca_mcp_bridge` and `websockets`
-6. Starts the bridge
+2. Installs or upgrades `itasca-mcp-bridge` according to `AUTO_UPGRADE`
+3. Ensures the user site-packages directory is importable
+4. Imports `itasca_mcp_bridge` and `websockets`
+5. Starts the bridge
+
+Set `AUTO_UPGRADE = False` near the top if you want to pin the locally
+installed version and skip the network call on every start.
 """
 
 import importlib
@@ -23,6 +25,7 @@ import sys
 
 PACKAGE_NAME = "itasca-mcp-bridge"
 PORT = 9001  # Change this to run multiple bridges on different ports
+AUTO_UPGRADE = True  # Set False to keep the locally installed version
 
 # Index URLs tried in order. Mirrors act as a fallback when the primary
 # is unreachable (corporate proxies, slow international routes).
@@ -160,20 +163,17 @@ def _import_bridge():
     return itasca_mcp_bridge, websockets
 
 
-def _prompt_for_upgrade(current_version):
+def _should_install(current_version):
     if current_version is None:
         print("{} is not installed. Installing the latest version ...".format(PACKAGE_NAME))
         return True
 
     print("Installed itasca-mcp-bridge:", current_version)
-
-    try:
-        answer = input("Update to the latest version before start? [y/N]: ")
-    except Exception:
-        print("Input unavailable. Keeping the current installation.")
-        return False
-
-    return answer.strip().lower() in ("y", "yes")
+    if AUTO_UPGRADE:
+        print("AUTO_UPGRADE is on. Checking for a newer version ...")
+        return True
+    print("AUTO_UPGRADE is off. Keeping the current installation.")
+    return False
 
 
 def main():
@@ -187,7 +187,7 @@ def main():
     if installed_bridge is not None:
         installed_version = getattr(installed_bridge, "__version__", "unknown")
 
-    if _prompt_for_upgrade(installed_version):
+    if _should_install(installed_version):
         code = _install_bridge()
         if code != 0:
             raise RuntimeError(
@@ -198,8 +198,6 @@ def main():
                 "install manually and re-run this script:\n"
                 "    python -m pip install --user itasca-mcp-bridge".format(code)
             )
-    else:
-        print("Skipping package upgrade.")
 
     itasca_mcp_bridge, websockets = _import_bridge()
 

--- a/src/pfc_mcp/tools/execute_code.py
+++ b/src/pfc_mcp/tools/execute_code.py
@@ -55,6 +55,15 @@ def register(mcp: FastMCP) -> None:
         - Create and export plots: itasca.command('plot ...')
         - Development and REPL-style testing
 
+        Do NOT invoke `program call '<file>.p3dat'` (or .p2dat / .dat)
+        through this tool. PFC's command-script interpreter blocks the
+        bridge for the script's entire duration with no cycle-gap
+        interleaving, so any long `model cycle` inside the file leaves
+        the bridge unreachable until PFC is stopped manually. If the
+        user asks to run a .dat / .p3dat / .p2dat file, read the file
+        and translate its commands into a sequence of
+        `itasca.command(...)` calls in Python instead.
+
         This is a synchronous tool: the request blocks until the code
         finishes or hits the timeout (default 10s, max 600s). Output
         is returned in full; the call is NOT tracked by pfc_list_tasks

--- a/src/pfc_mcp/tools/execute_task.py
+++ b/src/pfc_mcp/tools/execute_task.py
@@ -39,6 +39,15 @@ def register(mcp: FastMCP) -> None:
         and interleaved with Python prints in the task log, visible
         through pfc_check_task_status.
 
+        Do NOT have the script invoke `program call '<file>.p3dat'`
+        (or .p2dat / .dat). PFC's command-script interpreter blocks
+        the bridge for the script's entire duration with no cycle-gap
+        interleaving, leaving the bridge unreachable until PFC is
+        stopped manually. If the user asks to run a .dat / .p3dat /
+        .p2dat file, read the file and translate its commands into a
+        sequence of `itasca.command(...)` calls in the Python script
+        instead.
+
         This is the async / background execution path: pollable via
         pfc_check_task_status, cancellable via pfc_interrupt_task.
         Submission does not lock parameters — start with reasonable

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -3,7 +3,7 @@
 ``addon.py`` runs inside PFC's embedded Python (3.6 on PFC 6/7), while this
 suite runs on the MCP package's interpreter (3.10+). These tests therefore
 guard the *control flow* of the bootstrap -- argument construction, the
-index-fallback loop, pip entry-point resolution, and the upgrade prompt --
+index-fallback loop, pip entry-point resolution, and the install gate --
 and deliberately do NOT exercise real pip behaviour or the in-PFC ``start()``
 path. Confirming the bootstrap against an actual PFC interpreter stays a
 manual step.
@@ -194,35 +194,27 @@ def test_install_bridge_honors_index_override(monkeypatch, clean_pip_env):
     assert "https://override.test/simple/" in calls[0]
 
 
-# --- _prompt_for_upgrade -------------------------------------------------
+# --- _should_install -----------------------------------------------------
 
 
-def test_prompt_for_upgrade_true_when_not_installed():
-    # No installed version -> fresh install, no prompt shown.
-    assert addon._prompt_for_upgrade(None) is True
+def test_should_install_true_when_not_installed(monkeypatch):
+    # Missing install -> always install, regardless of the AUTO_UPGRADE switch.
+    monkeypatch.setattr(addon, "AUTO_UPGRADE", False)
+
+    assert addon._should_install(None) is True
 
 
-@pytest.mark.parametrize("answer", ["y", "Y", "yes", "YES", "  yes  "])
-def test_prompt_for_upgrade_accepts_affirmative(monkeypatch, answer):
-    monkeypatch.setattr("builtins.input", lambda _prompt="": answer)
+def test_should_install_true_when_auto_upgrade_on(monkeypatch):
+    monkeypatch.setattr(addon, "AUTO_UPGRADE", True)
 
-    assert addon._prompt_for_upgrade("0.1.0") is True
-
-
-@pytest.mark.parametrize("answer", ["n", "no", "", "  ", "maybe"])
-def test_prompt_for_upgrade_rejects_non_affirmative(monkeypatch, answer):
-    monkeypatch.setattr("builtins.input", lambda _prompt="": answer)
-
-    assert addon._prompt_for_upgrade("0.1.0") is False
+    assert addon._should_install("0.1.0") is True
 
 
-def test_prompt_for_upgrade_false_when_input_unavailable(monkeypatch):
-    def no_input(_prompt=""):
-        raise EOFError("no stdin in this host")
+def test_should_install_false_when_auto_upgrade_off(monkeypatch):
+    # Pinning behaviour: an existing install with AUTO_UPGRADE off stays put.
+    monkeypatch.setattr(addon, "AUTO_UPGRADE", False)
 
-    monkeypatch.setattr("builtins.input", no_input)
-
-    assert addon._prompt_for_upgrade("0.1.0") is False
+    assert addon._should_install("0.1.0") is False
 
 
 # --- DEFAULT_INDEXES config ----------------------------------------------


### PR DESCRIPTION
## Summary

- **`addon.py`** — replace the stdin-based upgrade prompt (effectively dead in PFC's `pythonfile` host, which has no usable stdin) with an `AUTO_UPGRADE = True` constant near the top. Users who want to pin the installed bridge version flip it to `False`. Default is upgrade-on-each-start, which keeps users on the latest published bridge with zero interaction.
- **Bootstrap install** — PyPI primary, Tsinghua mirror fallback (follow-up to Step 3 of the agentic install guide; previously committed on this branch).
- **`pfc_execute_code` / `pfc_execute_task` docstrings** — instruct agents NOT to emit `itasca.command("program call '*.p?dat'")`. PFC's command-script interpreter blocks the **entire** bridge for the script's duration: even bridge-internal calls like `pfc_list_tasks` time out, and recovery requires the user to manually stop PFC. If a user asks to run a `.dat` / `.p3dat` / `.p2dat` file, the agent should read it and translate each line into a `itasca.command(...)` call instead — that path preserves cycle-gap interleaving and keeps every command inspectable.

The `program call` warning is the one users will feel most: lots of existing PFC workflows are `.p3dat` scripts, and pointing an agent at one currently wedges the bridge — making the toolchain look broken when it's actually a usage trap.

## Test plan

- [x] `uv run pytest tests/test_addon.py` — 19 passed (AUTO_UPGRADE branches + pip entry-point + mirror fallback)
- [x] `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed
- [x] Reproduced the `program call` bridge wedge against live PFC 7.0 with `test_interrupt.p3dat` (contains `model cycle 10000000`); confirmed even `pfc_list_tasks` returns `bridge_unavailable` while PFC is inside the command script
- [x] Manual smoke: ran updated `addon.py` via PFC `pythonfile`; bridge came up on :9001, `pfc_execute_code` round-trip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)