### PR TITLE
Slim task-status pagination + add --bridge-port CLI arg

### DIFF
--- a/docs/development/source-install.md
+++ b/docs/development/source-install.md
@@ -73,7 +73,10 @@ If you want your MCP client to use local source instead of the published PyPI pa
 }
 ```
 
-The `--bridge-url` argument is optional (defaults to `ws://localhost:9001`). Use it to connect to a bridge on a different port.
+The `--bridge-url` argument is optional (defaults to `ws://localhost:9001`). To
+connect to a bridge on a non-default port, pass `--bridge-port` instead of
+spelling out the whole URL — e.g. `"args": [..., "pfc-mcp", "--bridge-port", "9002"]`
+when the bridge was started with `itasca_mcp_bridge.start(port=9002)`.
 
 This is the simplest way to test MCP-side changes without building or publishing packages.
 

--- a/docs/development/source-install.zh-CN.md
+++ b/docs/development/source-install.zh-CN.md
@@ -73,7 +73,10 @@ uv run pytest tests
 }
 ```
 
-`--bridge-url` 参数是可选的（默认 `ws://localhost:9001`），用于连接不同端口上的 bridge。
+`--bridge-url` 参数是可选的（默认 `ws://localhost:9001`）。若 bridge 跑在非默认端口上，
+直接用 `--bridge-port` 即可，无需写出整条 URL——例如 bridge 以
+`itasca_mcp_bridge.start(port=9002)` 启动时，配置写
+`"args": [..., "pfc-mcp", "--bridge-port", "9002"]`。
 
 这是验证 MCP 侧改动最简单的方式，不需要先构建或发布包。
 

--- a/src/pfc_mcp/formatting.py
+++ b/src/pfc_mcp/formatting.py
@@ -60,8 +60,6 @@ def paginate_output(
     pagination = {
         "total_lines": total_lines,
         "line_range": f"{start_idx + 1}-{end_idx}" if selected else "0-0",
-        "has_older": start_idx > 0,
-        "has_newer": skip_newest > 0,
     }
 
     return "\n".join(selected) if selected else "(no output)", pagination

--- a/src/pfc_mcp/server.py
+++ b/src/pfc_mcp/server.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import os
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from fastmcp import FastMCP
 
@@ -50,6 +51,16 @@ interrupt_task.register(mcp)
 execute_code.register(mcp)
 
 
+DEFAULT_BRIDGE_URL = "ws://localhost:9001"
+
+
+def _override_bridge_port(url: str, port: int) -> str:
+    """Return ``url`` with its port replaced, preserving scheme/host/path."""
+    parts = urlsplit(url)
+    host = parts.hostname or "localhost"
+    return urlunsplit((parts.scheme or "ws", f"{host}:{port}", parts.path, parts.query, parts.fragment))
+
+
 def main() -> None:
     """Entry point for the PFC MCP server."""
     parser = argparse.ArgumentParser(
@@ -80,6 +91,16 @@ def main() -> None:
         help="Bridge WebSocket URL (default: ws://localhost:9001, or PFC_MCP_BRIDGE_URL env)",
     )
     parser.add_argument(
+        "--bridge-port",
+        type=int,
+        default=None,
+        help=(
+            "Bridge WebSocket port; shorthand for --bridge-url ws://localhost:PORT. "
+            "Overrides only the port of --bridge-url / PFC_MCP_BRIDGE_URL when both "
+            "are given (default: 9001)"
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         choices=["debug", "info", "warning", "error"],
         default="warning",
@@ -87,8 +108,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.bridge_url:
-        os.environ["PFC_MCP_BRIDGE_URL"] = args.bridge_url
+    # Resolve the bridge URL from (in order of precedence) --bridge-url,
+    # the PFC_MCP_BRIDGE_URL env, then the default. --bridge-port then
+    # overrides just the port, so users can point at a non-default bridge
+    # port without spelling out the whole ws:// URL.
+    bridge_url = args.bridge_url or os.environ.get("PFC_MCP_BRIDGE_URL")
+    if args.bridge_port is not None:
+        if not 1 <= args.bridge_port <= 65535:
+            parser.error("--bridge-port must be between 1 and 65535")
+        bridge_url = _override_bridge_port(bridge_url or DEFAULT_BRIDGE_URL, args.bridge_port)
+    if bridge_url:
+        os.environ["PFC_MCP_BRIDGE_URL"] = bridge_url
 
     # Configure logging
     level = getattr(logging, args.log_level.upper())

--- a/src/pfc_mcp/tools/check_task_status.py
+++ b/src/pfc_mcp/tools/check_task_status.py
@@ -76,14 +76,21 @@ def register(mcp: FastMCP) -> None:
         data = response.get("data") or {}
 
         # Prefer bridge-side pagination when available: the bridge sees
-        # the full log and reports accurate total_lines / has_older /
+        # the full log and reports accurate total_lines / line_range /
         # filter matches. Fall back to MCP-side paginate_output only for
         # legacy bridges that still send unpaginated output.
         bridge_output = data.get("output") or ""
         bridge_pagination = data.get("pagination")
         if isinstance(bridge_pagination, dict):
             output_text = bridge_output if bridge_output else "(no output)"
-            pagination = bridge_pagination
+            # Normalize to the slim shape regardless of bridge version:
+            # total_lines + line_range are self-describing, so the old
+            # has_older / has_newer booleans (still emitted by pre-slim
+            # bridges on PyPI) are dropped here for a consistent contract.
+            pagination = {
+                "total_lines": bridge_pagination.get("total_lines"),
+                "line_range": bridge_pagination.get("line_range"),
+            }
         else:
             output_text, pagination = paginate_output(
                 output=bridge_output,

--- a/tests/test_phase2_tools.py
+++ b/tests/test_phase2_tools.py
@@ -29,8 +29,7 @@ def test_pagination() -> None:
 
     assert text == "c\nd"
     assert page["line_range"] == "3-4"
-    assert page["has_older"] is True
-    assert page["has_newer"] is False
+    assert page["total_lines"] == 4
 
 
 def test_validate_script_path_requires_absolute() -> None:

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -226,8 +226,6 @@ async def test_check_task_status_running_fields(mock_bridge, tmp_path):
         pag = data["pagination"]
         assert "total_lines" in pag
         assert "line_range" in pag
-        assert "has_older" in pag
-        assert "has_newer" in pag
 
 
 @pytest.mark.asyncio
@@ -270,10 +268,9 @@ async def test_check_task_status_passes_through_bridge_pagination(mock_bridge, t
     parsed = json.loads(result.content[0].text)
     assert parsed["ok"] is True
     data = parsed["data"]
-    # Bridge pagination should pass through unchanged
+    # Bridge pagination values are used (total_lines + line_range)
     assert data["pagination"]["total_lines"] == 12345
     assert data["pagination"]["line_range"] == "12281-12345"
-    assert data["pagination"]["has_older"] is True
     # Output should come from bridge verbatim (not re-split/joined)
     assert data["output"] == "paginated-window-line"
 


### PR DESCRIPTION
## Summary

- **refactor:** slim task-status pagination to `total_lines` + `line_range`. Drop the redundant `has_older` / `has_newer` booleans from the MCP-side `paginate_output` fallback, and normalize bridge-supplied pagination to the same slim pair so output is consistent regardless of bridge version (pre-slim bridges on PyPI still emit the booleans; they are stripped here).
- **feat:** add `--bridge-port` CLI arg. MCP clients can point at a non-default bridge port (e.g. when the bridge was started with `itasca_mcp_bridge.start(port=9002)`) by passing `--bridge-port` instead of spelling out the whole `PFC_MCP_BRIDGE_URL`. Resolves the bridge URL from `--bridge-url` / env / default, then overrides just the port. Docs updated.

## Notes

- MCP-side normalization is bridge-version-agnostic, so this does **not** depend on the matching `itasca-mcp-bridge` PR and does **not** bump the submodule pin — the pin bump is a separate follow-up after the bridge is released.
- Mirrors the equivalent `flac-mcp` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
