### PR TITLE
fix(docker): pass explicit bridge mode instead of mode=auto

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,13 +18,20 @@ set -e
 # not in the bridge install dir.
 cd /workspace 2>/dev/null || true
 
-# Bootstrap that starts the bridge inside PFC's embedded Python. mode=auto
-# attaches a QTimer pump if a Qt app is running (GUI mode), otherwise falls
-# back to a blocking poll (console mode).
+# Bootstrap that starts the bridge inside PFC's embedded Python. The pump
+# mode must be explicit: pfc3d9_console has a live QCoreApplication but
+# never runs its event loop, so mode=auto (bridge >= 0.1.4, PySide6 probe)
+# would attach a QTimer that never fires and return from start(), parking
+# the main thread at the console prompt -- which starves every bridge
+# thread and leaves ws://:9001 accepting TCP but never answering.
+BRIDGE_MODE=console
+if [ "${PFC_GUI:-}" = "1" ]; then
+    BRIDGE_MODE=gui
+fi
 BOOTSTRAP=/tmp/itasca_mcp_bridge_start.py
-cat > "$BOOTSTRAP" << 'PYEOF'
+cat > "$BOOTSTRAP" << PYEOF
 import itasca_mcp_bridge
-itasca_mcp_bridge.start(host="0.0.0.0", port=9001, mode="auto")
+itasca_mcp_bridge.start(host="0.0.0.0", port=9001, mode="${BRIDGE_MODE}")
 PYEOF
 
 # ── GUI mode ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Headless console containers came up with a dead bridge: TCP on :9001 accepted (docker-proxy) but the WebSocket handshake never completed, and `bridge.log` went silent right after `Qt binding detected: PySide6`.

Root cause: itasca-mcp-bridge >= 0.1.4 probes PySide6 for the Qt task pump (added to fix the pump on PFC 9.7 GUI). `pfc3d9_console` satisfies both `mode=auto` conditions — PySide6 imports **and** a `QCoreApplication` instance exists — but never runs its event loop. The bridge therefore attaches a QTimer that never fires and `start()` returns, parking PFC's main thread at the console prompt, which starves the WebSocket server thread and the task pump alike. Bridge <= 0.1.3 only probed PySide2, failed the probe in this image, and fell back to the blocking poll — which is why the container used to work.

The entrypoint already knows which mode it is launching, so it now tells the bridge instead of letting it guess:

- default (headless): `mode="console"` → blocking poll on the main thread
- `PFC_GUI=1`: `mode="gui"` → QTimer pump on the real Qt event loop

## Verification

In the dev container (PFC 9.7 beta console, bridge 0.2.1):

- before: `Task loop running via Qt timer` printed, then every bridge request timed out (raw WS handshake included)
- after: `Task loop running via blocking poll` printed; `pfc_execute_code`, `pfc_execute_task`, mid-run status polling, cycle-gap interleaving, and `pfc_interrupt_task` all verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)