### PR TITLE
docs(tools): version-gate the program-call warning

### DIFF
--- a/src/pfc_mcp/tools/execute_code.py
+++ b/src/pfc_mcp/tools/execute_code.py
@@ -55,14 +55,21 @@ def register(mcp: FastMCP) -> None:
         - Create and export plots: itasca.command('plot ...')
         - Development and REPL-style testing
 
-        Do NOT invoke `program call '<file>.p3dat'` (or .p2dat / .dat)
-        through this tool. PFC's command-script interpreter blocks the
-        bridge for the script's entire duration with no cycle-gap
-        interleaving, so any long `model cycle` inside the file leaves
-        the bridge unreachable until PFC is stopped manually. If the
-        user asks to run a .dat / .p3dat / .p2dat file, read the file
-        and translate its commands into a sequence of
-        `itasca.command(...)` calls in Python instead.
+        `program call '<file>.p3dat'` (or .p2dat / .dat) through this
+        tool is PFC-version-gated. On PFC 6/7 the command-script
+        interpreter blocks the bridge for the script's entire
+        duration with no cycle-gap interleaving — any long
+        `model cycle` inside the file leaves the bridge unreachable
+        until PFC is stopped manually. Never emit it there, and
+        treat unknown or unverified versions (including PFC
+        9.0-9.6) the same way. On PFC 9.7+ the bridge stays fully
+        responsive during a `program call` (verified on 9.7: status
+        polling, cycle-gap interleaving, and interrupt all work
+        mid-call). Even where it is safe, prefer reading the file
+        and translating its commands into a sequence of
+        `itasca.command(...)` calls in Python — that keeps
+        per-command output, error locality, and mid-script control
+        that a single opaque `program call` cannot give.
 
         This is a synchronous tool: the request blocks until the code
         finishes or hits the timeout (default 10s, max 600s). Output

--- a/src/pfc_mcp/tools/execute_task.py
+++ b/src/pfc_mcp/tools/execute_task.py
@@ -39,14 +39,21 @@ def register(mcp: FastMCP) -> None:
         and interleaved with Python prints in the task log, visible
         through pfc_check_task_status.
 
-        Do NOT have the script invoke `program call '<file>.p3dat'`
-        (or .p2dat / .dat). PFC's command-script interpreter blocks
-        the bridge for the script's entire duration with no cycle-gap
-        interleaving, leaving the bridge unreachable until PFC is
-        stopped manually. If the user asks to run a .dat / .p3dat /
-        .p2dat file, read the file and translate its commands into a
-        sequence of `itasca.command(...)` calls in the Python script
-        instead.
+        Having the script invoke `program call '<file>.p3dat'` (or
+        .p2dat / .dat) is PFC-version-gated. On PFC 6/7 the
+        command-script interpreter blocks the bridge for the
+        script's entire duration with no cycle-gap interleaving,
+        leaving the bridge unreachable until PFC is stopped
+        manually. Never emit it there, and treat unknown or
+        unverified versions (including PFC 9.0-9.6) the same way.
+        On PFC 9.7+ the bridge stays fully responsive during a
+        `program call` (verified on 9.7: status polling, cycle-gap
+        interleaving, and interrupt all work mid-call). Even where
+        it is safe, prefer reading the file and translating its
+        commands into a sequence of `itasca.command(...)` calls in
+        the Python script — that keeps per-command output, error
+        locality, and mid-script control that a single opaque
+        `program call` cannot give.
 
         This is the async / background execution path: pollable via
         pfc_check_task_status, cancellable via pfc_interrupt_task.


### PR DESCRIPTION
## Summary

The execute_code / execute_task docstrings carried a blanket "do NOT `program call`" warning, written from a PFC 7.0 test (98256aa) where a long `.p3dat` froze the entire bridge. Re-testing on PFC 9.7 (beta, console, bridge 0.2.1) shows the behaviour is host-version dependent, not architectural: during `program call` cycling the bridge stays fully live — status polling, cycle-gap `execute_code` interleaving, and `pfc_interrupt_task` (InterruptedError propagates through the call) all verified working.

Both warnings are now version-gated:

- PFC 6/7: still forbidden — verified blocking, bridge unreachable until PFC is stopped manually
- PFC 9.0–9.6: untested, treat as blocking
- PFC 9.7+: verified safe, but translating the file into `itasca.command(...)` calls remains the preferred path — per-command output, error locality, and mid-script control beat a one-line opaque replay regardless of version

## Verification

- `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed
- ruff check / format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)