### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,30 @@ section exists.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-04
+
+### Added
+- `--bridge-port` CLI argument to override the bridge connection port —
+  shorthand for `--bridge-url ws://localhost:PORT`. When a full
+  `--bridge-url` / `PFC_MCP_BRIDGE_URL` is also supplied, only its port is
+  overridden.
+
+### Changed
+- `pfc_execute_task` now submits over the bridge's `execute_task` message
+  (renamed from `pfc_task` so the shared bridge protocol is product-neutral;
+  the bridge keeps `pfc_task` as a deprecated alias). **Requires
+  `itasca-mcp-bridge >= 0.1.5`** — older bridges silently ignore the message
+  and submission times out. If that happens, confirm the bridge version with
+  `pfc_execute_code` (`import itasca_mcp_bridge;
+  print(itasca_mcp_bridge.__version__)`) and upgrade by re-running addon.py.
+- Slimmed `pfc_check_task_status` pagination to `total_lines` + `line_range`,
+  replacing the heavier pagination object. Output windows are still selected
+  with `skip_newest` / `limit` / `filter_text`.
+- Bumped `itasca-mcp-bridge` to `0.1.5` (submodule pin). Picks up the PySide6
+  Qt task-pump fix so the bridge starts on PFC 9.7+ (Python 3.10 / Qt6),
+  where a hard `PySide2` import previously froze the GUI on startup, and the
+  `execute_task` protocol rename.
+
 ## [0.4.4] - 2026-06-03
 
 ### Fixed

--- a/src/pfc_mcp/__init__.py
+++ b/src/pfc_mcp/__init__.py
@@ -1,3 +1,3 @@
 """PFC MCP Server - ITASCA PFC discrete element simulation tools via MCP."""
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"


### PR DESCRIPTION
Release **0.5.0**. Bumps `__version__` 0.4.4 → 0.5.0 and promotes `## [Unreleased]` → `## [0.5.0]` (required by the publish workflow's tag-matched extraction).

### Added
- `--bridge-port` CLI argument (shorthand for `--bridge-url ws://localhost:PORT`).

### Changed
- `pfc_execute_task` now uses the bridge's `execute_task` message (renamed from `pfc_task` for product-neutrality; `pfc_task` kept as a deprecated alias). **Requires `itasca-mcp-bridge >= 0.1.5`.**
- Slimmed `pfc_check_task_status` pagination to `total_lines` + `line_range`.
- Bumped `itasca-mcp-bridge` submodule pin to `0.1.5` (PFC 9.7+ PySide6 Qt pump + execute_task rename).

### Release order
Bridge `0.1.5` is already on PyPI, so this client release is safe (no new-client → old-bridge skew for users who upgrade both).

After merge, tag `v0.5.0` on the merge commit to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)