### PR TITLE
fix: separate thermal contact API docs

### DIFF
--- a/src/pfc_mcp/knowledge/adapters/api_adapter.py
+++ b/src/pfc_mcp/knowledge/adapters/api_adapter.py
@@ -136,15 +136,15 @@ class APIDocumentAdapter:
         """
         # Import contact types for mapping
         try:
-            from pfc_mcp.knowledge.python_api.types.contact import CONTACT_TYPES
+            from pfc_mcp.knowledge.python_api.types.contact import ALL_CONTACT_TYPES
         except ImportError:
-            CONTACT_TYPES = []
+            ALL_CONTACT_TYPES = []
 
         # Check if it's a Contact type (e.g., BallBallContact, BallFacetContact)
         parts = api_name.split(".")
         if len(parts) >= 2:
             # Check if second part is a Contact type
-            if parts[1] in CONTACT_TYPES:
+            if parts[1] in ALL_CONTACT_TYPES:
                 return "itasca.contact"
 
         # Standard module function: itasca.ball.create → itasca.ball

--- a/src/pfc_mcp/knowledge/python_api/formatter.py
+++ b/src/pfc_mcp/knowledge/python_api/formatter.py
@@ -105,15 +105,12 @@ class APIDocFormatter:
             else:
                 obj_path = name
 
-            # Handle Contact types - they are in itasca root namespace
-            if name == "Contact":
-                contact_types = data.get("types", [])
-                if contact_types:
-                    for ct in contact_types:
-                        object_lines.append(f"- itasca.{ct}: {desc}")
-                    continue
-                else:
-                    obj_path = f"itasca.{name}"
+            # Handle Contact interface aliases - concrete contact types are in the itasca root namespace.
+            contact_types = data.get("types", [])
+            if contact_types:
+                for ct in contact_types:
+                    object_lines.append(f"- itasca.{ct}: {desc}")
+                continue
 
             object_lines.append(f"- {obj_path}: {desc}")
 

--- a/src/pfc_mcp/knowledge/python_api/loader.py
+++ b/src/pfc_mcp/knowledge/python_api/loader.py
@@ -12,6 +12,7 @@ Responsibilities:
 
 import json
 from collections import defaultdict
+from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
@@ -190,7 +191,7 @@ class DocumentationLoader:
         if "methods" in doc:
             for method in doc["methods"]:
                 if method["name"] == anchor:
-                    return cast(dict[str, Any], method)
+                    return DocumentationLoader._decorate_contact_method(api_name, cast(dict[str, Any], method))
         elif "functions" in doc:
             for func in doc["functions"]:
                 if func["name"] == anchor:
@@ -224,31 +225,32 @@ class DocumentationLoader:
                 "PebblePebbleContact.gap": "modules/contact/Contact.json#gap"
                 "PebbleFacetContact.gap": "modules/contact/Contact.json#gap"
         """
-        from pfc_mcp.knowledge.python_api.types.contact import CONTACT_TYPES
+        from pfc_mcp.knowledge.python_api.types.contact import get_contact_types_for_interface
 
         quick_ref = index.get("quick_ref", {})
 
-        # Find all Contact.* entries
+        # Find abstract Contact.* / ThermalContact.* entries.
         contact_entries = {}
         entries_to_remove = []
 
         for api_name, file_ref in quick_ref.items():
-            # Format 1: Short format "Contact.gap" (legacy)
-            if api_name.startswith("Contact."):
-                # Extract method name
-                method_name = api_name.split(".", 1)[1]
-                contact_entries[method_name] = file_ref
-                entries_to_remove.append(api_name)
-            # Format 2: Unified format "itasca.contact.Contact.gap" (preferred)
-            elif api_name.startswith("itasca.contact.Contact."):
-                # Extract method name after "itasca.contact.Contact."
-                method_name = api_name.split(".", 3)[3]
-                contact_entries[method_name] = file_ref
-                entries_to_remove.append(api_name)
+            for interface in ("Contact", "ThermalContact"):
+                short_prefix = f"{interface}."
+                full_prefix = f"itasca.contact.{interface}."
+                if api_name.startswith(short_prefix):
+                    method_name = api_name.split(".", 1)[1]
+                    contact_entries[(interface, method_name)] = file_ref
+                    entries_to_remove.append(api_name)
+                    break
+                if api_name.startswith(full_prefix):
+                    method_name = api_name.split(".", 3)[3]
+                    contact_entries[(interface, method_name)] = file_ref
+                    entries_to_remove.append(api_name)
+                    break
 
-        # Expand each Contact.* entry to all Contact types
-        for method_name, file_ref in contact_entries.items():
-            for contact_type in CONTACT_TYPES:
+        # Expand each abstract interface entry to its concrete Contact types.
+        for (interface, method_name), file_ref in contact_entries.items():
+            for contact_type in get_contact_types_for_interface(interface):
                 # Create only full official paths: itasca.BallBallContact.gap
                 # This eliminates the need for PathResolver to add "itasca." prefix
                 full_path = f"itasca.{contact_type}.{method_name}"
@@ -397,7 +399,10 @@ class DocumentationLoader:
                     "itasca.PebbleFacetContact.gap"
                 ]}
         """
-        from pfc_mcp.knowledge.python_api.types.contact import CONTACT_TYPES
+        from pfc_mcp.knowledge.python_api.types.contact import (
+            get_contact_types_for_interface,
+            get_contact_types_for_method,
+        )
 
         # Create a new dict to store expanded results
         expanded_keywords = defaultdict(list)
@@ -408,11 +413,14 @@ class DocumentationLoader:
             for api_name in api_list:
                 # Check if this is a Contact abstract path
                 if api_name.startswith("itasca.contact.Contact."):
-                    # Extract method name after "itasca.contact.Contact."
                     method_name = api_name.split(".", 3)[3]
 
-                    # Expand to all Contact types
-                    for contact_type in CONTACT_TYPES:
+                    for contact_type in get_contact_types_for_method(method_name):
+                        expanded_apis.append(f"itasca.{contact_type}.{method_name}")
+                elif api_name.startswith("itasca.contact.ThermalContact."):
+                    method_name = api_name.split(".", 3)[3]
+
+                    for contact_type in get_contact_types_for_interface("ThermalContact"):
                         expanded_apis.append(f"itasca.{contact_type}.{method_name}")
                 else:
                     # Keep non-Contact APIs as-is
@@ -581,23 +589,40 @@ class DocumentationLoader:
         index = DocumentationLoader.load_index()
         objects = index.get("objects", {})
 
-        if object_name not in objects:
-            return None
+        concrete_contact_type = None
+        if object_name in objects:
+            object_info = objects[object_name]
+        else:
+            from pfc_mcp.knowledge.python_api.types.contact import get_contact_interface
 
-        object_info = objects[object_name]
+            interface = get_contact_interface(object_name)
+            if not interface or interface not in objects:
+                return None
+            concrete_contact_type = object_name
+            object_info = objects[interface]
+
         file_path = object_info.get("file")
 
         if not file_path:
             # Return basic info from index
-            return cast(dict[str, Any], object_info)
+            object_doc = cast(dict[str, Any], deepcopy(object_info))
+            if concrete_contact_type:
+                object_doc = DocumentationLoader._filter_contact_object_doc(object_doc, concrete_contact_type)
+            return object_doc
 
         # Load full object documentation
         doc_path = PFC_DOCS_SOURCE / file_path
         if not doc_path.exists():
-            return cast(dict[str, Any], object_info)
+            object_doc = cast(dict[str, Any], deepcopy(object_info))
+            if concrete_contact_type:
+                object_doc = DocumentationLoader._filter_contact_object_doc(object_doc, concrete_contact_type)
+            return object_doc
 
         with open(doc_path, encoding="utf-8") as f:
-            return cast(dict[str, Any], json.load(f))
+            object_doc = cast(dict[str, Any], json.load(f))
+            if concrete_contact_type:
+                object_doc = DocumentationLoader._filter_contact_object_doc(object_doc, concrete_contact_type)
+            return object_doc
 
     @staticmethod
     def load_method(object_name: str, method_name: str) -> dict[str, Any] | None:
@@ -629,9 +654,64 @@ class DocumentationLoader:
         methods = object_doc.get("methods", [])
         for method in methods:
             if isinstance(method, dict) and method.get("name") == method_name:
-                return method
+                return DocumentationLoader._decorate_contact_method(object_name, method)
 
         return None
+
+    @staticmethod
+    def _decorate_contact_method(api_name: str, method: dict[str, Any]) -> dict[str, Any]:
+        """Attach concrete Contact type availability to aliased methods."""
+        from pfc_mcp.knowledge.python_api.types.contact import (
+            get_contact_interface,
+            get_contact_type_from_api_path,
+            get_contact_type_versions,
+            get_contact_types_for_interface,
+        )
+
+        contact_type = get_contact_type_from_api_path(api_name)
+        if not contact_type:
+            return method
+
+        interface = get_contact_interface(contact_type)
+        decorated = deepcopy(method)
+        decorated["availability"] = {"versions": get_contact_type_versions(contact_type)}
+        if interface:
+            decorated["applicable_contact_types"] = get_contact_types_for_interface(interface)
+        return decorated
+
+    @staticmethod
+    def _filter_contact_object_doc(object_doc: dict[str, Any], contact_type: str) -> dict[str, Any]:
+        """Filter an abstract Contact document to one concrete Contact type."""
+        from pfc_mcp.knowledge.python_api.types.contact import contact_type_supports_method, get_contact_type_versions
+
+        filtered = deepcopy(object_doc)
+        filtered["class"] = contact_type
+        filtered["namespace"] = f"itasca.{contact_type}"
+        filtered["description"] = object_doc.get("description", "")
+        filtered["availability"] = {"versions": get_contact_type_versions(contact_type)}
+
+        if "methods" in filtered:
+            methods = []
+            for method in filtered["methods"]:
+                if not isinstance(method, dict):
+                    continue
+                method_name = method.get("name", "")
+                if contact_type_supports_method(contact_type, method_name):
+                    methods.append(DocumentationLoader._decorate_contact_method(contact_type, method))
+            filtered["methods"] = methods
+
+        if "method_groups" in filtered:
+            groups = {}
+            for group_name, group_methods in filtered["method_groups"].items():
+                if isinstance(group_methods, list):
+                    kept = [m for m in group_methods if contact_type_supports_method(contact_type, str(m))]
+                    if kept:
+                        groups[group_name] = kept
+                else:
+                    groups[group_name] = group_methods
+            filtered["method_groups"] = groups
+
+        return filtered
 
     @staticmethod
     def clear_cache() -> None:

--- a/src/pfc_mcp/knowledge/python_api/types/__init__.py
+++ b/src/pfc_mcp/knowledge/python_api/types/__init__.py
@@ -4,7 +4,7 @@ This package provides specialized handling for PFC type systems,
 including Contact type aliasing and class-to-module mappings.
 """
 
-from .contact import CONTACT_TYPES, ContactQueryResult, ContactTypeResolver
+from .contact import ALL_CONTACT_TYPES, CONTACT_TYPES, ContactQueryResult, ContactTypeResolver
 from .mappings import CLASS_TO_MODULE
 
-__all__ = ["ContactTypeResolver", "CONTACT_TYPES", "ContactQueryResult", "CLASS_TO_MODULE"]
+__all__ = ["ContactTypeResolver", "CONTACT_TYPES", "ALL_CONTACT_TYPES", "ContactQueryResult", "CLASS_TO_MODULE"]

--- a/src/pfc_mcp/knowledge/python_api/types/contact.py
+++ b/src/pfc_mcp/knowledge/python_api/types/contact.py
@@ -13,15 +13,10 @@ Architecture:
 
 from dataclasses import dataclass
 
-# Contact types sharing the same mechanical interface.
-# Thermal contact types (e.g. BallBallThermalContact) are intentionally
-# excluded: they lack force_normal / force_shear and need a separate
-# expansion strategy (see issue #10).
-#
-# Keep in sync with `objects.Contact.types` in
-# `src/pfc_mcp/knowledge/resources/python_sdk_docs/index.json` —
-# browse path resolution uses that list instead of this one.
-CONTACT_TYPES = [
+ALL_VERSIONS = ["6.0", "7.0", "9.0"]
+
+# Contact types sharing the full mechanical interface.
+MECHANICAL_CONTACT_TYPES = [
     "BallBallContact",
     "BallFacetContact",
     "BallPebbleContact",
@@ -31,7 +26,81 @@ CONTACT_TYPES = [
     "PebbleRBlockContact",
     "RBlockFacetContact",
     "RBlockRBlockContact",
+    "VertexFacetContact",
 ]
+
+THERMAL_CONTACT_TYPES = [
+    "BallBallThermalContact",
+    "BallFacetThermalContact",
+    "BallPebbleThermalContact",
+    "PebblePebbleThermalContact",
+    "PebbleFacetThermalContact",
+]
+
+CONTACT_TYPES = MECHANICAL_CONTACT_TYPES
+ALL_CONTACT_TYPES = MECHANICAL_CONTACT_TYPES + THERMAL_CONTACT_TYPES
+
+CONTACT_INTERFACE_TYPES = {
+    "Contact": MECHANICAL_CONTACT_TYPES,
+    "ThermalContact": THERMAL_CONTACT_TYPES,
+}
+
+CONTACT_TYPE_TO_INTERFACE = {
+    contact_type: interface
+    for interface, contact_types in CONTACT_INTERFACE_TYPES.items()
+    for contact_type in contact_types
+}
+
+CONTACT_TYPE_VERSIONS = {contact_type: ALL_VERSIONS for contact_type in ALL_CONTACT_TYPES}
+CONTACT_TYPE_VERSIONS["VertexFacetContact"] = ["9.0"]
+
+# PFC 9 runtime reflection shows thermal contacts share these non-force
+# Contact methods. Thermal-specific power/set_power are real but do not have
+# source docs in this tree yet, so they are intentionally not expanded here.
+THERMAL_CONTACT_METHODS = {
+    "activate",
+    "activated",
+    "active",
+    "end1",
+    "end2",
+    "extra",
+    "gap",
+    "group",
+    "group_remove",
+    "groups",
+    "has_prop",
+    "id",
+    "in_group",
+    "inhibit",
+    "method",
+    "model",
+    "normal",
+    "normal_x",
+    "normal_y",
+    "normal_z",
+    "offset",
+    "offset_x",
+    "offset_y",
+    "offset_z",
+    "persist",
+    "pos",
+    "pos_x",
+    "pos_y",
+    "pos_z",
+    "prop",
+    "props",
+    "set_extra",
+    "set_group",
+    "set_inhibit",
+    "set_model",
+    "set_persist",
+    "set_prop",
+    "shear",
+    "shear_x",
+    "shear_y",
+    "shear_z",
+    "valid",
+}
 
 
 @dataclass
@@ -59,6 +128,44 @@ class ContactQueryResult:
     all_types: list[str]
 
 
+def is_contact_type(contact_type: str) -> bool:
+    return contact_type in CONTACT_TYPE_TO_INTERFACE
+
+
+def get_contact_interface(contact_type: str) -> str | None:
+    return CONTACT_TYPE_TO_INTERFACE.get(contact_type)
+
+
+def get_contact_type_versions(contact_type: str) -> list[str]:
+    return CONTACT_TYPE_VERSIONS.get(contact_type, ALL_VERSIONS)
+
+
+def get_contact_types_for_interface(interface: str) -> list[str]:
+    return CONTACT_INTERFACE_TYPES.get(interface, [])
+
+
+def get_contact_types_for_method(method_name: str) -> list[str]:
+    contact_types = list(MECHANICAL_CONTACT_TYPES)
+    if method_name in THERMAL_CONTACT_METHODS:
+        contact_types.extend(THERMAL_CONTACT_TYPES)
+    return contact_types
+
+
+def get_contact_type_from_api_path(api_path: str) -> str | None:
+    parts = api_path.split(".")
+    for part in parts:
+        if is_contact_type(part):
+            return part
+    return None
+
+
+def contact_type_supports_method(contact_type: str, method_name: str) -> bool:
+    interface = get_contact_interface(contact_type)
+    if interface == "ThermalContact":
+        return method_name in THERMAL_CONTACT_METHODS
+    return interface == "Contact"
+
+
 class ContactTypeResolver:
     """Resolves Contact type queries to internal documentation paths.
 
@@ -83,7 +190,7 @@ class ContactTypeResolver:
             False
         """
         parts_lower = [p.lower() for p in api_path.split(".")]
-        return any(ct.lower() in parts_lower for ct in CONTACT_TYPES)
+        return any(ct.lower() in parts_lower for ct in ALL_CONTACT_TYPES)
 
     @staticmethod
     def resolve(api_path: str, quick_ref: dict[str, str]) -> ContactQueryResult | None:
@@ -115,7 +222,7 @@ class ContactTypeResolver:
         parts = api_path.split(".")
         parts_lower = [p.lower() for p in parts]
 
-        for contact_type in CONTACT_TYPES:
+        for contact_type in ALL_CONTACT_TYPES:
             contact_type_lower = contact_type.lower()
 
             if contact_type_lower in parts_lower:
@@ -124,16 +231,21 @@ class ContactTypeResolver:
                 # Extract method name after contact type
                 if contact_idx + 1 < len(parts):
                     method_name = parts[contact_idx + 1]
-                    internal_path = f"Contact.{method_name}"
+                    interface = get_contact_interface(contact_type)
+                    if not interface:
+                        continue
+                    internal_path = f"{interface}.{method_name}"
 
                     # Only return exact matches
                     # Partial matching is handled by BM25 search
-                    if ContactTypeResolver._verify_method(internal_path, quick_ref):
+                    if contact_type_supports_method(contact_type, method_name) and ContactTypeResolver._verify_method(
+                        internal_path, quick_ref
+                    ):
                         return ContactQueryResult(
                             internal_path=internal_path,
                             contact_type=contact_type,
                             original_query=api_path.strip(),
-                            all_types=CONTACT_TYPES,
+                            all_types=get_contact_types_for_method(method_name),
                         )
 
         return None
@@ -152,6 +264,13 @@ class ContactTypeResolver:
         # Try exact match
         if internal_path in quick_ref:
             return True
+
+        if internal_path.startswith(("Contact.", "ThermalContact.")):
+            interface, method_name = internal_path.split(".", 1)
+            return any(
+                f"itasca.{contact_type}.{method_name}" in quick_ref
+                for contact_type in get_contact_types_for_interface(interface)
+            )
 
         # Try case-insensitive match
         internal_path_lower = internal_path.lower()

--- a/src/pfc_mcp/knowledge/resources/python_sdk_docs/index.json
+++ b/src/pfc_mcp/knowledge/resources/python_sdk_docs/index.json
@@ -723,7 +723,7 @@
       "file": "modules/rblock/template/Template.json"
     },
     "Contact": {
-      "description": "Contact object instance (all contact types share this interface)",
+      "description": "Mechanical contact object instance (ball, pebble, facet, rblock, and vertex-facet contacts share this interface)",
       "file": "modules/contact/Contact.json",
       "types": [
         "BallBallContact",
@@ -734,8 +734,59 @@
         "BallRBlockContact",
         "PebbleRBlockContact",
         "RBlockFacetContact",
-        "RBlockRBlockContact"
+        "RBlockRBlockContact",
+        "VertexFacetContact"
       ],
+      "type_versions": {
+        "BallBallContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "BallFacetContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "BallPebbleContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "PebblePebbleContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "PebbleFacetContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "BallRBlockContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "PebbleRBlockContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "RBlockFacetContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "RBlockRBlockContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "VertexFacetContact": [
+          "9.0"
+        ]
+      },
       "methods": [
         "activate",
         "activated",
@@ -819,6 +870,88 @@
         "shear_z",
         "to_global",
         "to_local",
+        "valid"
+      ]
+    },
+    "ThermalContact": {
+      "description": "Thermal contact object instance (heat-transfer contacts expose geometry/orientation methods, not mechanical force methods)",
+      "file": "modules/contact/ThermalContact.json",
+      "types": [
+        "BallBallThermalContact",
+        "BallFacetThermalContact",
+        "BallPebbleThermalContact",
+        "PebblePebbleThermalContact",
+        "PebbleFacetThermalContact"
+      ],
+      "type_versions": {
+        "BallBallThermalContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "BallFacetThermalContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "BallPebbleThermalContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "PebblePebbleThermalContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ],
+        "PebbleFacetThermalContact": [
+          "6.0",
+          "7.0",
+          "9.0"
+        ]
+      },
+      "methods": [
+        "activate",
+        "activated",
+        "active",
+        "end1",
+        "end2",
+        "extra",
+        "gap",
+        "group",
+        "group_remove",
+        "groups",
+        "has_prop",
+        "id",
+        "in_group",
+        "inhibit",
+        "method",
+        "model",
+        "normal",
+        "normal_x",
+        "normal_y",
+        "normal_z",
+        "offset",
+        "offset_x",
+        "offset_y",
+        "offset_z",
+        "persist",
+        "pos",
+        "pos_x",
+        "pos_y",
+        "pos_z",
+        "prop",
+        "props",
+        "set_extra",
+        "set_group",
+        "set_inhibit",
+        "set_model",
+        "set_persist",
+        "set_prop",
+        "shear",
+        "shear_x",
+        "shear_y",
+        "shear_z",
         "valid"
       ]
     },
@@ -2029,7 +2162,49 @@
     "itasca.pebblefacetarray.offset": "modules/pebblefacetarray/module.json#offset",
     "itasca.pebblefacetarray.pos": "modules/pebblefacetarray/module.json#pos",
     "itasca.pebblefacetarray.set_extra": "modules/pebblefacetarray/module.json#set_extra",
-    "itasca.pebblefacetarray.set_group": "modules/pebblefacetarray/module.json#set_group"
+    "itasca.pebblefacetarray.set_group": "modules/pebblefacetarray/module.json#set_group",
+    "ThermalContact.activate": "modules/contact/ThermalContact.json#activate",
+    "ThermalContact.activated": "modules/contact/ThermalContact.json#activated",
+    "ThermalContact.active": "modules/contact/ThermalContact.json#active",
+    "ThermalContact.end1": "modules/contact/ThermalContact.json#end1",
+    "ThermalContact.end2": "modules/contact/ThermalContact.json#end2",
+    "ThermalContact.extra": "modules/contact/ThermalContact.json#extra",
+    "ThermalContact.gap": "modules/contact/ThermalContact.json#gap",
+    "ThermalContact.group": "modules/contact/ThermalContact.json#group",
+    "ThermalContact.group_remove": "modules/contact/ThermalContact.json#group_remove",
+    "ThermalContact.groups": "modules/contact/ThermalContact.json#groups",
+    "ThermalContact.has_prop": "modules/contact/ThermalContact.json#has_prop",
+    "ThermalContact.id": "modules/contact/ThermalContact.json#id",
+    "ThermalContact.in_group": "modules/contact/ThermalContact.json#in_group",
+    "ThermalContact.inhibit": "modules/contact/ThermalContact.json#inhibit",
+    "ThermalContact.method": "modules/contact/ThermalContact.json#method",
+    "ThermalContact.model": "modules/contact/ThermalContact.json#model",
+    "ThermalContact.normal": "modules/contact/ThermalContact.json#normal",
+    "ThermalContact.normal_x": "modules/contact/ThermalContact.json#normal_x",
+    "ThermalContact.normal_y": "modules/contact/ThermalContact.json#normal_y",
+    "ThermalContact.normal_z": "modules/contact/ThermalContact.json#normal_z",
+    "ThermalContact.offset": "modules/contact/ThermalContact.json#offset",
+    "ThermalContact.offset_x": "modules/contact/ThermalContact.json#offset_x",
+    "ThermalContact.offset_y": "modules/contact/ThermalContact.json#offset_y",
+    "ThermalContact.offset_z": "modules/contact/ThermalContact.json#offset_z",
+    "ThermalContact.persist": "modules/contact/ThermalContact.json#persist",
+    "ThermalContact.pos": "modules/contact/ThermalContact.json#pos",
+    "ThermalContact.pos_x": "modules/contact/ThermalContact.json#pos_x",
+    "ThermalContact.pos_y": "modules/contact/ThermalContact.json#pos_y",
+    "ThermalContact.pos_z": "modules/contact/ThermalContact.json#pos_z",
+    "ThermalContact.prop": "modules/contact/ThermalContact.json#prop",
+    "ThermalContact.props": "modules/contact/ThermalContact.json#props",
+    "ThermalContact.set_extra": "modules/contact/ThermalContact.json#set_extra",
+    "ThermalContact.set_group": "modules/contact/ThermalContact.json#set_group",
+    "ThermalContact.set_inhibit": "modules/contact/ThermalContact.json#set_inhibit",
+    "ThermalContact.set_model": "modules/contact/ThermalContact.json#set_model",
+    "ThermalContact.set_persist": "modules/contact/ThermalContact.json#set_persist",
+    "ThermalContact.set_prop": "modules/contact/ThermalContact.json#set_prop",
+    "ThermalContact.shear": "modules/contact/ThermalContact.json#shear",
+    "ThermalContact.shear_x": "modules/contact/ThermalContact.json#shear_x",
+    "ThermalContact.shear_y": "modules/contact/ThermalContact.json#shear_y",
+    "ThermalContact.shear_z": "modules/contact/ThermalContact.json#shear_z",
+    "ThermalContact.valid": "modules/contact/ThermalContact.json#valid"
   },
   "fallback_hints": {
     "batch creation": "For creating many balls with packing patterns, use itasca.command('ball generate ...')",

--- a/src/pfc_mcp/knowledge/resources/python_sdk_docs/modules/contact/Contact.json
+++ b/src/pfc_mcp/knowledge/resources/python_sdk_docs/modules/contact/Contact.json
@@ -1,7 +1,7 @@
 {
   "class": "Contact",
-  "namespace": "itasca.BallBallContact, itasca.BallFacetContact, itasca.BallPebbleContact, itasca.PebblePebbleContact, itasca.PebbleFacetContact",
-  "description": "Contact object representing interaction between objects in PFC. This interface is shared by all contact types: BallBallContact (ball-ball), BallFacetContact (ball-facet), BallPebbleContact (ball-pebble), PebblePebbleContact (pebble-pebble), and PebbleFacetContact (pebble-facet). Cannot be instantiated directly - obtain instances via itasca.contact.list() or itasca.contact.find().",
+  "namespace": "itasca.BallBallContact, itasca.BallFacetContact, itasca.BallPebbleContact, itasca.PebblePebbleContact, itasca.PebbleFacetContact, itasca.BallRBlockContact, itasca.PebbleRBlockContact, itasca.RBlockFacetContact, itasca.RBlockRBlockContact, itasca.VertexFacetContact",
+  "description": "Mechanical contact object representing interaction between objects in PFC. This interface is shared by mechanical ball, pebble, facet, rblock, and vertex-facet contact types. Thermal contacts use the separate ThermalContact interface because they do not expose mechanical force methods. Cannot be instantiated directly - obtain instances via itasca.contact.list() or itasca.contact.find().",
   "instantiation": "Cannot be instantiated. Obtained via itasca.contact.list() or itasca.contact.find()",
   "methods": [
     {

--- a/src/pfc_mcp/knowledge/resources/python_sdk_docs/modules/contact/ThermalContact.json
+++ b/src/pfc_mcp/knowledge/resources/python_sdk_docs/modules/contact/ThermalContact.json
@@ -1,0 +1,562 @@
+{
+  "class": "ThermalContact",
+  "namespace": "itasca.BallBallThermalContact, itasca.BallFacetThermalContact, itasca.BallPebbleThermalContact, itasca.PebblePebbleThermalContact, itasca.PebbleFacetThermalContact",
+  "description": "Thermal contact object representing heat-transfer interaction between objects in PFC. Thermal contacts expose contact state, geometry, grouping, model/property, and orientation methods, but do not expose mechanical force or moment methods such as force_normal or force_shear. Cannot be instantiated directly - obtain instances via thermal contact iterators.",
+  "instantiation": "Cannot be instantiated directly. Obtained from PFC thermal contact iterators.",
+  "methods": [
+    {
+      "name": "activate",
+      "signature": "contact.activate(flag: bool) -> None",
+      "description": "Set the contact activated state. If a contact has been activated it is always active.",
+      "parameters": [
+        {
+          "name": "flag",
+          "type": "bool",
+          "required": true,
+          "description": "Activation state to set"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "activated",
+      "signature": "contact.activated() -> bool",
+      "description": "Get the contact activated state. If a contact has been activated it is always active.",
+      "parameters": [],
+      "returns": {
+        "type": "bool",
+        "description": "True if contact is activated"
+      }
+    },
+    {
+      "name": "active",
+      "signature": "contact.active() -> bool",
+      "description": "Get the contact activity state.",
+      "parameters": [],
+      "returns": {
+        "type": "bool",
+        "description": "True if contact is currently active"
+      }
+    },
+    {
+      "name": "end1",
+      "signature": "contact.end1() -> any",
+      "description": "Get the object at the first end of this contact.",
+      "parameters": [],
+      "returns": {
+        "type": "any",
+        "description": "Object at first end (typically a Ball)"
+      }
+    },
+    {
+      "name": "end2",
+      "signature": "contact.end2() -> any",
+      "description": "Get the object at the second end of this contact.",
+      "parameters": [],
+      "returns": {
+        "type": "any",
+        "description": "Object at second end (typically a Ball)"
+      }
+    },
+    {
+      "name": "extra",
+      "signature": "contact.extra(slot: int) -> any",
+      "description": "Get the contact extra data in the given slot.",
+      "parameters": [
+        {
+          "name": "slot",
+          "type": "int",
+          "required": true,
+          "description": "Extra data slot index"
+        }
+      ],
+      "returns": {
+        "type": "any",
+        "description": "Extra data value"
+      }
+    },
+    {
+      "name": "gap",
+      "signature": "contact.gap() -> float",
+      "description": "Get the contact gap.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Contact gap distance"
+      }
+    },
+    {
+      "name": "group",
+      "signature": "contact.group(slot: str or int = None) -> str",
+      "description": "Get the contact group name in a given slot.",
+      "parameters": [
+        {
+          "name": "slot",
+          "type": "str or int",
+          "required": false,
+          "description": "Group slot identifier"
+        }
+      ],
+      "returns": {
+        "type": "str",
+        "description": "Group name"
+      }
+    },
+    {
+      "name": "group_remove",
+      "signature": "contact.group_remove(group_name: str or int, slot: str or int = None) -> bool",
+      "description": "Remove from the given group from all group slots of the contact.",
+      "parameters": [
+        {
+          "name": "group_name",
+          "type": "str or int",
+          "required": true,
+          "description": "Group name to remove"
+        },
+        {
+          "name": "slot",
+          "type": "str or int",
+          "required": false,
+          "description": "Specific slot to remove from"
+        }
+      ],
+      "returns": {
+        "type": "bool",
+        "description": "True if group was removed from any slot"
+      }
+    },
+    {
+      "name": "groups",
+      "signature": "contact.groups() -> dict",
+      "description": "Get a dictionary describing which groups this contact is part of. The keys are slot names and values are group names.",
+      "parameters": [],
+      "returns": {
+        "type": "dict {slot: group_name}",
+        "description": "Dictionary of slot to group name mappings"
+      }
+    },
+    {
+      "name": "has_prop",
+      "signature": "contact.has_prop(property_name: str) -> bool",
+      "description": "Query the existence of a contact model property.",
+      "parameters": [
+        {
+          "name": "property_name",
+          "type": "str",
+          "required": true,
+          "description": "Property name to check"
+        }
+      ],
+      "returns": {
+        "type": "bool",
+        "description": "True if property exists"
+      }
+    },
+    {
+      "name": "id",
+      "signature": "contact.id() -> int",
+      "description": "Get the contact id.",
+      "parameters": [],
+      "returns": {
+        "type": "int",
+        "description": "Contact ID"
+      }
+    },
+    {
+      "name": "in_group",
+      "signature": "contact.in_group(group_name: str or int, slot: str or int = None) -> bool",
+      "description": "Test if the contact is part of a given group. If slot is given, only that slot is searched. Otherwise, all group slots are searched.",
+      "parameters": [
+        {
+          "name": "group_name",
+          "type": "str or int",
+          "required": true,
+          "description": "Group name to check"
+        },
+        {
+          "name": "slot",
+          "type": "str or int",
+          "required": false,
+          "description": "Specific slot to search"
+        }
+      ],
+      "returns": {
+        "type": "bool",
+        "description": "True if contact is in the group"
+      }
+    },
+    {
+      "name": "inhibit",
+      "signature": "contact.inhibit() -> bool",
+      "description": "Get the contact inhibit flag.",
+      "parameters": [],
+      "returns": {
+        "type": "bool",
+        "description": "True if contact is inhibited"
+      }
+    },
+    {
+      "name": "method",
+      "signature": "contact.method(method_name: str, args: dict = None) -> None",
+      "description": "Execute a contact model method. The first argument must be a string identifying a method that exists in the contact model assigned to the contact. The optional second argument should be a dictionary with string keys which give the contact model method arguments.",
+      "parameters": [
+        {
+          "name": "method_name",
+          "type": "str",
+          "required": true,
+          "description": "Method name to execute"
+        },
+        {
+          "name": "args",
+          "type": "dict {str: any}",
+          "required": false,
+          "description": "Method arguments as dictionary"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "model",
+      "signature": "contact.model() -> str",
+      "description": "Get the contact model name.",
+      "parameters": [],
+      "returns": {
+        "type": "str",
+        "description": "Contact model name"
+      }
+    },
+    {
+      "name": "normal",
+      "signature": "contact.normal() -> vec",
+      "description": "Get the contact unit normal.",
+      "parameters": [],
+      "returns": {
+        "type": "vec",
+        "description": "Unit normal vector"
+      }
+    },
+    {
+      "name": "normal_x",
+      "signature": "contact.normal_x() -> float",
+      "description": "Get the x-component of the contact unit normal.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "X-component of unit normal"
+      }
+    },
+    {
+      "name": "normal_y",
+      "signature": "contact.normal_y() -> float",
+      "description": "Get the y-component of the contact unit normal.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Y-component of unit normal"
+      }
+    },
+    {
+      "name": "normal_z",
+      "signature": "contact.normal_z() -> float",
+      "description": "Get the z-component of the contact unit normal.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Z-component of unit normal"
+      }
+    },
+    {
+      "name": "offset",
+      "signature": "contact.offset() -> vec",
+      "description": "Get the contact offset.",
+      "parameters": [],
+      "returns": {
+        "type": "vec",
+        "description": "Offset vector"
+      }
+    },
+    {
+      "name": "offset_x",
+      "signature": "contact.offset_x() -> float",
+      "description": "Get the x-component of the contact offset.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "X-component of offset"
+      }
+    },
+    {
+      "name": "offset_y",
+      "signature": "contact.offset_y() -> float",
+      "description": "Get the y-component of the contact offset.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Y-component of offset"
+      }
+    },
+    {
+      "name": "offset_z",
+      "signature": "contact.offset_z() -> float",
+      "description": "Get the z-component of the contact offset.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Z-component of offset"
+      }
+    },
+    {
+      "name": "persist",
+      "signature": "contact.persist() -> bool",
+      "description": "Get the contact persistence flag.",
+      "parameters": [],
+      "returns": {
+        "type": "bool",
+        "description": "True if contact persists"
+      }
+    },
+    {
+      "name": "pos",
+      "signature": "contact.pos() -> vec",
+      "description": "Get the contact position.",
+      "parameters": [],
+      "returns": {
+        "type": "vec",
+        "description": "Contact position vector"
+      }
+    },
+    {
+      "name": "pos_x",
+      "signature": "contact.pos_x() -> float",
+      "description": "Get the x-component of the contact position.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "X-coordinate of contact position"
+      }
+    },
+    {
+      "name": "pos_y",
+      "signature": "contact.pos_y() -> float",
+      "description": "Get the y-component of the contact position.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Y-coordinate of contact position"
+      }
+    },
+    {
+      "name": "pos_z",
+      "signature": "contact.pos_z() -> float",
+      "description": "Get the z-component of the contact position.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Z-coordinate of contact position"
+      }
+    },
+    {
+      "name": "prop",
+      "signature": "contact.prop(property_name or index: str or int) -> any",
+      "description": "Get a contact model property.",
+      "parameters": [
+        {
+          "name": "property_name or index",
+          "type": "str or int",
+          "required": true,
+          "description": "Property name or index"
+        }
+      ],
+      "returns": {
+        "type": "any",
+        "description": "Property value"
+      }
+    },
+    {
+      "name": "props",
+      "signature": "contact.props() -> dict",
+      "description": "Get the contact model properties as a dictionary.",
+      "parameters": [],
+      "returns": {
+        "type": "dict {str: any}",
+        "description": "Dictionary of all contact properties"
+      }
+    },
+    {
+      "name": "set_extra",
+      "signature": "contact.set_extra(slot: int, value: any) -> None",
+      "description": "Set the contact extra data in the given slot.",
+      "parameters": [
+        {
+          "name": "slot",
+          "type": "int",
+          "required": true,
+          "description": "Extra data slot index"
+        },
+        {
+          "name": "value",
+          "type": "any",
+          "required": true,
+          "description": "Value to set"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "set_group",
+      "signature": "contact.set_group(group_name: str or int, slot: str or int = None) -> None",
+      "description": "Set the contact group name in a given slot.",
+      "parameters": [
+        {
+          "name": "group_name",
+          "type": "str or int",
+          "required": true,
+          "description": "Group name to set"
+        },
+        {
+          "name": "slot",
+          "type": "str or int",
+          "required": false,
+          "description": "Slot to set group in"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "set_inhibit",
+      "signature": "contact.set_inhibit(flag: bool) -> None",
+      "description": "Set the contact inhibit flag.",
+      "parameters": [
+        {
+          "name": "flag",
+          "type": "bool",
+          "required": true,
+          "description": "Inhibit flag to set"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "set_model",
+      "signature": "contact.set_model(model_name: str = None) -> None",
+      "description": "Set the contact model for this contact.",
+      "parameters": [
+        {
+          "name": "model_name",
+          "type": "str",
+          "required": false,
+          "description": "Contact model name"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "set_persist",
+      "signature": "contact.set_persist(flag: bool) -> None",
+      "description": "Set the contact persistence flag.",
+      "parameters": [
+        {
+          "name": "flag",
+          "type": "bool",
+          "required": true,
+          "description": "Persistence flag to set"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "set_prop",
+      "signature": "contact.set_prop(property_name or index: str or int, value: any) -> None",
+      "description": "Set a contact model property.",
+      "parameters": [
+        {
+          "name": "property_name or index",
+          "type": "str or int",
+          "required": true,
+          "description": "Property name or index"
+        },
+        {
+          "name": "value",
+          "type": "any",
+          "required": true,
+          "description": "Property value to set"
+        }
+      ],
+      "returns": {
+        "type": "None",
+        "description": "No return value"
+      }
+    },
+    {
+      "name": "shear",
+      "signature": "contact.shear() -> vec",
+      "description": "Get the contact shear direction.",
+      "parameters": [],
+      "returns": {
+        "type": "vec",
+        "description": "Shear direction vector"
+      }
+    },
+    {
+      "name": "shear_x",
+      "signature": "contact.shear_x() -> float",
+      "description": "Get the x-component of the contact shear direction.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "X-component of shear direction"
+      }
+    },
+    {
+      "name": "shear_y",
+      "signature": "contact.shear_y() -> float",
+      "description": "Get the y-component of the contact shear direction.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Y-component of shear direction"
+      }
+    },
+    {
+      "name": "shear_z",
+      "signature": "contact.shear_z() -> float",
+      "description": "Get the z-component of the contact shear direction.",
+      "parameters": [],
+      "returns": {
+        "type": "float",
+        "description": "Z-component of shear direction"
+      }
+    },
+    {
+      "name": "valid",
+      "signature": "contact.valid() -> bool",
+      "description": "Returns True if this contact is live.",
+      "parameters": [],
+      "returns": {
+        "type": "bool",
+        "description": "True if contact is live"
+      }
+    }
+  ]
+}

--- a/src/pfc_mcp/knowledge/search/postprocessing/contact_consolidation.py
+++ b/src/pfc_mcp/knowledge/search/postprocessing/contact_consolidation.py
@@ -72,7 +72,7 @@ def consolidate_contact_apis(results: list[SearchResult]) -> list[SearchResult]:
     """
     # Import Contact types
     try:
-        from pfc_mcp.knowledge.python_api.types.contact import CONTACT_TYPES
+        from pfc_mcp.knowledge.python_api.types.contact import ALL_CONTACT_TYPES, get_contact_types_for_method
     except ImportError:
         # If Contact types not available, return unchanged
         return results
@@ -87,7 +87,7 @@ def consolidate_contact_apis(results: list[SearchResult]) -> list[SearchResult]:
         contact_type = None
         method_name = None
 
-        for ct in CONTACT_TYPES:
+        for ct in ALL_CONTACT_TYPES:
             # Check if doc_name contains this Contact type
             # Examples: "itasca.BallBallContact.gap", "BallBallContact.gap"
             if f".{ct}." in doc_name or doc_name.startswith(f"{ct}."):
@@ -108,25 +108,13 @@ def consolidate_contact_apis(results: list[SearchResult]) -> list[SearchResult]:
             first_idx = seen_methods[method_name]
             first_result = consolidated[first_idx]
 
-            # Update metadata to include this Contact type
-            if "all_contact_types" not in first_result.document.metadata:
-                # Initialize with the first Contact type we saw
-                first_contact_type = None
-                for ct in CONTACT_TYPES:
-                    if f".{ct}." in first_result.document.name or first_result.document.name.startswith(f"{ct}."):
-                        first_contact_type = ct
-                        break
-
-                first_result.document.metadata["all_contact_types"] = [first_contact_type] if first_contact_type else []
-
-            # Add current Contact type if not already in the list
-            if contact_type not in first_result.document.metadata["all_contact_types"]:
-                first_result.document.metadata["all_contact_types"].append(contact_type)
+            first_result.document.metadata["all_contact_types"] = get_contact_types_for_method(method_name)
 
             # Skip adding this duplicate result
             continue
 
         # First time seeing this Contact method - add it and track it
+        result.document.metadata["all_contact_types"] = get_contact_types_for_method(method_name)
         seen_methods[method_name] = len(consolidated)
         consolidated.append(result)
 

--- a/src/pfc_mcp/tools/browse_python_api.py
+++ b/src/pfc_mcp/tools/browse_python_api.py
@@ -104,11 +104,7 @@ def _parse_api_path(api: str) -> dict[str, Any]:
 
         actual_object_name = object_name
         if object_name not in objects:
-            contact_data = objects.get("Contact", {})
-            contact_types = contact_data.get("types", [])
-            if object_name in contact_types:
-                actual_object_name = "Contact"
-            else:
+            if not _is_documented_object_type(object_name, objects):
                 return {
                     "type": "error",
                     "error": f"Object '{object_name}' not found",
@@ -169,6 +165,10 @@ def _format_module_path(index_key: str) -> str:
     if index_key == "itasca":
         return "itasca"
     return f"itasca.{index_key}"
+
+
+def _is_documented_object_type(object_name: str, objects: dict[str, Any]) -> bool:
+    return any(object_name in object_info.get("types", []) for object_info in objects.values())
 
 
 def _extract_function_names(functions: list[Any]) -> list[str]:

--- a/tests/test_contact_type_expansion.py
+++ b/tests/test_contact_type_expansion.py
@@ -1,0 +1,73 @@
+"""Regression tests for concrete Contact type expansion."""
+
+import json
+
+import pytest
+
+from pfc_mcp.knowledge.python_api.loader import DocumentationLoader
+from pfc_mcp.knowledge.python_api.types.contact import THERMAL_CONTACT_METHODS, ContactTypeResolver
+from pfc_mcp.server import mcp
+
+
+def setup_function() -> None:
+    DocumentationLoader.clear_cache()
+
+
+def test_thermal_contact_methods_are_expanded_without_mechanical_force_methods() -> None:
+    index = DocumentationLoader.load_index()
+    quick_ref = index["quick_ref"]
+
+    assert "itasca.BallBallThermalContact.gap" in quick_ref
+    assert "itasca.BallBallThermalContact.normal" in quick_ref
+    assert "itasca.BallBallThermalContact.pos" in quick_ref
+    assert "itasca.BallBallThermalContact.shear" in quick_ref
+    assert "itasca.BallBallThermalContact.force_normal" not in quick_ref
+    assert "itasca.BallBallThermalContact.force_shear" not in quick_ref
+
+
+def test_thermal_contact_loader_rejects_force_methods() -> None:
+    assert DocumentationLoader.load_api_doc("itasca.BallBallThermalContact.gap") is not None
+    assert DocumentationLoader.load_api_doc("itasca.BallBallThermalContact.force_normal") is None
+    assert DocumentationLoader.load_method("BallBallThermalContact", "force_normal") is None
+
+
+def test_thermal_contact_object_is_filtered_to_verified_methods() -> None:
+    doc = DocumentationLoader.load_object("BallBallThermalContact")
+
+    assert doc is not None
+    method_names = {method["name"] for method in doc["methods"]}
+    assert method_names == THERMAL_CONTACT_METHODS
+    assert "force_normal" not in method_names
+    assert "force_shear" not in method_names
+    assert doc["availability"]["versions"] == ["6.0", "7.0", "9.0"]
+
+
+def test_vertex_facet_contact_is_version_gated_to_pfc_9() -> None:
+    index = DocumentationLoader.load_index()
+
+    assert "itasca.VertexFacetContact.force_normal" in index["quick_ref"]
+
+    doc = DocumentationLoader.load_api_doc("itasca.VertexFacetContact.force_normal")
+    assert doc is not None
+    assert doc["availability"]["versions"] == ["9.0"]
+
+
+def test_contact_resolver_does_not_match_unrelated_object_methods() -> None:
+    index = DocumentationLoader.load_index()
+
+    assert ContactTypeResolver.resolve("BallBallContact.gap", index["quick_ref"]) is not None
+    assert ContactTypeResolver.resolve("BallBallContact.radius", index["quick_ref"]) is None
+
+
+@pytest.mark.asyncio
+async def test_browse_python_api_reports_missing_thermal_force_method() -> None:
+    result = await mcp.call_tool(
+        "pfc_browse_python_api",
+        {"api": "itasca.BallBallThermalContact.force_normal"},
+    )
+
+    assert result is not None
+    payload = json.loads(result.content[0].text)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "method_not_found"
+    assert "force_normal" not in payload["error"]["details"]["available_methods"]


### PR DESCRIPTION
## Summary

Fixes the contact API documentation expansion so thermal contact types use a separate documented interface instead of inheriting mechanical-only methods from `Contact`.

Changes include:
- add a `ThermalContact` documentation model for thermal contact types
- prevent thermal contacts from exposing `force_normal` and `force_shear`
- keep shared contact methods available across applicable mechanical and thermal types
- mark `VertexFacetContact` as a PFC 9.0-only mechanical contact type
- add regression tests for contact expansion, object loading, browse behavior, and version availability

## Validation

- `uv run pytest -q --basetemp .pytest-tmp` -> 74 passed
- `uv run ruff check src tests`
- `git diff --check`

Runtime spot checks were also performed against PFC 9 : mechanical contact methods were callable on a real ball-ball contact, and PFC class reflection confirmed thermal contact classes do not expose `force_normal` / `force_shear` while `VertexFacetContact` has the mechanical interface.