### PR TITLE
docs: recommend the self-upgrading two-liner; bump bridge pin to v0.2.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository has two runtime contexts:
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
 
-End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `addon.py`; the submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
+End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
 ## Core Architecture
 
@@ -27,7 +27,7 @@ End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `ad
 - Runs in PFC GUI process
 - Owns thread-safe interaction with ITASCA SDK
 - Handles long-running tasks and diagnostics
-- Started inside PFC GUI via `addon.py` (which pip-installs `itasca-mcp-bridge` and calls `itasca_mcp_bridge.start()`)
+- Started inside PFC GUI via `itasca_mcp_bridge.start()`, which self-upgrades from PyPI first (best-effort); `addon.py` remains the manual first-install bootstrap
 
 ## Repository Layout
 
@@ -40,7 +40,7 @@ pfc-mcp/
 │   ├── formatting.py    # shared response formatting
 │   └── server.py        # MCP server entrypoint
 ├── itasca-mcp-bridge/   # submodule → github.com/yusong652/itasca-mcp-bridge
-├── addon.py             # PFC-side bootstrap (pip-installs the bridge)
+├── addon.py             # PFC-side first-install bootstrap (pip-installs the bridge)
 └── tests/               # MCP/tool contract tests
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This repository has two runtime contexts:
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
 
-Treat these as separate deployment targets. End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `addon.py`; the submodule exists only so contributors can edit bridge code alongside MCP code without two clones.
+Treat these as separate deployment targets. End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones.
 
 The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated and no longer maintained — its code lived in `pfc-mcp-bridge/` here and was removed when the submodule replaced it.
 
@@ -29,7 +29,7 @@ The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is depre
 - Runs in PFC GUI process
 - Owns thread-safe interaction with ITASCA SDK
 - Handles long-running tasks and diagnostics
-- Started inside PFC GUI via `addon.py` (which pip-installs `itasca-mcp-bridge` and calls `itasca_mcp_bridge.start()`)
+- Started inside PFC GUI via `itasca_mcp_bridge.start()`, which self-upgrades from PyPI first (best-effort); `addon.py` remains the manual first-install bootstrap
 - The submodule pin in this repo controls which bridge revision contributors develop against; runtime users always get whatever is on PyPI
 
 ## Repository Layout
@@ -43,7 +43,7 @@ pfc-mcp/
 │   ├── formatting.py    # shared response formatting
 │   └── server.py        # MCP server entrypoint
 ├── itasca-mcp-bridge/   # submodule → github.com/yusong652/itasca-mcp-bridge
-├── addon.py             # PFC-side bootstrap (pip-installs the bridge)
+├── addon.py             # PFC-side first-install bootstrap (pip-installs the bridge)
 └── tests/               # MCP/tool contract tests
 ```
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,7 +11,7 @@ This repository has two runtime contexts:
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
 
-End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `addon.py`; the submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
+End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
 ## Core Architecture
 
@@ -27,7 +27,7 @@ End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `ad
 - Runs in PFC GUI process
 - Owns thread-safe interaction with ITASCA SDK
 - Handles long-running tasks and diagnostics
-- Started inside PFC GUI via `addon.py` (which pip-installs `itasca-mcp-bridge` and calls `itasca_mcp_bridge.start()`)
+- Started inside PFC GUI via `itasca_mcp_bridge.start()`, which self-upgrades from PyPI first (best-effort); `addon.py` remains the manual first-install bootstrap
 
 ## Repository Layout
 
@@ -40,7 +40,7 @@ pfc-mcp/
 │   ├── formatting.py    # shared response formatting
 │   └── server.py        # MCP server entrypoint
 ├── itasca-mcp-bridge/   # submodule → github.com/yusong652/itasca-mcp-bridge
-├── addon.py             # PFC-side bootstrap (pip-installs the bridge)
+├── addon.py             # PFC-side first-install bootstrap (pip-installs the bridge)
 └── tests/               # MCP/tool contract tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,14 @@ Restart your AI agent (Claude Code, Codex CLI, Gemini CLI, etc.) and ask it to c
 
 ## Daily Startup
 
-Once first-time setup is done, each new PFC session only needs the bridge re-started — paste [`addon.py`](addon.py) into PFC's IPython console and you're back online. The MCP client config persists.
+Once first-time setup is done, each new PFC session only needs the bridge re-started — run this in PFC's IPython console and you're back online:
+
+```python
+import itasca_mcp_bridge
+itasca_mcp_bridge.start()
+```
+
+`start()` checks PyPI for a newer bridge release and self-upgrades before starting (best-effort: offline machines just start the installed version; pass `auto_upgrade=False` to pin). The MCP client config persists.
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,7 +72,14 @@ https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bo
 
 ## 日常启动
 
-完成首次配置之后，每次启动 PFC 只需要把 [`addon.py`](addon.py) 粘进 IPython 控制台运行，bridge 起来后就可以继续用了。MCP 客户端配置会一直保留。
+完成首次配置之后，每次启动 PFC 只需要在 IPython 控制台里运行下面两行，bridge 起来后就可以继续用了：
+
+```python
+import itasca_mcp_bridge
+itasca_mcp_bridge.start()
+```
+
+`start()` 会先检查 PyPI 上是否有新版 bridge，有则自动升级再启动（尽力而为：离线时直接启动已安装版本；传 `auto_upgrade=False` 可锁定版本）。MCP 客户端配置会一直保留。
 
 ## 功能亮点
 

--- a/WARP.md
+++ b/WARP.md
@@ -11,7 +11,7 @@ This repository has two runtime contexts:
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
 
-End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `addon.py`; the submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
+End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
 ## Core Architecture
 
@@ -27,7 +27,7 @@ End users install the bridge from PyPI (`pip install itasca-mcp-bridge`) via `ad
 - Runs in PFC GUI process
 - Owns thread-safe interaction with ITASCA SDK
 - Handles long-running tasks and diagnostics
-- Started inside PFC GUI via `addon.py` (which pip-installs `itasca-mcp-bridge` and calls `itasca_mcp_bridge.start()`)
+- Started inside PFC GUI via `itasca_mcp_bridge.start()`, which self-upgrades from PyPI first (best-effort); `addon.py` remains the manual first-install bootstrap
 
 ## Repository Layout
 
@@ -40,7 +40,7 @@ pfc-mcp/
 │   ├── formatting.py    # shared response formatting
 │   └── server.py        # MCP server entrypoint
 ├── itasca-mcp-bridge/   # submodule → github.com/yusong652/itasca-mcp-bridge
-├── addon.py             # PFC-side bootstrap (pip-installs the bridge)
+├── addon.py             # PFC-side first-install bootstrap (pip-installs the bridge)
 └── tests/               # MCP/tool contract tests
 ```
 

--- a/addon.py
+++ b/addon.py
@@ -205,6 +205,11 @@ def main():
     print("Installed websockets:", getattr(websockets, "__version__", "unknown"))
     print("Starting bridge on port {} ...".format(PORT))
 
+    # This script already handled install/upgrade above; tell start() to skip
+    # its own update check. The env var works across bridge versions, unlike
+    # the start(auto_upgrade=...) kwarg which older bridges don't accept.
+    os.environ["ITASCA_MCP_BRIDGE_AUTO_UPGRADE"] = "0"
+
     itasca_mcp_bridge.start(port=PORT)
 
 

--- a/docs/agentic/pfc-mcp-bootstrap.md
+++ b/docs/agentic/pfc-mcp-bootstrap.md
@@ -6,7 +6,7 @@ Use this guide when an agent needs to set up `pfc-mcp` execution end-to-end on a
 
 1. MCP client is configured to run `pfc-mcp`.
 2. `itasca-mcp-bridge` is installed in the correct PFC embedded Python environment.
-3. Bridge is started in PFC GUI (via `addon.py` or `itasca_mcp_bridge.start()`).
+3. Bridge is started in PFC GUI via `itasca_mcp_bridge.start()`.
 4. MCP execution tools are verified with `pfc_execute_code`.
 
 ## Agent Execution Rules
@@ -151,8 +151,8 @@ Install/upgrade:
 ```
 
 If that index is unreachable (PyPI blocked behind a regional network or
-corporate proxy), retry via the Tsinghua mirror -- the same fallback
-`addon.py` performs automatically:
+corporate proxy), retry via the Tsinghua mirror -- the same fallback the
+bridge's own self-upgrade performs automatically:
 
 ```powershell
 & "{pfc_python}" -m pip install --user --upgrade --index-url https://pypi.tuna.tsinghua.edu.cn/simple/ --trusted-host pypi.tuna.tsinghua.edu.cn itasca-mcp-bridge
@@ -197,38 +197,26 @@ powershell -NoProfile -Command "$procs=Get-CimInstance Win32_Process | Where-Obj
 
 If both `pfc2d*_gui.exe` and `pfc3d*_gui.exe` are available and user did not specify, prefer 3D (`pfc3d`) by default.
 
-Download `addon.py` to a local path the user can easily find (e.g. Desktop or working directory):
-
-```bash
-curl -o addon.py https://raw.githubusercontent.com/yusong652/pfc-mcp/main/addon.py
-```
-
-PowerShell form (recommended on Windows shells):
-
-```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/yusong652/pfc-mcp/main/addon.py" -OutFile "addon.py"
-```
-
-Tell the user where the file was saved.
-
 [USER ACTION REQUIRED]
 
-Use one of these two options to start the bridge, then restart the client session before Step 5.
-
-**Option A (recommended):** Open the downloaded `addon.py` in PFC GUI and execute it, or copy its contents into the PFC IPython console and run them. The script handles install, upgrade, and startup automatically.
-
-**Option B (manual):** In PFC GUI Python console:
+Ask the user to run this in the PFC GUI IPython console (the package was
+already installed in Step 3), then restart the client session before Step 5:
 
 ```python
 import itasca_mcp_bridge
 itasca_mcp_bridge.start()
 ```
 
+On every start the bridge checks PyPI for a newer release and self-upgrades
+before starting, so this same two-liner keeps the install current in later
+sessions. The check is best-effort: offline machines just start the
+installed version.
+
 Expected output includes:
 
-- `PFC Bridge Server`
+- `Itasca MCP Bridge Server`
 - `ws://localhost:9001`
-- `Bridge started in non-blocking mode`
+- `Task loop running via Qt timer`
 
 ## Step 5 - Verify from MCP Client
 
@@ -259,7 +247,12 @@ Success example (shape may vary by client):
 - `Connection refused`:
   - Bridge not running in PFC GUI, or port `9001` not available.
 - `No module named itasca_mcp_bridge`:
-  - Bridge package not installed in PFC embedded Python.
+  - Bridge package not installed in PFC embedded Python (or installed into the
+    wrong interpreter). Re-run Step 3 against the resolved `pfc_python`.
+  - One-shot fallback: paste the contents of
+    <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/addon.py> into the
+    PFC IPython console -- it installs (with mirror fallback) and starts the
+    bridge in one go.
 - `No module named websockets`:
   - Install `websockets==9.1` for PFC 6/7 or `websockets==16.0` for PFC 9 in the embedded Python environment.
 - `status remains pending / plot diagnostic timeout during solve`:


### PR DESCRIPTION
## Why

itasca-mcp-bridge 0.2.0/0.2.1 shipped a self-upgrading start() (plus post-upgrade whats-new announcements), so daily startup and the agentic bootstrap no longer need to route through addon.py.

## What

- READMEs (EN/zh): Daily Startup is now the plain two-liner with a note on self-upgrade behaviour and pinning. addon.py stays as the manual first-install path.
- Agentic bootstrap guide: Step 4 drops the addon.py download entirely (the agent already pip-installs via the embedded interpreter in Step 3); user action shrinks to the two-liner. Fixes the stale expected-output sample. addon.py remains in troubleshooting as the one-shot recovery path.
- addon.py: sets ITASCA_MCP_BRIDGE_AUTO_UPGRADE=0 before start() so the upgrade it just performed is not re-checked (env var works across bridge versions, unlike the auto_upgrade kwarg).
- CLAUDE/AGENTS/GEMINI/WARP: addon.py role rewording (first-install bootstrap; start() self-upgrades).
- Submodule pin: c41f3a9 (v0.1.6) -> 2beba71 (v0.2.1).

Mirrors flac-mcp PR #62 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)