### PR TITLE
docs: trim self-upgrade caveats from daily-start note

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import itasca_mcp_bridge
 itasca_mcp_bridge.start()
 ```
 
-`start()` checks PyPI for a newer bridge release and self-upgrades before starting (best-effort: offline machines just start the installed version; pass `auto_upgrade=False` to pin). The MCP client config persists.
+`start()` checks PyPI for a newer bridge release and self-upgrades before starting. The MCP client config persists.
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ import itasca_mcp_bridge
 itasca_mcp_bridge.start()
 ```
 
-`start()` 会先检查 PyPI 上是否有新版 bridge，有则自动升级再启动（尽力而为：离线时直接启动已安装版本；传 `auto_upgrade=False` 可锁定版本）。MCP 客户端配置会一直保留。
+`start()` 会先检查 PyPI 上是否有新版 bridge，有则自动升级再启动。MCP 客户端配置会一直保留。
 
 ## 功能亮点
 


### PR DESCRIPTION
Drops the parenthetical "(best-effort: offline machines just start the installed version; pass `auto_upgrade=False` to pin)" from the daily-start note in both READMEs.

Offline machines are not a real bridge scenario — without an online LLM inference service there is nothing for the bridge to serve. The failure-fallback and `auto_upgrade` pin semantics stay documented in the itasca-mcp-bridge README, where `start()`'s interface contract belongs.

Companion PR in flac-mcp applies the same trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)