### PR TITLE
chore: bump itasca-mcp-bridge to v0.3.0 + drop pfc_task mock alias

### DIFF
--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -28,7 +28,7 @@ async def _mock_bridge_handler(websocket):
         req_id = req.get("request_id", "unknown")
         msg_type = req.get("type", "execute_task")
 
-        if msg_type in ("execute_task", "pfc_task"):
+        if msg_type == "execute_task":
             task_id = req.get("task_id", "000000")
             TASK_STORE[task_id] = {
                 "status": "running",


### PR DESCRIPTION
Catches pfc-mcp up to bridge **v0.3.0** (`99902d4`):
- Bump the bridge submodule pin (picks up the L2 logging-lock deadlock fix and the legacy PFC-naming removal).
- Drop the now-removed `pfc_task` alias from the contract-test mock bridge — the client only sends `execute_task`.

Submodule bump is contributor-facing only; runtime users self-upgrade the bridge from PyPI (0.3.0 already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)