### PR TITLE
fix: round task elapsed_time to 2 decimals for display

### DIFF
--- a/src/pfc_mcp/formatting.py
+++ b/src/pfc_mcp/formatting.py
@@ -26,6 +26,22 @@ def format_unix_timestamp(value: Any) -> str:
         return str(value)
 
 
+def format_elapsed_seconds(value: Any) -> float | None:
+    """Round a bridge-supplied elapsed-time float to 2 decimals for display.
+
+    The bridge reports elapsed wall-clock at full float precision (e.g.
+    0.010000944137573242); sub-millisecond digits are noise for a task
+    duration. Kept numeric (not stringified) so the field stays
+    machine-readable. None and unparseable values pass through as None.
+    """
+    if value is None:
+        return None
+    try:
+        return round(float(value), 2)
+    except (TypeError, ValueError):
+        return None
+
+
 def paginate_output(
     output: str,
     skip_newest: int,

--- a/src/pfc_mcp/tools/check_task_status.py
+++ b/src/pfc_mcp/tools/check_task_status.py
@@ -9,6 +9,7 @@ from pfc_mcp.contracts import build_ok
 from pfc_mcp.formatting import (
     build_bridge_error,
     build_operation_error,
+    format_elapsed_seconds,
     format_unix_timestamp,
     paginate_output,
 )
@@ -96,7 +97,7 @@ def register(mcp: FastMCP) -> None:
             "task_status": status,
             "start_time": format_unix_timestamp(data.get("start_time")),
             "end_time": format_unix_timestamp(data.get("end_time")),
-            "elapsed_time": data.get("elapsed_time"),
+            "elapsed_time": format_elapsed_seconds(data.get("elapsed_time")),
             "entry_script": data.get("entry_script") or data.get("script_path"),
             "description": data.get("description"),
             "output": output_text,

--- a/src/pfc_mcp/tools/list_tasks.py
+++ b/src/pfc_mcp/tools/list_tasks.py
@@ -6,7 +6,12 @@ from fastmcp import FastMCP
 
 from pfc_mcp.bridge import get_bridge_client
 from pfc_mcp.contracts import build_ok
-from pfc_mcp.formatting import build_bridge_error, build_operation_error, format_unix_timestamp
+from pfc_mcp.formatting import (
+    build_bridge_error,
+    build_operation_error,
+    format_elapsed_seconds,
+    format_unix_timestamp,
+)
 from pfc_mcp.utils import SkipNewestTasks, TaskListLimit
 
 
@@ -51,7 +56,7 @@ def register(mcp: FastMCP) -> None:
                 "source": task.get("source", "agent"),
                 "start_time": format_unix_timestamp(task.get("start_time")),
                 "end_time": format_unix_timestamp(task.get("end_time")),
-                "elapsed_time": task.get("elapsed_time"),
+                "elapsed_time": format_elapsed_seconds(task.get("elapsed_time")),
                 "entry_script": task.get("entry_script") or task.get("name"),
                 "description": task.get("description"),
             }

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,26 @@
+"""Unit tests for pfc_mcp.formatting display helpers."""
+
+from pfc_mcp.formatting import format_elapsed_seconds
+
+
+def test_rounds_full_precision_float_to_two_decimals():
+    # The bridge reports elapsed wall-clock at full float precision.
+    assert format_elapsed_seconds(0.010000944137573242) == 0.01
+    assert format_elapsed_seconds(5.236) == 5.24
+
+
+def test_keeps_value_numeric_not_stringified():
+    result = format_elapsed_seconds(1.5)
+    assert isinstance(result, float)
+
+
+def test_integer_input_is_accepted():
+    assert format_elapsed_seconds(3) == 3.0
+
+
+def test_none_passes_through():
+    assert format_elapsed_seconds(None) is None
+
+
+def test_unparseable_value_becomes_none():
+    assert format_elapsed_seconds("5.0s") is None


### PR DESCRIPTION
The bridge reports elapsed wall-clock at full float precision (e.g. 0.010000944137573242); sub-millisecond digits are noise for a task duration. Round it in the MCP tool layer — the same boundary where the sibling timing fields (start_time/end_time) are already formatted from the bridge's raw values — via a new format_elapsed_seconds() helper that keeps the field numeric (machine-readable), not stringified. Applies to both pfc_check_task_status and pfc_list_tasks.