### PR TITLE
chore(release): pfc-mcp 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ section exists.
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-03
+
+### Fixed
+- Bumped `itasca-mcp-bridge` to `0.1.3` (submodule pin `25668d7`), picking up
+  two abspath-vs-CWD fixes since 0.4.3. Command-log capture: `itasca.command()`
+  output no longer comes back empty when the engine's working directory
+  diverges from Python's (headless consoles, or after a task `os.chdir()`).
+  Task-log resolution: `pfc_check_task_status` no longer returns `(no output)`
+  for a task that called `os.chdir()` — the task log and `tasks.json` are now
+  read from a bridge root frozen at startup rather than the live working
+  directory.
+
+### Changed
+- Task `elapsed_time` is now rounded to 2 decimals in `pfc_check_task_status`
+  and `pfc_list_tasks` (e.g. `0.01` instead of `0.010000944137573242`). The
+  field stays numeric; the bridge still reports full precision, with rounding
+  applied at the MCP presentation layer alongside the existing
+  `start_time` / `end_time` formatting.
+
 ## [0.4.3] - 2026-05-26
 
 Contact API documentation now distinguishes mechanical and thermal

--- a/src/pfc_mcp/__init__.py
+++ b/src/pfc_mcp/__init__.py
@@ -1,3 +1,3 @@
 """PFC MCP Server - ITASCA PFC discrete element simulation tools via MCP."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"


### PR DESCRIPTION
Release 0.4.4.

**Fixed** — Bridge bumped to 0.1.3 (submodule pin 25668d7): command-log and task-log abspath-vs-CWD fixes. `itasca.command()` output and `pfc_check_task_status` no longer return empty after a task `os.chdir()` or on headless consoles.

**Changed** — Task `elapsed_time` rounded to 2 decimals in `pfc_check_task_status` / `pfc_list_tasks` (kept numeric).

Tag v0.4.4 pushed after merge to publish to PyPI.