### PR TITLE
refactor: send execute_task bridge message + bump bridge pin

### DIFF
--- a/src/pfc_mcp/bridge/client.py
+++ b/src/pfc_mcp/bridge/client.py
@@ -195,13 +195,13 @@ class PFCBridgeClient:
     ) -> dict[str, Any]:
         return await self._request_with_retry(
             {
-                "type": "pfc_task",
+                "type": "execute_task",
                 "task_id": task_id,
                 "script_path": script_path,
                 "description": description,
                 "source": source,
             },
-            operation_name="pfc_task",
+            operation_name="execute_task",
             timeout_s=10.0,
         )
 

--- a/src/pfc_mcp/tools/execute_task.py
+++ b/src/pfc_mcp/tools/execute_task.py
@@ -54,6 +54,13 @@ def register(mcp: FastMCP) -> None:
         values and refine live via pfc_execute_code as the task
         cycles. For synchronous, inline execution, use
         pfc_execute_code directly.
+
+        Submission uses the bridge's `execute_task` protocol message. If
+        a submission times out, the connected bridge may predate it —
+        confirm its version with pfc_execute_code (`import
+        itasca_mcp_bridge; print(itasca_mcp_bridge.__version__)`). To
+        upgrade, fetch and follow the bootstrap guide, then resubmit:
+        https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap.md
         """
         try:
             client = await get_bridge_client()

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -26,9 +26,9 @@ async def _mock_bridge_handler(websocket):
     async for raw in websocket:
         req = json.loads(raw)
         req_id = req.get("request_id", "unknown")
-        msg_type = req.get("type", "pfc_task")
+        msg_type = req.get("type", "execute_task")
 
-        if msg_type == "pfc_task":
+        if msg_type in ("execute_task", "pfc_task"):
             task_id = req.get("task_id", "000000")
             TASK_STORE[task_id] = {
                 "status": "running",


### PR DESCRIPTION
## Why

The bridge renamed its WebSocket message type `pfc_task` → `execute_task` (product-neutral; bridge PR #10, now merged). This switches the pfc-mcp client to the canonical name and bumps the submodule pin.

## What

- `bridge/client.py`: send `type: "execute_task"` (the bridge still accepts `pfc_task` as a deprecated alias, so this is safe against bridges that already shipped #10).
- `tools/execute_task.py`: docstring troubleshooting note — if a submission times out, the connected bridge may predate `execute_task`; the agent can confirm `itasca_mcp_bridge.__version__` via `pfc_execute_code` (understood by all bridge versions) and upgrade by fetching the bootstrap guide.
- `tests/test_tool_contracts.py`: mock bridge accepts both `execute_task` and `pfc_task`.
- Bump `itasca-mcp-bridge` submodule pin `78148a8` → `9042090` (execute_task rename merged).

## Rollout note

Recommended order was bridge-first (done), then this client switch. New-client → old-bridge (pre-#10) would time out; the docstring note gives the agent an actionable recovery path. flac-mcp gets the mirror change in its own PR.

## Tests

`test_tool_contracts.py` + `test_phase2_tools.py` pass; ruff format/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)