### PR TITLE
fix(docs): include rblock contacts in shared Contact interface expansion

### DIFF
--- a/src/pfc_mcp/knowledge/python_api/types/contact.py
+++ b/src/pfc_mcp/knowledge/python_api/types/contact.py
@@ -17,6 +17,10 @@ from dataclasses import dataclass
 # Thermal contact types (e.g. BallBallThermalContact) are intentionally
 # excluded: they lack force_normal / force_shear and need a separate
 # expansion strategy (see issue #10).
+#
+# Keep in sync with `objects.Contact.types` in
+# `src/pfc_mcp/knowledge/resources/python_sdk_docs/index.json` —
+# browse path resolution uses that list instead of this one.
 CONTACT_TYPES = [
     "BallBallContact",
     "BallFacetContact",

--- a/src/pfc_mcp/knowledge/python_api/types/contact.py
+++ b/src/pfc_mcp/knowledge/python_api/types/contact.py
@@ -13,14 +13,20 @@ Architecture:
 
 from dataclasses import dataclass
 
-# All contact types sharing the same interface
-# These are the official PFC contact type names
+# Contact types sharing the same mechanical interface.
+# Thermal contact types (e.g. BallBallThermalContact) are intentionally
+# excluded: they lack force_normal / force_shear and need a separate
+# expansion strategy (see issue #10).
 CONTACT_TYPES = [
     "BallBallContact",
     "BallFacetContact",
     "BallPebbleContact",
     "PebblePebbleContact",
     "PebbleFacetContact",
+    "BallRBlockContact",
+    "PebbleRBlockContact",
+    "RBlockFacetContact",
+    "RBlockRBlockContact",
 ]
 
 

--- a/src/pfc_mcp/knowledge/resources/python_sdk_docs/index.json
+++ b/src/pfc_mcp/knowledge/resources/python_sdk_docs/index.json
@@ -730,7 +730,11 @@
         "BallFacetContact",
         "BallPebbleContact",
         "PebblePebbleContact",
-        "PebbleFacetContact"
+        "PebbleFacetContact",
+        "BallRBlockContact",
+        "PebbleRBlockContact",
+        "RBlockFacetContact",
+        "RBlockRBlockContact"
       ],
       "methods": [
         "activate",


### PR DESCRIPTION
## Summary

Adds the 4 rblock-related mechanical contact types to the
`CONTACT_TYPES` list in `python_api/types/contact.py` so the
`Contact.*` doc expansion correctly advertises them on
`BallRBlockContact` / `PebbleRBlockContact` / `RBlockFacetContact` /
`RBlockRBlockContact`.

## Background

v0.4.2 surfaced two related coverage issues while expanding the array
API docs:

1. `*array.rotation` was advertised but doesn't exist on any PFC
   version — fixed in 42276eb.
2. The hardcoded `CONTACT_TYPES` list backing
   `_expand_contact_types` covers only the 5 mechanical
   ball/pebble/facet types — the 4 rblock contacts and the 5
   thermal contacts are missing.

This PR closes the rblock half. Thermal contacts intentionally
remain out: they lack `force_normal` / `force_shear` and need a
different expansion strategy. Tracked in #10.

## Verification

Bridged into PFC 6.0 and 7.0 GUIs, confirmed the 4 rblock contact
classes carry the full Contact mechanical surface
(`normal` / `gap` / `force_normal` / `force_shear` / `pos` / `shear`)
just like `BallBallContact`.

## Test plan

- [x] `pytest tests/` (68/68)
- [x] `ruff check src tests` + `ruff format --check src tests`
- [x] `mypy src/pfc_mcp`
- [x] Live PFC 6.0 / 7.0 bridge `hasattr` cross-check of the 4 rblock
      contact classes