### PR TITLE
refactor: rename pfc_* tools to itasca_* and neutralize PFC self-identity

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-PFC Bridge bootstrap script.
+Itasca Bridge bootstrap script.
 
-Use it inside PFC in either of these ways:
-1. Copy the file contents into the PFC IPython console and run them
-2. Or save/download this file and execute it in PFC GUI
+Use it inside the Itasca engine (PFC/FLAC/3DEC/…) in either of these ways:
+1. Copy the file contents into the engine's IPython console and run them
+2. Or save/download this file and execute it in the engine GUI
 
 What it does:
 1. Detects the currently installed `itasca-mcp-bridge`, if any
@@ -71,7 +71,7 @@ def _resolve_pip_main():
     There is no single stable location. `pip.main` exists in pip <= 9
     (what PFC 6.0 ships), was removed in pip 10.0, and was later restored
     as an internal-only shim; `pip._internal.main` covers pip 10 .. 19.2;
-    `pip._internal.cli.main.main` covers pip >= 19.3. The embedded PFC
+    `pip._internal.cli.main.main` covers pip >= 19.3. The embedded engine
     Python may carry any pip version, so probe each location in turn
     rather than guessing from the pip or Python version.
     """
@@ -100,12 +100,12 @@ def _run_pip(args):
     pip_main = _resolve_pip_main()
     if pip_main is None:
         raise RuntimeError(
-            "Could not locate pip's Python entry point in this PFC interpreter. "
+            "Could not locate pip's Python entry point in this engine interpreter. "
             "Install the bridge manually, then re-run this script:\n"
             "    python -m pip install --user itasca-mcp-bridge"
         )
 
-    # PFC runs pip inside an IPython host; temporarily suppress logging
+    # The engine runs pip inside an IPython host; temporarily suppress logging
     # handler tracebacks that don't reflect actual installation failures.
     previous_raise_exceptions = logging.raiseExceptions
     logging.raiseExceptions = False
@@ -118,7 +118,7 @@ def _run_pip(args):
 def _install_bridge():
     os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
-    override = os.environ.get("PFC_MCP_PIP_INDEX_URL")
+    override = os.environ.get("ITASCA_MCP_PIP_INDEX_URL")
     if override:
         indexes = [(override, ())]
     else:
@@ -178,7 +178,7 @@ def _should_install(current_version):
 
 def main():
     print("=" * 60)
-    print("PFC MCP Bridge Bootstrap")
+    print("Itasca MCP Bridge Bootstrap")
     print("=" * 60)
     print("Python:", sys.version.split()[0])
 

--- a/src/itasca_mcp/__init__.py
+++ b/src/itasca_mcp/__init__.py
@@ -1,3 +1,3 @@
-"""PFC MCP Server - ITASCA PFC discrete element simulation tools via MCP."""
+"""Itasca MCP Server - ITASCA simulation tools (PFC, FLAC, 3DEC, MPoint, MassFlow) via MCP."""
 
 __version__ = "0.5.0"

--- a/src/itasca_mcp/bridge/client.py
+++ b/src/itasca_mcp/bridge/client.py
@@ -1,4 +1,4 @@
-"""WebSocket client for communicating with the PFC bridge server."""
+"""WebSocket client for communicating with the Itasca bridge server."""
 
 import asyncio
 import json
@@ -13,7 +13,7 @@ from itasca_mcp.config import get_bridge_config
 logger = logging.getLogger("itasca-mcp.bridge")
 
 
-class PFCBridgeClient:
+class ItascaBridgeClient:
     """Async request/response client for itasca-mcp-bridge WebSocket protocol."""
 
     def __init__(
@@ -265,17 +265,17 @@ class PFCBridgeClient:
         return data.get("working_directory")
 
 
-_client: PFCBridgeClient | None = None
+_client: ItascaBridgeClient | None = None
 _client_lock = asyncio.Lock()
 
 
-async def get_bridge_client() -> PFCBridgeClient:
+async def get_bridge_client() -> ItascaBridgeClient:
     """Return the global bridge client instance with lazy initialization."""
     global _client
     async with _client_lock:
         if _client is None:
             config = get_bridge_config()
-            _client = PFCBridgeClient(
+            _client = ItascaBridgeClient(
                 url=config.url,
                 reconnect_interval_s=config.reconnect_interval_s,
                 max_retries=config.max_retries,

--- a/src/itasca_mcp/config.py
+++ b/src/itasca_mcp/config.py
@@ -1,4 +1,4 @@
-"""Runtime configuration for PFC MCP server."""
+"""Runtime configuration for Itasca MCP server."""
 
 import os
 from dataclasses import dataclass
@@ -43,9 +43,9 @@ class BridgeConfig:
 def get_bridge_config() -> BridgeConfig:
     """Load bridge config from environment variables."""
     return BridgeConfig(
-        url=os.getenv("PFC_MCP_BRIDGE_URL", "ws://localhost:9001"),
-        reconnect_interval_s=_env_float("PFC_MCP_RECONNECT_INTERVAL_S", 0.5),
-        max_retries=max(0, _env_int("PFC_MCP_MAX_RETRIES", 2)),
-        request_timeout_s=max(1.0, _env_float("PFC_MCP_REQUEST_TIMEOUT_S", 10.0)),
-        auto_reconnect=_env_bool("PFC_MCP_AUTO_RECONNECT", True),
+        url=os.getenv("ITASCA_MCP_BRIDGE_URL", "ws://localhost:9001"),
+        reconnect_interval_s=_env_float("ITASCA_MCP_RECONNECT_INTERVAL_S", 0.5),
+        max_retries=max(0, _env_int("ITASCA_MCP_MAX_RETRIES", 2)),
+        request_timeout_s=max(1.0, _env_float("ITASCA_MCP_REQUEST_TIMEOUT_S", 10.0)),
+        auto_reconnect=_env_bool("ITASCA_MCP_AUTO_RECONNECT", True),
     )

--- a/src/itasca_mcp/formatting.py
+++ b/src/itasca_mcp/formatting.py
@@ -109,11 +109,11 @@ def build_bridge_error(exc: Exception, *, task_id: str | None = None) -> dict[st
     details: dict[str, Any] = {
         "bridge_url": cfg.url,
         "reason": reason,
-        "action": "start itasca-mcp-bridge in PFC GUI, then retry",
+        "action": "start itasca-mcp-bridge in the Itasca engine GUI, then retry",
     }
     if task_id:
         details["task_id"] = task_id
-    return build_error("bridge_unavailable", "PFC bridge unavailable", details)
+    return build_error("bridge_unavailable", "Itasca bridge unavailable", details)
 
 
 def build_operation_error(

--- a/src/itasca_mcp/knowledge/__init__.py
+++ b/src/itasca_mcp/knowledge/__init__.py
@@ -1,4 +1,4 @@
-"""PFC documentation system.
+"""Itasca documentation system.
 
 Provides command, Python API, and reference documentation loading,
 formatting, and BM25-based search capabilities.

--- a/src/itasca_mcp/knowledge/adapters/__init__.py
+++ b/src/itasca_mcp/knowledge/adapters/__init__.py
@@ -1,4 +1,4 @@
-"""Document adapters for PFC search system.
+"""Document adapters for Itasca documentation search system.
 
 This package provides adapters to convert raw documentation data from loaders
 into unified SearchDocument models. Each adapter handles a specific document

--- a/src/itasca_mcp/knowledge/adapters/api_adapter.py
+++ b/src/itasca_mcp/knowledge/adapters/api_adapter.py
@@ -1,4 +1,4 @@
-"""Python API document adapter for PFC search system.
+"""Python API document adapter for Itasca documentation search system.
 
 This module converts Python SDK API documentation from the DocumentationLoader
 format into unified SearchDocument models for search.

--- a/src/itasca_mcp/knowledge/adapters/command_adapter.py
+++ b/src/itasca_mcp/knowledge/adapters/command_adapter.py
@@ -1,9 +1,9 @@
-"""Command document adapter for PFC search system.
+"""Command document adapter for Itasca documentation search system.
 
-This module converts PFC command documentation from the CommandLoader format
+This module converts Itasca command documentation from the CommandLoader format
 into unified SearchDocument models for search.
 
-Note: Model properties are handled separately via pfc_browse_reference tool.
+Note: Model properties are handled separately via itasca_browse_reference tool.
 """
 
 from itasca_mcp.knowledge.commands.loader import CommandLoader
@@ -11,14 +11,14 @@ from itasca_mcp.knowledge.models import DocumentType, SearchDocument
 
 
 class CommandDocumentAdapter:
-    """Adapter for PFC command documentation.
+    """Adapter for Itasca command documentation.
 
     Converts command data from CommandLoader into unified SearchDocument format.
     This enables:
     - Consistent interface for search engines
     - Separation of data loading and search logic
 
-    Note: For contact model properties, use pfc_browse_reference tool directly.
+    Note: For contact model properties, use itasca_browse_reference tool directly.
 
     Usage:
         >>> documents = CommandDocumentAdapter.load_commands()
@@ -28,7 +28,7 @@ class CommandDocumentAdapter:
 
     @staticmethod
     def load_commands(version: str = CommandLoader.DEFAULT_VERSION, *, software: str) -> list[SearchDocument]:
-        """Load all PFC command documents.
+        """Load all Itasca command documents.
 
         Returns:
             List of SearchDocument instances for all commands

--- a/src/itasca_mcp/knowledge/commands/__init__.py
+++ b/src/itasca_mcp/knowledge/commands/__init__.py
@@ -1,7 +1,7 @@
-"""PFC Command Documentation System.
+"""Itasca Command Documentation System.
 
 This module provides command documentation loading and formatting capabilities
-for PFC commands.
+for Itasca commands.
 
 Components:
     - CommandLoader: Load command docs from JSON files

--- a/src/itasca_mcp/knowledge/commands/formatter.py
+++ b/src/itasca_mcp/knowledge/commands/formatter.py
@@ -1,4 +1,4 @@
-"""Markdown formatter for PFC command documentation.
+"""Markdown formatter for Itasca command documentation.
 
 This module formats command documentation and model properties as markdown
 for LLM consumption.
@@ -16,7 +16,7 @@ from itasca_mcp.knowledge.commands.models import CommandSearchResult, DocumentTy
 
 
 class CommandFormatter:
-    """Format PFC command documentation as markdown.
+    """Format Itasca command documentation as markdown.
 
     This class provides static methods for formatting commands and model
     properties in a consistent, LLM-friendly markdown format.
@@ -27,7 +27,7 @@ class CommandFormatter:
         """Prepend error message to fallback content.
 
         Used when a requested path doesn't exist but we can show the parent level.
-        Format matches pfc_browse_python_api for consistency.
+        Format matches itasca_browse_python_api for consistency.
 
         Args:
             error_msg: Error message describing what wasn't found
@@ -52,7 +52,7 @@ class CommandFormatter:
 
         total_commands = sum(len(cat_data.get("commands", [])) for cat_data in categories.values())
 
-        parts.append("## PFC Command Documentation")
+        parts.append("## Itasca Command Documentation")
         parts.append("")
         parts.append(f"Total: {len(categories)} categories, {total_commands} commands")
         parts.append("")
@@ -288,7 +288,7 @@ class CommandFormatter:
         Returns:
             Formatted markdown string with suggestions
         """
-        return f"""No PFC command documentation found for '{query}'.
+        return f"""No Itasca command documentation found for '{query}'.
 
 Suggestions:
 - Try simpler keywords (e.g., "ball create" instead of "how to create a ball")

--- a/src/itasca_mcp/knowledge/commands/loader.py
+++ b/src/itasca_mcp/knowledge/commands/loader.py
@@ -1,4 +1,4 @@
-"""Data loading layer for PFC command documentation.
+"""Data loading layer for Itasca command documentation.
 
 This module loads command documentation from JSON files with caching
 for performance.
@@ -18,7 +18,7 @@ from itasca_mcp.knowledge.config import command_index_path, resolve
 
 
 class CommandLoader:
-    """Loads and caches PFC command documentation.
+    """Loads and caches Itasca command documentation.
 
     This class provides static methods for loading command docs.
     All methods use caching to avoid repeated file I/O.
@@ -108,7 +108,7 @@ class CommandLoader:
         Args:
             category: Command category (e.g., "ball", "contact", "model")
             command_name: Command name (e.g., "create", "property", "cycle")
-            version: PFC version string to resolve (defaults to 7.0)
+            version: engine version string to resolve (defaults to 7.0)
 
         Returns:
             Command documentation dict with fields:

--- a/src/itasca_mcp/knowledge/commands/models.py
+++ b/src/itasca_mcp/knowledge/commands/models.py
@@ -1,4 +1,4 @@
-"""Data models for PFC command documentation system.
+"""Data models for Itasca command documentation system.
 
 DEPRECATED: This module is kept for backward compatibility only.
 New code should use itasca_mcp.knowledge.search.legacy_models instead.

--- a/src/itasca_mcp/knowledge/models/__init__.py
+++ b/src/itasca_mcp/knowledge/models/__init__.py
@@ -1,4 +1,4 @@
-"""Shared models for PFC search system.
+"""Shared models for Itasca documentation search system.
 
 This package provides unified data models for the search infrastructure,
 enabling consistent handling of different document types (commands, APIs, etc.).

--- a/src/itasca_mcp/knowledge/models/document.py
+++ b/src/itasca_mcp/knowledge/models/document.py
@@ -1,8 +1,8 @@
-"""Unified document model for PFC search system.
+"""Unified document model for Itasca documentation search system.
 
 This module provides a unified representation of different document types
 (commands, model properties, Python API) to enable consistent search operations
-across the entire PFC documentation system.
+across the entire Itasca documentation system.
 """
 
 from dataclasses import dataclass, field
@@ -13,8 +13,8 @@ from typing import Any
 class DocumentType(Enum):
     """Document type enumeration.
 
-    Defines the types of searchable documents in the PFC system:
-    - COMMAND: PFC command documentation (e.g., "ball create", "contact property")
+    Defines the types of searchable documents in the Itasca system:
+    - COMMAND: Itasca command documentation (e.g., "ball create", "contact property")
     - MODEL_PROPERTY: Contact model property documentation (e.g., "linear", "hertz")
     - PYTHON_API: Python SDK API documentation (e.g., "itasca.ball.create")
 

--- a/src/itasca_mcp/knowledge/models/search_result.py
+++ b/src/itasca_mcp/knowledge/models/search_result.py
@@ -1,4 +1,4 @@
-"""Search result model for PFC search system.
+"""Search result model for Itasca documentation search system.
 
 This module defines the structure of search results returned by search engines,
 including relevance scores, ranking information, and match details for

--- a/src/itasca_mcp/knowledge/python_api/__init__.py
+++ b/src/itasca_mcp/knowledge/python_api/__init__.py
@@ -1,6 +1,6 @@
-"""PFC SDK Documentation System - Direct Access Interface.
+"""Itasca SDK Documentation System - Direct Access Interface.
 
-This module provides direct access to the PFC Python SDK documentation
+This module provides direct access to the Itasca Python SDK documentation
 components without wrapper layers.
 
 Usage:

--- a/src/itasca_mcp/knowledge/python_api/formatter.py
+++ b/src/itasca_mcp/knowledge/python_api/formatter.py
@@ -114,7 +114,7 @@ class APIDocFormatter:
 
             object_lines.append(f"- {obj_path}: {desc}")
 
-        parts.append("## PFC Python SDK Documentation")
+        parts.append("## Itasca Python SDK Documentation")
         parts.append("")
         parts.append(f"Modules ({len(modules)}):")
         parts.append("\n".join(module_lines))
@@ -527,7 +527,7 @@ class APIDocFormatter:
         Example output:
             **Python SDK**: Not available for this operation
 
-            **Next Step**: Use pfc_query_command tool to search for PFC commands instead
+            **Next Step**: Use itasca_query_command tool to search for Itasca commands instead
         """
         hint_text = f"\nNote: {hints[0]}" if hints else ""
 

--- a/src/itasca_mcp/knowledge/python_api/loader.py
+++ b/src/itasca_mcp/knowledge/python_api/loader.py
@@ -1,4 +1,4 @@
-"""Data loading layer for PFC SDK documentation.
+"""Data loading layer for Itasca SDK documentation.
 
 This module is responsible for loading documentation data from JSON files
 and providing cached access to avoid repeated I/O operations.

--- a/src/itasca_mcp/knowledge/python_api/models.py
+++ b/src/itasca_mcp/knowledge/python_api/models.py
@@ -1,4 +1,4 @@
-"""Data models for PFC SDK documentation system.
+"""Data models for Itasca SDK documentation system.
 
 This module defines the core data structures used throughout the SDK
 documentation system, providing type-safe contracts for search results
@@ -50,7 +50,7 @@ class SearchResult:
 class APIDocumentation:
     """Structured API documentation.
 
-    This model represents the complete documentation for a PFC Python SDK API,
+    This model represents the complete documentation for a Itasca Python SDK API,
     parsed from JSON documentation files.
 
     Attributes:
@@ -61,7 +61,7 @@ class APIDocumentation:
         returns: Return value information (type and description)
         examples: Usage examples with code snippets
         limitations: Known limitations (optional)
-        fallback_commands: Alternative PFC commands to use instead (optional)
+        fallback_commands: Alternative Itasca commands to use instead (optional)
         best_practices: Recommended usage patterns (optional)
         notes: Additional notes (optional)
         see_also: Related APIs (optional)

--- a/src/itasca_mcp/knowledge/python_api/types/__init__.py
+++ b/src/itasca_mcp/knowledge/python_api/types/__init__.py
@@ -1,4 +1,4 @@
-"""Type handling for PFC SDK documentation.
+"""Type handling for Itasca SDK documentation.
 
 This package provides specialized handling for PFC type systems,
 including Contact type aliasing and class-to-module mappings.

--- a/src/itasca_mcp/knowledge/python_api/types/mappings.py
+++ b/src/itasca_mcp/knowledge/python_api/types/mappings.py
@@ -1,11 +1,11 @@
-"""Type system mappings for PFC SDK.
+"""Type system mappings for Itasca SDK.
 
 This module defines mappings between PFC object classes and their
 parent modules, used for generating official API paths.
 """
 
 # Object class to module mapping
-# Maps class names to their parent module names in PFC Python SDK
+# Maps class names to their parent module names in Itasca Python SDK
 # Format: "ClassName" -> "module_name" or "module.submodule"
 # Official API path structure: itasca.{module}.{Class}.{method}
 #

--- a/src/itasca_mcp/knowledge/query/__init__.py
+++ b/src/itasca_mcp/knowledge/query/__init__.py
@@ -1,4 +1,4 @@
-"""High-level query interfaces for PFC documentation search.
+"""High-level query interfaces for Itasca documentation search.
 
 This module provides user-facing search APIs that abstract away
 the complexity of search engines and adapters.

--- a/src/itasca_mcp/knowledge/query/api_search.py
+++ b/src/itasca_mcp/knowledge/query/api_search.py
@@ -1,6 +1,6 @@
 """High-level Python API search interface.
 
-This module provides a simple, user-friendly API for searching PFC Python SDK
+This module provides a simple, user-friendly API for searching Itasca Python SDK
 documentation using BM25 algorithm with multi-field scoring.
 
 Features:
@@ -23,7 +23,7 @@ from itasca_mcp.knowledge.search.postprocessing import consolidate_component_api
 class APISearch:
     """Python SDK API search interface.
 
-    This class provides a high-level API for searching PFC Python SDK
+    This class provides a high-level API for searching Itasca Python SDK
     documentation using BM25 algorithm with multi-field scoring.
 
     Search Scope:

--- a/src/itasca_mcp/knowledge/query/command_search.py
+++ b/src/itasca_mcp/knowledge/query/command_search.py
@@ -1,7 +1,7 @@
 """High-level command search interface.
 
-This module provides a simple, user-friendly API for searching PFC commands.
-Model properties are handled separately via pfc_browse_reference tool.
+This module provides a simple, user-friendly API for searching Itasca commands.
+Model properties are handled separately via itasca_browse_reference tool.
 """
 
 from typing import Any
@@ -13,9 +13,9 @@ from itasca_mcp.knowledge.search.engines.bm25_engine import BM25SearchEngine
 
 
 class CommandSearch:
-    """Command search interface for PFC documentation.
+    """Command search interface for Itasca documentation.
 
-    This class provides a high-level API for searching PFC commands
+    This class provides a high-level API for searching Itasca commands
     using BM25 algorithm with multi-field scoring.
 
     Features:
@@ -24,7 +24,7 @@ class CommandSearch:
     - Support for filtering by category
     - BM25 with multi-field scoring (name=0.5, keywords=0.3, description=0.2)
 
-    Note: For contact model properties, use pfc_browse_reference tool directly.
+    Note: For contact model properties, use itasca_browse_reference tool directly.
 
     Usage:
         >>> # Basic search
@@ -68,7 +68,7 @@ class CommandSearch:
         *,
         software: str,
     ) -> list[SearchResult]:
-        """Search for PFC commands.
+        """Search for Itasca commands.
 
         Args:
             query: Search query string

--- a/src/itasca_mcp/knowledge/references/__init__.py
+++ b/src/itasca_mcp/knowledge/references/__init__.py
@@ -1,7 +1,7 @@
-"""PFC Reference Documentation System.
+"""Itasca Reference Documentation System.
 
 This module provides reference documentation loading and formatting capabilities
-for PFC reference items (contact models, range elements).
+for Itasca reference items (contact models, range elements).
 
 Components:
     - ReferenceLoader: Load reference docs from JSON files

--- a/src/itasca_mcp/knowledge/references/formatter.py
+++ b/src/itasca_mcp/knowledge/references/formatter.py
@@ -1,4 +1,4 @@
-"""Markdown formatter for PFC reference documentation.
+"""Markdown formatter for Itasca reference documentation.
 
 This module formats reference documentation (contact models, range elements)
 as markdown for LLM consumption.
@@ -13,7 +13,7 @@ from typing import Any
 
 
 class ReferenceFormatter:
-    """Format PFC reference documentation as markdown.
+    """Format Itasca reference documentation as markdown.
 
     This class provides static methods for formatting contact models and
     range elements in a consistent, LLM-friendly markdown format.
@@ -24,7 +24,7 @@ class ReferenceFormatter:
         """Prepend error message to fallback content.
 
         Used when a requested path doesn't exist but we can show the parent level.
-        Format matches pfc_browse_python_api for consistency.
+        Format matches itasca_browse_python_api for consistency.
 
         Args:
             error_msg: Error message describing what wasn't found
@@ -47,7 +47,7 @@ class ReferenceFormatter:
         """
         parts = []
 
-        parts.append("## PFC Reference Documentation")
+        parts.append("## Itasca Reference Documentation")
         parts.append("")
         parts.append(f"Total: {len(categories)} categories")
         parts.append("")
@@ -82,12 +82,12 @@ class ReferenceFormatter:
         if "models" in index:
             items = index["models"]
             item_type = "model"
-            title = "PFC Contact Models"
+            title = "Contact Models"
             intro = "Contact models define mechanical behavior at contact points."
         elif "elements" in index:
             items = index["elements"]
             item_type = "element"
-            title = "PFC Range Elements"
+            title = "Range Elements"
             intro = "Range elements filter objects by geometric regions, attributes, or logical conditions."
         else:
             return "Unknown reference index format."
@@ -147,7 +147,7 @@ class ReferenceFormatter:
         availability = doc.get("availability")
         if isinstance(availability, dict):
             avail_in = [v for v, ok in availability.items() if ok]
-            parts.append(f"*Available in PFC: {', '.join(avail_in) or 'none'}*")
+            parts.append(f"*Available in versions: {', '.join(avail_in) or 'none'}*")
         parts.append("")
 
         # Description
@@ -373,7 +373,7 @@ class ReferenceFormatter:
         parts.append(f"- **Inheritable**: {'Yes' if inheritable else 'No'}")
         since = target_property.get("since")
         if since:
-            parts.append(f"- **Since**: PFC {since}")
+            parts.append(f"- **Since**: version {since}")
         parts.append("")
 
         # Notes

--- a/src/itasca_mcp/knowledge/references/loader.py
+++ b/src/itasca_mcp/knowledge/references/loader.py
@@ -1,4 +1,4 @@
-"""Data loading layer for PFC reference documentation.
+"""Data loading layer for Itasca reference documentation.
 
 This module loads reference documentation from JSON files with caching
 for performance.
@@ -23,7 +23,7 @@ from itasca_mcp.knowledge.config import SUPPORTED_SOFTWARE, references_root, res
 
 
 class ReferenceLoader:
-    """Loads and caches PFC reference documentation.
+    """Loads and caches Itasca reference documentation.
 
     This class provides static methods for loading reference docs
     (contact models, range elements). All methods use caching
@@ -238,7 +238,7 @@ class ReferenceLoader:
 
         Args:
             category: Category name (e.g., "contact-models", "range-elements")
-            version: Optional PFC version (e.g. "6.0"). When given, items
+            version: Optional engine version (e.g. "6.0"). When given, items
                 whose ``availability`` map excludes that version are filtered
                 out. Items without an ``availability`` map are kept.
 

--- a/src/itasca_mcp/knowledge/search/__init__.py
+++ b/src/itasca_mcp/knowledge/search/__init__.py
@@ -1,4 +1,4 @@
-"""Search infrastructure for PFC documentation systems.
+"""Search infrastructure for Itasca documentation systems.
 
 Provides unified search components used by both command search
 and Python API search systems.

--- a/src/itasca_mcp/knowledge/search/engines/__init__.py
+++ b/src/itasca_mcp/knowledge/search/engines/__init__.py
@@ -1,4 +1,4 @@
-"""Search engine implementations for PFC documentation search.
+"""Search engine implementations for Itasca documentation search.
 
 This module provides high-level search engines that orchestrate
 indexing, scoring, and result formatting.

--- a/src/itasca_mcp/knowledge/search/engines/base_engine.py
+++ b/src/itasca_mcp/knowledge/search/engines/base_engine.py
@@ -1,4 +1,4 @@
-"""Base search engine interface for PFC documentation search.
+"""Base search engine interface for Itasca documentation search.
 
 This module defines the abstract interface that all search engines must implement,
 ensuring consistent behavior across different search algorithms.

--- a/src/itasca_mcp/knowledge/search/engines/bm25_engine.py
+++ b/src/itasca_mcp/knowledge/search/engines/bm25_engine.py
@@ -1,4 +1,4 @@
-"""BM25-based search engine for PFC documentation with multi-field support.
+"""BM25-based search engine for Itasca documentation with multi-field support.
 
 This module implements a complete search engine using BM25 algorithm with
 multi-field scoring, providing a high-level interface for document search.

--- a/src/itasca_mcp/knowledge/search/indexing/__init__.py
+++ b/src/itasca_mcp/knowledge/search/indexing/__init__.py
@@ -1,4 +1,4 @@
-"""Indexing utilities for PFC search system."""
+"""Indexing utilities for Itasca documentation search system."""
 
 from itasca_mcp.knowledge.search.indexing.bm25_indexer import BM25Indexer
 

--- a/src/itasca_mcp/knowledge/search/indexing/bm25_indexer.py
+++ b/src/itasca_mcp/knowledge/search/indexing/bm25_indexer.py
@@ -1,4 +1,4 @@
-"""BM25 inverted index builder for PFC search system with multi-field support.
+"""BM25 inverted index builder for Itasca documentation search system with multi-field support.
 
 This module implements BM25 indexing using only Python standard library
 (no NumPy dependency), optimized for technical documentation search.

--- a/src/itasca_mcp/knowledge/search/legacy_models.py
+++ b/src/itasca_mcp/knowledge/search/legacy_models.py
@@ -1,4 +1,4 @@
-"""Unified search result models for PFC documentation systems.
+"""Unified search result models for Itasca documentation systems.
 
 This module provides shared data structures for search results across
 command and Python API documentation systems.
@@ -12,8 +12,8 @@ from typing import Any
 class DocumentType(Enum):
     """Type of documentation being searched.
 
-    This enum unifies document types across all PFC documentation systems:
-    - COMMAND: PFC commands (e.g., "ball create", "contact property")
+    This enum unifies document types across all Itasca documentation systems:
+    - COMMAND: Itasca commands (e.g., "ball create", "contact property")
     - MODEL_PROPERTY: Contact model properties (e.g., "linear", "rrlinear")
     - API: Python SDK APIs (e.g., "itasca.ball.create", "Ball.pos")
     """
@@ -39,7 +39,7 @@ class SearchStrategy(Enum):
 
 @dataclass
 class SearchResult:
-    """Unified search result across all PFC documentation types.
+    """Unified search result across all Itasca documentation types.
 
     This model replaces both CommandSearchResult and the Python API SearchResult,
     providing a single unified interface for all search operations.

--- a/src/itasca_mcp/knowledge/search/preprocessing/__init__.py
+++ b/src/itasca_mcp/knowledge/search/preprocessing/__init__.py
@@ -1,4 +1,4 @@
-"""Text preprocessing utilities for PFC search system.
+"""Text preprocessing utilities for Itasca documentation search system.
 
 This package provides text processing utilities for search, including
 tokenization and stopword filtering optimized for technical documentation.

--- a/src/itasca_mcp/knowledge/search/preprocessing/stopwords.py
+++ b/src/itasca_mcp/knowledge/search/preprocessing/stopwords.py
@@ -1,4 +1,4 @@
-"""Stopwords list for PFC technical documentation.
+"""Stopwords list for Itasca technical documentation.
 
 This module provides a curated stopwords list optimized for scientific and
 technical documentation, preserving technical terms while filtering common
@@ -125,11 +125,11 @@ STOPWORDS = {
 }
 
 # Technical terms to PRESERVE (not stopwords)
-# These are often confused with stopwords but are meaningful in PFC context
+# These are often confused with stopwords but are meaningful in Itasca context
 TECHNICAL_PRESERVE = {
     "set",  # set property, set value
     "get",  # get value, get property
-    "command",  # PFC command
+    "command",  # Itasca command
     "generate",  # generate balls
     "create",  # create objects
     "delete",  # delete objects

--- a/src/itasca_mcp/knowledge/search/preprocessing/tokenizer.py
+++ b/src/itasca_mcp/knowledge/search/preprocessing/tokenizer.py
@@ -1,4 +1,4 @@
-"""Text tokenization for PFC search system.
+"""Text tokenization for Itasca documentation search system.
 
 This module provides tokenization functionality optimized for technical
 documentation, handling special cases like hyphenated terms, numbers,

--- a/src/itasca_mcp/knowledge/search/scoring/__init__.py
+++ b/src/itasca_mcp/knowledge/search/scoring/__init__.py
@@ -1,4 +1,4 @@
-"""Scoring algorithms for PFC search system."""
+"""Scoring algorithms for Itasca documentation search system."""
 
 from itasca_mcp.knowledge.search.scoring.bm25_scorer import BM25Scorer
 

--- a/src/itasca_mcp/knowledge/search/scoring/bm25_scorer.py
+++ b/src/itasca_mcp/knowledge/search/scoring/bm25_scorer.py
@@ -1,4 +1,4 @@
-"""BM25 scoring algorithm for PFC search system with multi-field support.
+"""BM25 scoring algorithm for Itasca documentation search system with multi-field support.
 
 This module implements BM25 ranking with multi-field scoring and weighted combination,
 using only Python standard library (no NumPy dependency).

--- a/src/itasca_mcp/server.py
+++ b/src/itasca_mcp/server.py
@@ -1,4 +1,4 @@
-"""PFC MCP Server - ITASCA PFC tools exposed over MCP."""
+"""Itasca MCP Server - ITASCA simulation tools exposed over MCP."""
 
 import argparse
 import asyncio
@@ -25,12 +25,13 @@ from itasca_mcp.tools import (
 )
 
 mcp = FastMCP(
-    "PFC MCP Server",
+    "Itasca MCP Server",
     instructions=(
-        "PFC (Particle Flow Code) MCP server. "
-        "Provides tools for browsing/searching PFC documentation "
-        "and for executing simulation tasks and managing runs "
-        "through an itasca-mcp-bridge WebSocket service running inside PFC GUI."
+        "ITASCA MCP server for PFC, FLAC, 3DEC, MPoint, and MassFlow. "
+        "Provides tools for browsing/searching engine documentation (select the "
+        "engine via the required 'software' parameter) and for executing simulation "
+        "tasks and managing runs through an itasca-mcp-bridge service running inside "
+        "the Itasca engine GUI."
     ),
 )
 
@@ -62,10 +63,10 @@ def _override_bridge_port(url: str, port: int) -> str:
 
 
 def main() -> None:
-    """Entry point for the PFC MCP server."""
+    """Entry point for the Itasca MCP server."""
     parser = argparse.ArgumentParser(
         prog="itasca-mcp",
-        description="PFC MCP Server - ITASCA PFC tools exposed over MCP",
+        description="Itasca MCP Server - ITASCA simulation tools exposed over MCP",
     )
     parser.add_argument("--version", "-v", action="version", version=f"itasca-mcp {__version__}")
     parser.add_argument(
@@ -88,7 +89,7 @@ def main() -> None:
     parser.add_argument(
         "--bridge-url",
         default=None,
-        help="Bridge WebSocket URL (default: ws://localhost:9001, or PFC_MCP_BRIDGE_URL env)",
+        help="Bridge WebSocket URL (default: ws://localhost:9001, or ITASCA_MCP_BRIDGE_URL env)",
     )
     parser.add_argument(
         "--bridge-port",
@@ -96,7 +97,7 @@ def main() -> None:
         default=None,
         help=(
             "Bridge WebSocket port; shorthand for --bridge-url ws://localhost:PORT. "
-            "Overrides only the port of --bridge-url / PFC_MCP_BRIDGE_URL when both "
+            "Overrides only the port of --bridge-url / ITASCA_MCP_BRIDGE_URL when both "
             "are given (default: 9001)"
         ),
     )
@@ -109,16 +110,16 @@ def main() -> None:
     args = parser.parse_args()
 
     # Resolve the bridge URL from (in order of precedence) --bridge-url,
-    # the PFC_MCP_BRIDGE_URL env, then the default. --bridge-port then
+    # the ITASCA_MCP_BRIDGE_URL env, then the default. --bridge-port then
     # overrides just the port, so users can point at a non-default bridge
     # port without spelling out the whole ws:// URL.
-    bridge_url = args.bridge_url or os.environ.get("PFC_MCP_BRIDGE_URL")
+    bridge_url = args.bridge_url or os.environ.get("ITASCA_MCP_BRIDGE_URL")
     if args.bridge_port is not None:
         if not 1 <= args.bridge_port <= 65535:
             parser.error("--bridge-port must be between 1 and 65535")
         bridge_url = _override_bridge_port(bridge_url or DEFAULT_BRIDGE_URL, args.bridge_port)
     if bridge_url:
-        os.environ["PFC_MCP_BRIDGE_URL"] = bridge_url
+        os.environ["ITASCA_MCP_BRIDGE_URL"] = bridge_url
 
     # Configure logging
     level = getattr(logging, args.log_level.upper())

--- a/src/itasca_mcp/tools/__init__.py
+++ b/src/itasca_mcp/tools/__init__.py
@@ -1,4 +1,4 @@
-"""PFC MCP tool implementations."""
+"""Itasca MCP tool implementations."""
 
 from . import (
     browse_commands,

--- a/src/itasca_mcp/tools/browse_commands.py
+++ b/src/itasca_mcp/tools/browse_commands.py
@@ -1,4 +1,4 @@
-"""PFC Command Browse Tool - Navigate and retrieve command documentation."""
+"""Itasca Command Browse Tool - Navigate and retrieve command documentation."""
 
 from typing import Any
 
@@ -18,15 +18,15 @@ from itasca_mcp.utils import (
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_browse_commands tool with the MCP server."""
+    """Register itasca_browse_commands tool with the MCP server."""
 
     @mcp.tool()
-    def pfc_browse_commands(
+    def itasca_browse_commands(
         software: SoftwareParam,
         command: str | None = Field(
             None,
             description=(
-                "PFC command to browse (space-separated, matching PFC syntax). Examples:\n"
+                "Itasca command to browse (space-separated, matching Itasca command syntax). Examples:\n"
                 "- None or '': List all command categories\n"
                 "- 'ball': List all ball commands\n"
                 "- 'ball create': Get ball create documentation\n"
@@ -42,7 +42,7 @@ def register(mcp: FastMCP) -> None:
             ),
         ),
     ) -> dict[str, Any]:
-        """Browse PFC command documentation by path (like glob + cat).
+        """Browse Itasca command documentation by path (like glob + cat).
 
         Navigation levels:
         - No command: All command categories overview
@@ -54,8 +54,8 @@ def register(mcp: FastMCP) -> None:
         - You want to explore available commands
 
         Related tools:
-        - pfc_query_command: Search commands by keywords (when path unknown)
-        - pfc_browse_reference: Browse reference docs (e.g., "contact-models linear")
+        - itasca_query_command: Search commands by keywords (when path unknown)
+        - itasca_browse_reference: Browse reference docs (e.g., "contact-models linear")
         """
         cmd = normalize_input(command, lowercase=True)
         sw = normalize_software_value(software)
@@ -174,7 +174,7 @@ def _browse_category(category: str, version: str, software: str) -> dict[str, An
 def _browse_command(category: str, command_name: str, version: str, software: str) -> dict[str, Any]:
     """Level 2: Return full documentation for a specific command."""
     # JSON filenames use dash as sub-command separator (e.g. edge-create,
-    # cmat-add, scalar-create) while PFC syntax separates them with spaces.
+    # cmat-add, scalar-create) while Itasca command syntax separates them with spaces.
     # Accept either form on input.
     try:
         cmd_doc = CommandLoader.load_command_doc(category, command_name, version, software=software)

--- a/src/itasca_mcp/tools/browse_python_api.py
+++ b/src/itasca_mcp/tools/browse_python_api.py
@@ -1,4 +1,4 @@
-"""PFC Python API Browse Tool - Navigate and retrieve Python SDK documentation."""
+"""Itasca Python API Browse Tool - Navigate and retrieve Python SDK documentation."""
 
 from typing import Any
 
@@ -11,15 +11,15 @@ from itasca_mcp.utils import SoftwareParam, normalize_software_value
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_browse_python_api tool with the MCP server."""
+    """Register itasca_browse_python_api tool with the MCP server."""
 
     @mcp.tool()
-    def pfc_browse_python_api(
+    def itasca_browse_python_api(
         software: SoftwareParam,
         api: str | None = Field(
             None,
             description=(
-                "PFC Python API path to browse (dot-separated, starting from itasca). Examples:\n"
+                "Itasca Python API path to browse (dot-separated, starting from itasca). Examples:\n"
                 "- None or '': Root overview - all modules and objects\n"
                 "- 'itasca': Core module functions (command, cycle, gravity, etc.)\n"
                 "- 'itasca.ball': Ball module functions (create, find, list, etc.)\n"
@@ -31,7 +31,7 @@ def register(mcp: FastMCP) -> None:
             ),
         ),
     ) -> dict[str, Any]:
-        """Browse PFC Python SDK documentation by path (like glob + cat)."""
+        """Browse Itasca Python SDK documentation by path (like glob + cat)."""
         normalized = _normalize_api_path(api)
         sw = normalize_software_value(software)
 

--- a/src/itasca_mcp/tools/browse_reference.py
+++ b/src/itasca_mcp/tools/browse_reference.py
@@ -18,10 +18,10 @@ from itasca_mcp.utils import (
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_browse_reference tool with the MCP server."""
+    """Register itasca_browse_reference tool with the MCP server."""
 
     @mcp.tool()
-    def pfc_browse_reference(
+    def itasca_browse_reference(
         software: SoftwareParam,
         topic: str | None = Field(
             None,
@@ -66,8 +66,8 @@ def register(mcp: FastMCP) -> None:
         - Configuring "plot item create" commands
 
         Related tools:
-        - pfc_browse_commands: Command syntax (e.g., "zone create")
-        - pfc_query_command: Search commands by keywords
+        - itasca_browse_commands: Command syntax (e.g., "zone create")
+        - itasca_query_command: Search commands by keywords
         """
         topic_str = normalize_input(topic, lowercase=True)
         sw = normalize_software_value(software)
@@ -209,7 +209,7 @@ def _browse_item(category: str, item: str, version: str, software: str) -> dict[
             "error": {
                 "code": "item_unavailable_for_version",
                 "message": (
-                    f"'{item}' is not available in PFC {version} (available in: {', '.join(supported) or 'none'})."
+                    f"'{item}' is not available in {software} {version} (available in: {', '.join(supported) or 'none'})."
                 ),
             },
             "input": {"category": category, "item": item, "version": version, "software": software},
@@ -238,7 +238,7 @@ def _browse_item(category: str, item: str, version: str, software: str) -> dict[
                 "count": 1,
                 "sub_item_count": len(sub_items),
                 "version": version,
-                "hint": f"Use pfc_browse_reference('{category} {item} <sub_item>') for details",
+                "hint": f"Use itasca_browse_reference('{category} {item} <sub_item>') for details",
             },
         )
 

--- a/src/itasca_mcp/tools/check_task_status.py
+++ b/src/itasca_mcp/tools/check_task_status.py
@@ -17,19 +17,19 @@ from itasca_mcp.utils import FilterText, OutputLimit, SkipNewestLines, TaskId, W
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_check_task_status tool."""
+    """Register itasca_check_task_status tool."""
 
     @mcp.tool()
-    async def pfc_check_task_status(
+    async def itasca_check_task_status(
         task_id: TaskId,
         skip_newest: SkipNewestLines = 0,
         limit: OutputLimit = 64,
         filter: FilterText = None,
         wait_seconds: WaitSeconds = 1,
     ) -> dict[str, Any]:
-        """Check status and paginated output for a submitted PFC task.
+        """Check status and paginated output for a submitted Itasca task.
 
-        Output combines Python prints and PFC console output from
+        Output combines Python prints and Itasca console output from
         itasca.command() calls (table dumps, list output, command
         summaries) interleaved in execution order. Use skip_newest /
         limit to paginate, or filter to keep only matching lines.

--- a/src/itasca_mcp/tools/execute_code.py
+++ b/src/itasca_mcp/tools/execute_code.py
@@ -1,4 +1,4 @@
-"""PFC execute_code tool — synchronous code execution in PFC process."""
+"""execute_code tool — synchronous code execution in the Itasca engine process."""
 
 from typing import Any
 
@@ -11,36 +11,37 @@ from itasca_mcp.utils import ConsoleCode, ConsoleTimeoutSeconds
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_execute_code tool."""
+    """Register itasca_execute_code tool."""
 
     @mcp.tool()
-    async def pfc_execute_code(
+    async def itasca_execute_code(
         code: ConsoleCode,
         timeout: ConsoleTimeoutSeconds = 10,
     ) -> dict[str, Any]:
-        """Execute Python code synchronously in the running PFC process.
+        """Execute Python code synchronously in the running Itasca engine process.
 
         Returns stdout and an optional result variable immediately.
-        Code runs in PFC's main thread, sharing the same __main__
+        Code runs in the engine's main thread, sharing the same __main__
         namespace as any running task — side effects persist and are
         immediately visible to the task on its next cycle.
 
         This tool remains responsive EVEN WHILE a simulation task is
-        running (submitted via pfc_execute_task), as long as the task
+        running (submitted via itasca_execute_task), as long as the task
         is actively cycling — execute_code interleaves at cycle gaps.
         Use it as a live REPL to inspect simulation state in real
         time — no need to pre-script print statements, and parameter
         sweeps or sentinel-based control don't have to be baked into
         the task script up front.
 
-        Environment: PFC's embedded Python interpreter. The version
-        is bundled with PFC (PFC 6/7 → Python 3.6, PFC 9 → 3.10);
-        the PFC version is encoded in sys.executable (e.g. PFC700,
-        PFC900). When unsure, write code compatible with Python 3.6+.
+        Environment: the Itasca engine's embedded Python interpreter.
+        The version is bundled with the engine (Itasca 6/7 → Python 3.6,
+        Itasca 9 → 3.10); the product+version is encoded in sys.executable
+        (e.g. PFC900, FLAC900). When unsure, write code compatible with
+        Python 3.6+.
 
         Typical uses:
         - Query model state: ball/wall/contact counts, current cycle
-        - Issue PFC commands and read their console output:
+        - Issue Itasca commands and read their console output:
           itasca.command('ball list'), itasca.command('model list
           information'). Table dumps, list output, and command
           summaries are captured and interleaved with Python prints
@@ -56,13 +57,13 @@ def register(mcp: FastMCP) -> None:
         - Development and REPL-style testing
 
         `program call '<file>.p3dat'` (or .p2dat / .dat) through this
-        tool is PFC-version-gated. On PFC 6/7 the command-script
+        tool is engine-version-gated. On 6/7 the command-script
         interpreter blocks the bridge for the script's entire
         duration with no cycle-gap interleaving — any long
         `model cycle` inside the file leaves the bridge unreachable
-        until PFC is stopped manually. Never emit it there, and
-        treat unknown or unverified versions (including PFC
-        9.0-9.6) the same way. On PFC 9.7+ the bridge stays fully
+        until the engine is stopped manually. Never emit it there, and
+        treat unknown or unverified versions (including 9.0-9.6) the
+        same way. On 9.7+ the bridge stays fully
         responsive during a `program call` (verified on 9.7: status
         polling, cycle-gap interleaving, and interrupt all work
         mid-call). Even where it is safe, prefer reading the file
@@ -73,10 +74,10 @@ def register(mcp: FastMCP) -> None:
 
         This is a synchronous tool: the request blocks until the code
         finishes or hits the timeout (default 10s, max 600s). Output
-        is returned in full; the call is NOT tracked by pfc_list_tasks
+        is returned in full; the call is NOT tracked by itasca_list_tasks
         and cannot be interrupted mid-execution. For cancellable,
-        pollable, or background work, submit it via pfc_execute_task
-        instead — and you can still call pfc_execute_code against the
+        pollable, or background work, submit it via itasca_execute_task
+        instead — and you can still call itasca_execute_code against the
         task while it cycles.
         """
         try:
@@ -103,12 +104,12 @@ def register(mcp: FastMCP) -> None:
 
         if status == "terminated":
             # Bridge aborted the snippet at the timeout deadline and the
-            # worker thread settled. PFC state may be partially modified.
+            # worker thread settled. Engine state may be partially modified.
             return build_operation_error(
                 "terminated",
                 "Execution aborted by bridge timeout",
                 reason=message,
-                action="PFC state may be partially modified; verify with pfc_execute_code before retrying",
+                action="Engine state may be partially modified; verify with itasca_execute_code before retrying",
                 output=partial_output,
             )
 
@@ -117,7 +118,7 @@ def register(mcp: FastMCP) -> None:
                 action = (
                     "Bridge could not terminate the code (likely stuck "
                     "in a C extension). It may recover when the C call "
-                    "returns; otherwise restart PFC bridge."
+                    "returns; otherwise restart the Itasca bridge."
                 )
             else:
                 action = "Reduce code complexity or increase timeout"

--- a/src/itasca_mcp/tools/execute_task.py
+++ b/src/itasca_mcp/tools/execute_task.py
@@ -1,4 +1,4 @@
-"""PFC task execution tool backed by itasca-mcp-bridge."""
+"""Itasca task execution tool backed by itasca-mcp-bridge."""
 
 import uuid
 from typing import Any
@@ -12,41 +12,41 @@ from itasca_mcp.utils import ScriptPath, TaskDescription
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_execute_task tool."""
+    """Register itasca_execute_task tool."""
 
     @mcp.tool()
-    async def pfc_execute_task(
+    async def itasca_execute_task(
         entry_script: ScriptPath,
         description: TaskDescription,
     ) -> dict[str, Any]:
-        """Submit a Python script file for asynchronous execution in PFC.
+        """Submit a Python script file for asynchronous execution in the Itasca engine.
 
         Returns a task_id immediately; the script runs in the background.
         Use the companion tools to manage the task lifecycle:
-        - pfc_check_task_status: poll output, progress, and final status
-        - pfc_interrupt_task: cancel a running task
-        - pfc_list_tasks: browse task history
+        - itasca_check_task_status: poll output, progress, and final status
+        - itasca_interrupt_task: cancel a running task
+        - itasca_list_tasks: browse task history
 
-        While the task is cycling, you can call pfc_execute_code at any
+        While the task is cycling, you can call itasca_execute_code at any
         time to inspect or modify simulation state — including variables
         the task depends on. This is the standard way to probe progress,
         tune parameters mid-run, swap callbacks, or trigger early
         termination via a sentinel variable. Both tools share the same
-        __main__ namespace in PFC's main thread.
+        __main__ namespace in the engine's main thread.
 
         Console output from itasca.command() inside the script —
         table dumps, list output, command summaries — is captured
         and interleaved with Python prints in the task log, visible
-        through pfc_check_task_status.
+        through itasca_check_task_status.
 
         Having the script invoke `program call '<file>.p3dat'` (or
-        .p2dat / .dat) is PFC-version-gated. On PFC 6/7 the
+        .p2dat / .dat) is engine-version-gated. On 6/7 the
         command-script interpreter blocks the bridge for the
         script's entire duration with no cycle-gap interleaving,
-        leaving the bridge unreachable until PFC is stopped
+        leaving the bridge unreachable until the engine is stopped
         manually. Never emit it there, and treat unknown or
-        unverified versions (including PFC 9.0-9.6) the same way.
-        On PFC 9.7+ the bridge stays fully responsive during a
+        unverified versions (including 9.0-9.6) the same way.
+        On 9.7+ the bridge stays fully responsive during a
         `program call` (verified on 9.7: status polling, cycle-gap
         interleaving, and interrupt all work mid-call). Even where
         it is safe, prefer reading the file and translating its
@@ -56,15 +56,15 @@ def register(mcp: FastMCP) -> None:
         `program call` cannot give.
 
         This is the async / background execution path: pollable via
-        pfc_check_task_status, cancellable via pfc_interrupt_task.
+        itasca_check_task_status, cancellable via itasca_interrupt_task.
         Submission does not lock parameters — start with reasonable
-        values and refine live via pfc_execute_code as the task
+        values and refine live via itasca_execute_code as the task
         cycles. For synchronous, inline execution, use
-        pfc_execute_code directly.
+        itasca_execute_code directly.
 
         Submission uses the bridge's `execute_task` protocol message. If
         a submission times out, the connected bridge may predate it —
-        confirm its version with pfc_execute_code (`import
+        confirm its version with itasca_execute_code (`import
         itasca_mcp_bridge; print(itasca_mcp_bridge.__version__)`). To
         upgrade, fetch and follow the bootstrap guide, then resubmit:
         https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap.md

--- a/src/itasca_mcp/tools/interrupt_task.py
+++ b/src/itasca_mcp/tools/interrupt_task.py
@@ -11,11 +11,11 @@ from itasca_mcp.utils import TaskId
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_interrupt_task tool."""
+    """Register itasca_interrupt_task tool."""
 
     @mcp.tool()
-    async def pfc_interrupt_task(task_id: TaskId) -> dict[str, Any]:
-        """Request graceful interruption of a running PFC task."""
+    async def itasca_interrupt_task(task_id: TaskId) -> dict[str, Any]:
+        """Request graceful interruption of a running Itasca task."""
         try:
             client = await get_bridge_client()
             response = await client.interrupt_task(task_id)
@@ -31,7 +31,7 @@ def register(mcp: FastMCP) -> None:
                     "task_id": task_id,
                     "interrupt_requested": True,
                     "message": message or "signal sent",
-                    "next_action": f'call pfc_check_task_status(task_id="{task_id}")',
+                    "next_action": f'call itasca_check_task_status(task_id="{task_id}")',
                 }
             )
 

--- a/src/itasca_mcp/tools/list_tasks.py
+++ b/src/itasca_mcp/tools/list_tasks.py
@@ -16,14 +16,14 @@ from itasca_mcp.utils import SkipNewestTasks, TaskListLimit
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_list_tasks tool."""
+    """Register itasca_list_tasks tool."""
 
     @mcp.tool()
-    async def pfc_list_tasks(
+    async def itasca_list_tasks(
         skip_newest: SkipNewestTasks = 0,
         limit: TaskListLimit = 32,
     ) -> dict[str, Any]:
-        """List tracked PFC tasks with pagination."""
+        """List tracked Itasca tasks with pagination."""
         try:
             client = await get_bridge_client()
             response = await client.list_tasks(

--- a/src/itasca_mcp/tools/query_command.py
+++ b/src/itasca_mcp/tools/query_command.py
@@ -1,4 +1,4 @@
-"""PFC Command Query Tool - Keyword search for command documentation."""
+"""Itasca Command Query Tool - Keyword search for command documentation."""
 
 from typing import Any
 
@@ -20,10 +20,10 @@ from itasca_mcp.utils import (
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_query_command tool with the MCP server."""
+    """Register itasca_query_command tool with the MCP server."""
 
     @mcp.tool()
-    def pfc_query_command(
+    def itasca_query_command(
         query: SearchQuery,
         software: SoftwareParam,
         limit: SearchLimit = 10,
@@ -35,18 +35,18 @@ def register(mcp: FastMCP) -> None:
             ),
         ),
     ) -> dict[str, Any]:
-        """Search PFC command documentation by keywords (like grep).
+        """Search Itasca command documentation by keywords (like grep).
 
-        Returns matching command paths. Use pfc_browse_commands for full documentation.
+        Returns matching command paths. Use itasca_browse_commands for full documentation.
 
         When to use:
         - You have keywords but don't know exact command path
         - Example: "ball create", "contact property", "model solve"
 
         Related tools:
-        - pfc_browse_commands: Get full documentation for a known command path
-        - pfc_browse_reference: Browse reference docs (e.g., "contact-models linear")
-        - pfc_query_python_api: Search Python SDK by keywords
+        - itasca_browse_commands: Get full documentation for a known command path
+        - itasca_browse_reference: Browse reference docs (e.g., "contact-models linear")
+        - itasca_query_python_api: Search Python SDK by keywords
         """
         sw = normalize_software_value(software)
         version_value = effective_doc_version(sw, normalize_command_doc_version(version))

--- a/src/itasca_mcp/tools/query_python_api.py
+++ b/src/itasca_mcp/tools/query_python_api.py
@@ -1,4 +1,4 @@
-"""PFC Python API Query Tool - Keyword search for SDK documentation."""
+"""Itasca Python API Query Tool - Keyword search for SDK documentation."""
 
 from typing import Any
 
@@ -11,25 +11,25 @@ from itasca_mcp.utils import PythonAPISearchQuery, SearchLimit, SoftwareParam, n
 
 
 def register(mcp: FastMCP) -> None:
-    """Register pfc_query_python_api tool with the MCP server."""
+    """Register itasca_query_python_api tool with the MCP server."""
 
     @mcp.tool()
-    def pfc_query_python_api(
+    def itasca_query_python_api(
         query: PythonAPISearchQuery,
         software: SoftwareParam,
         limit: SearchLimit = 10,
     ) -> dict[str, Any]:
-        """Search PFC Python SDK documentation by keywords (like grep).
+        """Search Itasca Python SDK documentation by keywords (like grep).
 
-        Returns matching API paths with signatures. Use pfc_browse_python_api for full documentation.
+        Returns matching API paths with signatures. Use itasca_browse_python_api for full documentation.
 
         When to use:
         - You have keywords but don't know exact API path
         - Example: "ball velocity", "create", "contact force"
 
         Related tools:
-        - pfc_browse_python_api: Get full documentation for a known API path
-        - pfc_query_command: Search PFC commands by keywords
+        - itasca_browse_python_api: Get full documentation for a known API path
+        - itasca_query_command: Search Itasca commands by keywords
         """
         sw = normalize_software_value(software)
         matches = APISearch.search(query, top_k=limit, software=sw)

--- a/src/itasca_mcp/utils.py
+++ b/src/itasca_mcp/utils.py
@@ -1,4 +1,4 @@
-"""Validation models and utilities for PFC MCP tools."""
+"""Validation models and utilities for Itasca MCP tools."""
 
 from enum import Enum
 from pathlib import PurePosixPath, PureWindowsPath
@@ -30,7 +30,7 @@ DESCRIPTION_MAX_LENGTH = 200
 
 
 class CommandDocVersion(str, Enum):
-    """Supported PFC documentation versions for command tools."""
+    """Supported Itasca documentation versions for command tools."""
 
     V6_0 = "6.0"
     V7_0 = "7.0"
@@ -120,7 +120,7 @@ SearchQuery = Annotated[
         ...,
         min_length=1,
         description=(
-            "Search keywords for PFC commands. Examples: 'ball create', "
+            "Search keywords for Itasca commands. Examples: 'ball create', "
             "'contact property', 'model solve'. Case-insensitive."
         ),
     ),
@@ -134,7 +134,7 @@ PythonAPISearchQuery = Annotated[
         ...,
         min_length=1,
         description=(
-            "Search keywords for PFC Python SDK API. Examples: 'ball pos', "
+            "Search keywords for Itasca Python SDK API. Examples: 'ball pos', "
             "'contact force', 'model solve'. Case-insensitive."
         ),
     ),
@@ -163,13 +163,13 @@ SearchLimit = Annotated[
 TaskId = Annotated[
     str,
     AfterValidator(validate_non_empty_string),
-    Field(..., description="Task ID returned by pfc_execute_task"),
+    Field(..., description="Task ID returned by itasca_execute_task"),
 ]
 
 ScriptPath = Annotated[
     str,
     AfterValidator(validate_script_path),
-    Field(..., description="Absolute path to entry Python script in PFC workspace"),
+    Field(..., description="Absolute path to entry Python script in the Itasca engine workspace"),
 ]
 
 TaskDescription = Annotated[
@@ -216,7 +216,7 @@ WaitSeconds = Annotated[
 ConsoleCode = Annotated[
     str,
     AfterValidator(validate_non_empty_string),
-    Field(..., min_length=1, description="Python code to execute in PFC user console"),
+    Field(..., min_length=1, description="Python code to execute in the Itasca engine user console"),
 ]
 
 ConsoleTimeoutSeconds = Annotated[

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -141,7 +141,7 @@ def test_run_pip_restores_logging_even_on_failure(monkeypatch):
 @pytest.fixture
 def clean_pip_env(monkeypatch):
     """Neutralize the env vars `_install_bridge` reads and writes."""
-    monkeypatch.delenv("PFC_MCP_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("ITASCA_MCP_PIP_INDEX_URL", raising=False)
     monkeypatch.delenv("PIP_DISABLE_PIP_VERSION_CHECK", raising=False)
 
 
@@ -185,7 +185,7 @@ def test_install_bridge_returns_last_code_when_all_fail(monkeypatch, clean_pip_e
 
 
 def test_install_bridge_honors_index_override(monkeypatch, clean_pip_env):
-    monkeypatch.setenv("PFC_MCP_PIP_INDEX_URL", "https://override.test/simple/")
+    monkeypatch.setenv("ITASCA_MCP_PIP_INDEX_URL", "https://override.test/simple/")
     calls = _stub_run_pip(monkeypatch, [0])
 
     assert addon._install_bridge() == 0

--- a/tests/test_contact_type_expansion.py
+++ b/tests/test_contact_type_expansion.py
@@ -62,7 +62,7 @@ def test_contact_resolver_does_not_match_unrelated_object_methods() -> None:
 @pytest.mark.asyncio
 async def test_browse_python_api_reports_missing_thermal_force_method() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_python_api",
+        "itasca_browse_python_api",
         {"api": "itasca.BallBallThermalContact.force_normal", "software": "pfc"},
     )
 

--- a/tests/test_docs_tool_contracts.py
+++ b/tests/test_docs_tool_contracts.py
@@ -17,7 +17,7 @@ def _parse_tool_payload(result) -> dict:
 
 @pytest.mark.asyncio
 async def test_browse_commands_root_contract() -> None:
-    result = await mcp.call_tool("pfc_browse_commands", {"software": "pfc"})
+    result = await mcp.call_tool("itasca_browse_commands", {"software": "pfc"})
     payload = _parse_tool_payload(result)
     data = payload["data"]
 
@@ -34,7 +34,7 @@ async def test_browse_commands_root_contract() -> None:
 @pytest.mark.asyncio
 async def test_browse_commands_not_found_contract() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands",
+        "itasca_browse_commands",
         {"command": "ball not_a_real_command", "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -51,7 +51,7 @@ async def test_browse_commands_not_found_contract() -> None:
 @pytest.mark.asyncio
 async def test_query_command_contract() -> None:
     result = await mcp.call_tool(
-        "pfc_query_command",
+        "itasca_query_command",
         {"query": "ball create", "limit": 5, "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -69,7 +69,7 @@ async def test_query_command_contract() -> None:
 @pytest.mark.asyncio
 async def test_browse_commands_versioned_contract() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands",
+        "itasca_browse_commands",
         {"command": "brick assemble", "version": "6.0", "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -84,7 +84,7 @@ async def test_browse_commands_versioned_contract() -> None:
 @pytest.mark.asyncio
 async def test_browse_commands_accepts_mixed_case_paths() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands",
+        "itasca_browse_commands",
         {"command": "Ball Create", "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -99,7 +99,7 @@ async def test_browse_commands_accepts_mixed_case_paths() -> None:
 @pytest.mark.asyncio
 async def test_browse_category_filters_unavailable_commands_by_version() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands",
+        "itasca_browse_commands",
         {"command": "ball", "version": "6.0", "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -114,7 +114,7 @@ async def test_browse_category_filters_unavailable_commands_by_version() -> None
 @pytest.mark.asyncio
 async def test_browse_command_not_found_suggestions_are_version_filtered() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands",
+        "itasca_browse_commands",
         {"command": "ball not_a_real_command", "version": "6.0", "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -128,7 +128,7 @@ async def test_browse_command_not_found_suggestions_are_version_filtered() -> No
 @pytest.mark.asyncio
 async def test_query_command_versioned_contract() -> None:
     result = await mcp.call_tool(
-        "pfc_query_command",
+        "itasca_query_command",
         {"query": "brick assemble", "limit": 5, "version": "6.0", "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -142,7 +142,7 @@ async def test_query_command_versioned_contract() -> None:
 
 @pytest.mark.asyncio
 async def test_browse_python_api_root_contract() -> None:
-    result = await mcp.call_tool("pfc_browse_python_api", {"software": "pfc"})
+    result = await mcp.call_tool("itasca_browse_python_api", {"software": "pfc"})
     payload = _parse_tool_payload(result)
     data = payload["data"]
 
@@ -156,7 +156,7 @@ async def test_browse_python_api_root_contract() -> None:
 
 @pytest.mark.asyncio
 async def test_browse_python_api_array_module_contract() -> None:
-    result = await mcp.call_tool("pfc_browse_python_api", {"api": "itasca.ballarray", "software": "pfc"})
+    result = await mcp.call_tool("itasca_browse_python_api", {"api": "itasca.ballarray", "software": "pfc"})
     payload = _parse_tool_payload(result)
     data = payload["data"]
 
@@ -171,7 +171,7 @@ async def test_browse_python_api_array_module_contract() -> None:
 
 @pytest.mark.asyncio
 async def test_browse_python_api_array_function_contract() -> None:
-    result = await mcp.call_tool("pfc_browse_python_api", {"api": "itasca.ballarray.pos", "software": "pfc"})
+    result = await mcp.call_tool("itasca_browse_python_api", {"api": "itasca.ballarray.pos", "software": "pfc"})
     payload = _parse_tool_payload(result)
     data = payload["data"]
 
@@ -186,7 +186,7 @@ async def test_browse_python_api_array_function_contract() -> None:
 @pytest.mark.asyncio
 async def test_query_python_api_array_position_contract() -> None:
     result = await mcp.call_tool(
-        "pfc_query_python_api",
+        "itasca_query_python_api",
         {"query": "array position", "limit": 10, "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -199,7 +199,7 @@ async def test_query_python_api_array_position_contract() -> None:
 @pytest.mark.asyncio
 async def test_query_python_api_no_results_contract() -> None:
     result = await mcp.call_tool(
-        "pfc_query_python_api",
+        "itasca_query_python_api",
         {"query": "definitelynonexistentkeyword", "limit": 5, "software": "pfc"},
     )
     payload = _parse_tool_payload(result)
@@ -214,7 +214,7 @@ async def test_query_python_api_no_results_contract() -> None:
 
 @pytest.mark.asyncio
 async def test_browse_reference_root_contract() -> None:
-    result = await mcp.call_tool("pfc_browse_reference", {"software": "pfc"})
+    result = await mcp.call_tool("itasca_browse_reference", {"software": "pfc"})
     payload = _parse_tool_payload(result)
     data = payload["data"]
 

--- a/tests/test_multi_engine_software.py
+++ b/tests/test_multi_engine_software.py
@@ -47,7 +47,7 @@ def test_normalize_software_validates() -> None:
 async def test_software_is_required_on_tools() -> None:
     """Omitting ``software`` is a validation error (there is no default engine)."""
     with pytest.raises(Exception, match="(?i)software"):
-        await mcp.call_tool("pfc_browse_commands", {})
+        await mcp.call_tool("itasca_browse_commands", {})
 
 
 # --- FLAC coverage through the tools ----------------------------------------
@@ -55,7 +55,7 @@ async def test_software_is_required_on_tools() -> None:
 
 @pytest.mark.asyncio
 async def test_flac_browse_commands_root() -> None:
-    result = await mcp.call_tool("pfc_browse_commands", {"software": "flac"})
+    result = await mcp.call_tool("itasca_browse_commands", {"software": "flac"})
     data = _parse_tool_payload(result)["data"]
     names = {e["name"] for e in data["entries"]}
     assert "zone" in names  # FLAC-only family
@@ -67,7 +67,7 @@ async def test_flac_browse_commands_root() -> None:
 @pytest.mark.asyncio
 async def test_flac_browse_zone_command() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands", {"software": "flac", "command": "zone create", "version": "9.0"}
+        "itasca_browse_commands", {"software": "flac", "command": "zone create", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["entries"][0]["doc"]["command"] == "zone create"
@@ -75,7 +75,7 @@ async def test_flac_browse_zone_command() -> None:
 
 @pytest.mark.asyncio
 async def test_flac_query_command_finds_zone() -> None:
-    result = await mcp.call_tool("pfc_query_command", {"software": "flac", "query": "zone create"})
+    result = await mcp.call_tool("itasca_query_command", {"software": "flac", "query": "zone create"})
     data = _parse_tool_payload(result)["data"]
     assert data["summary"]["software"] == "flac"
     assert any("zone" in e["name"] for e in data["entries"])
@@ -83,7 +83,7 @@ async def test_flac_query_command_finds_zone() -> None:
 
 @pytest.mark.asyncio
 async def test_flac_browse_python_api_has_zone_not_ball() -> None:
-    result = await mcp.call_tool("pfc_browse_python_api", {"software": "flac"})
+    result = await mcp.call_tool("itasca_browse_python_api", {"software": "flac"})
     data = _parse_tool_payload(result)["data"]
     module_paths = {e.get("path") for e in data["entries"] if e.get("entry_type") == "module"}
     assert "itasca.zone" in module_paths
@@ -92,7 +92,7 @@ async def test_flac_browse_python_api_has_zone_not_ball() -> None:
 
 @pytest.mark.asyncio
 async def test_flac_browse_reference_root() -> None:
-    result = await mcp.call_tool("pfc_browse_reference", {"software": "flac"})
+    result = await mcp.call_tool("itasca_browse_reference", {"software": "flac"})
     data = _parse_tool_payload(result)["data"]
     names = {e["name"] for e in data["entries"]}
     assert "constitutive-models" in names
@@ -153,7 +153,7 @@ def test_reference_categories_are_engine_specific() -> None:
 
 @pytest.mark.asyncio
 async def test_3dec_browse_commands_root() -> None:
-    result = await mcp.call_tool("pfc_browse_commands", {"software": "3dec", "version": "9.0"})
+    result = await mcp.call_tool("itasca_browse_commands", {"software": "3dec", "version": "9.0"})
     data = _parse_tool_payload(result)["data"]
     names = {e["name"] for e in data["entries"]}
     assert "block" in names  # 3DEC-only family
@@ -166,7 +166,7 @@ async def test_3dec_browse_commands_root() -> None:
 @pytest.mark.asyncio
 async def test_3dec_browse_block_zone_generate() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands", {"software": "3dec", "command": "block zone generate", "version": "9.0"}
+        "itasca_browse_commands", {"software": "3dec", "command": "block zone generate", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["entries"][0]["doc"]["command"] == "block zone generate"
@@ -174,7 +174,9 @@ async def test_3dec_browse_block_zone_generate() -> None:
 
 @pytest.mark.asyncio
 async def test_3dec_query_command_finds_block_create() -> None:
-    result = await mcp.call_tool("pfc_query_command", {"software": "3dec", "query": "create block", "version": "9.0"})
+    result = await mcp.call_tool(
+        "itasca_query_command", {"software": "3dec", "query": "create block", "version": "9.0"}
+    )
     data = _parse_tool_payload(result)["data"]
     assert data["summary"]["software"] == "3dec"
     assert any(e["name"] == "block create" for e in data["entries"])
@@ -182,7 +184,7 @@ async def test_3dec_query_command_finds_block_create() -> None:
 
 @pytest.mark.asyncio
 async def test_3dec_python_api_exposes_itasca_core() -> None:
-    result = await mcp.call_tool("pfc_query_python_api", {"software": "3dec", "query": "run command"})
+    result = await mcp.call_tool("itasca_query_python_api", {"software": "3dec", "query": "run command"})
     data = _parse_tool_payload(result)["data"]
     assert any(e.get("api_path") == "itasca.command" for e in data["entries"])
 
@@ -296,7 +298,7 @@ def test_3dec_command_families_are_isolated() -> None:
 
 @pytest.mark.asyncio
 async def test_mpoint_browse_commands_root() -> None:
-    result = await mcp.call_tool("pfc_browse_commands", {"software": "mpoint", "version": "9.0"})
+    result = await mcp.call_tool("itasca_browse_commands", {"software": "mpoint", "version": "9.0"})
     data = _parse_tool_payload(result)["data"]
     names = {e["name"] for e in data["entries"]}
     assert "mpoint" in names  # MPoint-only family
@@ -310,7 +312,7 @@ async def test_mpoint_browse_commands_root() -> None:
 @pytest.mark.asyncio
 async def test_mpoint_browse_mpoint_create() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands", {"software": "mpoint", "command": "mpoint create", "version": "9.0"}
+        "itasca_browse_commands", {"software": "mpoint", "command": "mpoint create", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["entries"][0]["doc"]["command"] == "mpoint create"
@@ -320,7 +322,7 @@ async def test_mpoint_browse_mpoint_create() -> None:
 async def test_mpoint_browse_node_subcommand() -> None:
     # 'mpoint node fix' is keyed as node-fix.json but addressed with spaces.
     result = await mcp.call_tool(
-        "pfc_browse_commands", {"software": "mpoint", "command": "mpoint node fix", "version": "9.0"}
+        "itasca_browse_commands", {"software": "mpoint", "command": "mpoint node fix", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["entries"][0]["doc"]["command"] == "mpoint node fix"
@@ -329,7 +331,7 @@ async def test_mpoint_browse_node_subcommand() -> None:
 @pytest.mark.asyncio
 async def test_mpoint_query_command_finds_mpoint_create() -> None:
     result = await mcp.call_tool(
-        "pfc_query_command", {"software": "mpoint", "query": "create material point", "version": "9.0"}
+        "itasca_query_command", {"software": "mpoint", "query": "create material point", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["summary"]["software"] == "mpoint"
@@ -338,7 +340,7 @@ async def test_mpoint_query_command_finds_mpoint_create() -> None:
 
 @pytest.mark.asyncio
 async def test_mpoint_python_api_exposes_itasca_core() -> None:
-    result = await mcp.call_tool("pfc_query_python_api", {"software": "mpoint", "query": "run command"})
+    result = await mcp.call_tool("itasca_query_python_api", {"software": "mpoint", "query": "run command"})
     data = _parse_tool_payload(result)["data"]
     assert any(e.get("api_path") == "itasca.command" for e in data["entries"])
 
@@ -444,7 +446,7 @@ def test_mpoint_initial_conditions_field_and_gravity() -> None:
 
 @pytest.mark.asyncio
 async def test_massflow_browse_commands_root() -> None:
-    result = await mcp.call_tool("pfc_browse_commands", {"software": "massflow", "version": "9.0"})
+    result = await mcp.call_tool("itasca_browse_commands", {"software": "massflow", "version": "9.0"})
     data = _parse_tool_payload(result)["data"]
     names = {e["name"] for e in data["entries"]}
     assert "massflow" in names  # MassFlow-only family
@@ -459,7 +461,7 @@ async def test_massflow_browse_commands_root() -> None:
 @pytest.mark.asyncio
 async def test_massflow_browse_compute_command() -> None:
     result = await mcp.call_tool(
-        "pfc_browse_commands", {"software": "massflow", "command": "massflow compute", "version": "9.0"}
+        "itasca_browse_commands", {"software": "massflow", "command": "massflow compute", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["entries"][0]["doc"]["command"] == "massflow compute"
@@ -469,7 +471,7 @@ async def test_massflow_browse_compute_command() -> None:
 async def test_massflow_browse_subnamespace_command() -> None:
     # 'massflow drawpoint import' is keyed as drawpoint-import.json but addressed with spaces.
     result = await mcp.call_tool(
-        "pfc_browse_commands", {"software": "massflow", "command": "massflow drawpoint import", "version": "9.0"}
+        "itasca_browse_commands", {"software": "massflow", "command": "massflow drawpoint import", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["entries"][0]["doc"]["command"] == "massflow drawpoint import"
@@ -478,7 +480,7 @@ async def test_massflow_browse_subnamespace_command() -> None:
 @pytest.mark.asyncio
 async def test_massflow_query_command_finds_compute() -> None:
     result = await mcp.call_tool(
-        "pfc_query_command", {"software": "massflow", "query": "compute flow solution", "version": "9.0"}
+        "itasca_query_command", {"software": "massflow", "query": "compute flow solution", "version": "9.0"}
     )
     data = _parse_tool_payload(result)["data"]
     assert data["summary"]["software"] == "massflow"
@@ -487,7 +489,7 @@ async def test_massflow_query_command_finds_compute() -> None:
 
 @pytest.mark.asyncio
 async def test_massflow_python_api_exposes_itasca_core() -> None:
-    result = await mcp.call_tool("pfc_query_python_api", {"software": "massflow", "query": "run command"})
+    result = await mcp.call_tool("itasca_query_python_api", {"software": "massflow", "query": "run command"})
     data = _parse_tool_payload(result)["data"]
     assert any(e.get("api_path") == "itasca.command" for e in data["entries"])
 
@@ -613,7 +615,7 @@ def test_effective_doc_version_coerces_nine_zero_only() -> None:
 async def test_nine_zero_only_browse_without_version_resolves() -> None:
     # No version passed -> must NOT fail with "unavailable for 7.0".
     for sw, cmd in (("3dec", "block create"), ("mpoint", "mpoint create"), ("massflow", "massflow compute")):
-        result = await mcp.call_tool("pfc_browse_commands", {"software": sw, "command": cmd})
+        result = await mcp.call_tool("itasca_browse_commands", {"software": sw, "command": cmd})
         payload = _parse_tool_payload(result)
         assert payload["ok"] is True, (sw, payload)
         assert payload["data"]["entries"][0]["doc"]["command"] == cmd
@@ -622,7 +624,7 @@ async def test_nine_zero_only_browse_without_version_resolves() -> None:
 @pytest.mark.asyncio
 async def test_nine_zero_only_reference_summary_reports_9_0() -> None:
     for sw in ("3dec", "mpoint", "massflow"):
-        result = await mcp.call_tool("pfc_browse_reference", {"software": sw})
+        result = await mcp.call_tool("itasca_browse_reference", {"software": sw})
         data = _parse_tool_payload(result)["data"]
         assert data["summary"]["version"] == "9.0", sw
 
@@ -679,7 +681,7 @@ def test_3dec_joint_model_item_has_property_vocabulary() -> None:
 
 @pytest.mark.asyncio
 async def test_3dec_browse_reference_joint_models() -> None:
-    result = await mcp.call_tool("pfc_browse_reference", {"software": "3dec", "topic": "joint-models"})
+    result = await mcp.call_tool("itasca_browse_reference", {"software": "3dec", "topic": "joint-models"})
     data = _parse_tool_payload(result)["data"]
     assert {e.get("name") for e in data["entries"]} >= {"mohr", "cyjm", "nonlinear"}
 

--- a/tests/test_phase2_tools.py
+++ b/tests/test_phase2_tools.py
@@ -10,13 +10,13 @@ def test_phase2_tools_registered() -> None:
     tools = asyncio.run(mcp.list_tools())
     tool_names = {tool.name for tool in tools}
     expected = {
-        "pfc_execute_task",
-        "pfc_check_task_status",
-        "pfc_list_tasks",
-        "pfc_interrupt_task",
+        "itasca_execute_task",
+        "itasca_check_task_status",
+        "itasca_list_tasks",
+        "itasca_interrupt_task",
     }
     assert expected.issubset(tool_names)
-    assert "pfc_execute_code" in tool_names
+    assert "itasca_execute_code" in tool_names
 
 
 def test_pagination() -> None:
@@ -50,6 +50,6 @@ def test_bridge_error_message_is_friendly() -> None:
     assert envelope["ok"] is False
     error = envelope["error"]
     assert error["code"] == "bridge_unavailable"
-    assert error["message"] == "PFC bridge unavailable"
+    assert error["message"] == "Itasca bridge unavailable"
     assert error["details"]["reason"] == "cannot connect to bridge service"
-    assert error["details"]["action"] == "start itasca-mcp-bridge in PFC GUI, then retry"
+    assert error["details"]["action"] == "start itasca-mcp-bridge in the Itasca engine GUI, then retry"

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -141,8 +141,8 @@ async def mock_bridge(tmp_path):
     server = await websockets.serve(_mock_bridge_handler, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
 
-    prev = os.environ.get("PFC_MCP_BRIDGE_URL")
-    os.environ["PFC_MCP_BRIDGE_URL"] = f"ws://127.0.0.1:{port}"
+    prev = os.environ.get("ITASCA_MCP_BRIDGE_URL")
+    os.environ["ITASCA_MCP_BRIDGE_URL"] = f"ws://127.0.0.1:{port}"
 
     await close_bridge_client()
 
@@ -150,14 +150,14 @@ async def mock_bridge(tmp_path):
 
     await close_bridge_client()
     if prev is None:
-        os.environ.pop("PFC_MCP_BRIDGE_URL", None)
+        os.environ.pop("ITASCA_MCP_BRIDGE_URL", None)
     else:
-        os.environ["PFC_MCP_BRIDGE_URL"] = prev
+        os.environ["ITASCA_MCP_BRIDGE_URL"] = prev
     server.close()
     await server.wait_closed()
 
 
-# ── pfc_execute_task ─────────────────────────────────────
+# ── itasca_execute_task ─────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -166,7 +166,7 @@ async def test_execute_task_success_fields(mock_bridge, tmp_path):
     script.write_text("print('hello')")
 
     result = await mcp.call_tool(
-        "pfc_execute_task",
+        "itasca_execute_task",
         {"entry_script": str(script), "description": "test task"},
     )
 
@@ -190,7 +190,7 @@ async def test_execute_task_success_fields(mock_bridge, tmp_path):
         assert "message" in data
 
 
-# ── pfc_check_task_status ────────────────────────────────
+# ── itasca_check_task_status ────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -200,7 +200,7 @@ async def test_check_task_status_running_fields(mock_bridge, tmp_path):
     script.write_text("print('running')")
 
     exec_result = await mcp.call_tool(
-        "pfc_execute_task",
+        "itasca_execute_task",
         {"entry_script": str(script), "description": "simulation"},
     )
     exec_text = exec_result.content[0].text
@@ -208,7 +208,7 @@ async def test_check_task_status_running_fields(mock_bridge, tmp_path):
     task_id = exec_data.get("data", {}).get("task_id", list(TASK_STORE.keys())[0])
 
     result = await mcp.call_tool(
-        "pfc_check_task_status",
+        "itasca_check_task_status",
         {"task_id": task_id, "wait_seconds": 1},
     )
 
@@ -262,7 +262,7 @@ async def test_check_task_status_passes_through_bridge_pagination(mock_bridge, t
     monkeypatch.setattr(client, "check_task_status", fake_check)
 
     result = await mcp.call_tool(
-        "pfc_check_task_status",
+        "itasca_check_task_status",
         {"task_id": "abc123", "wait_seconds": 1},
     )
     parsed = json.loads(result.content[0].text)
@@ -278,7 +278,7 @@ async def test_check_task_status_passes_through_bridge_pagination(mock_bridge, t
 @pytest.mark.asyncio
 async def test_check_task_status_not_found(mock_bridge):
     result = await mcp.call_tool(
-        "pfc_check_task_status",
+        "itasca_check_task_status",
         {"task_id": "nonexistent", "wait_seconds": 1},
     )
 
@@ -290,7 +290,7 @@ async def test_check_task_status_not_found(mock_bridge):
         assert parsed["error"]["code"] == "not_found"
 
 
-# ── pfc_list_tasks ───────────────────────────────────────
+# ── itasca_list_tasks ───────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -299,11 +299,11 @@ async def test_list_tasks_with_tasks(mock_bridge, tmp_path):
     script = tmp_path / "job.py"
     script.write_text("print('done')")
     await mcp.call_tool(
-        "pfc_execute_task",
+        "itasca_execute_task",
         {"entry_script": str(script), "description": "list test"},
     )
 
-    result = await mcp.call_tool("pfc_list_tasks", {})
+    result = await mcp.call_tool("itasca_list_tasks", {})
 
     text = result.content[0].text
     parsed = json.loads(text) if text.startswith("{") else None
@@ -325,13 +325,13 @@ async def test_list_tasks_with_tasks(mock_bridge, tmp_path):
         assert "has_more" in data
 
 
-# ── pfc_execute_code ──────────────────────────────────────
+# ── itasca_execute_code ──────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_execute_code_success_fields(mock_bridge):
     result = await mcp.call_tool(
-        "pfc_execute_code",
+        "itasca_execute_code",
         {"code": "print(42)"},
     )
 
@@ -346,13 +346,13 @@ async def test_execute_code_success_fields(mock_bridge):
         assert data["result"] == 42
 
 
-# ── pfc_list_tasks (continued) ──────────────────────────
+# ── itasca_list_tasks (continued) ──────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_list_tasks_empty(mock_bridge):
     # No tasks submitted — TASK_STORE is cleared by fixture
-    result = await mcp.call_tool("pfc_list_tasks", {})
+    result = await mcp.call_tool("itasca_list_tasks", {})
 
     text = result.content[0].text
     parsed = json.loads(text) if text.startswith("{") else None


### PR DESCRIPTION
## Why

The doc corpus now spans **five engines** (PFC, FLAC, 3DEC, MPoint, MassFlow), but the MCP layer still identified itself as a PFC-only server and named all its tools `pfc_*`. For every non-PFC engine an agent drives, that's a name-vs-reality mismatch. This is the de-pfc step of the `itasca-mcp` consolidation (corpus is done; transport + deprecation cutover come later).

## What changed

- **Tool rename (breaking):** all 10 tools `pfc_*` → `itasca_*` (`execute_code`/`execute_task`, `check_task_status`, `interrupt_task`, `list_tasks`, `browse_commands`/`browse_python_api`/`browse_reference`, `query_command`/`query_python_api`), including every docstring cross-reference.
- **Server identity:** `FastMCP` name + instructions now describe the multi-engine Itasca server; package/CLI docstrings follow.
- **Env vars (breaking):** `PFC_MCP_*` → `ITASCA_MCP_*`, clean break, no fallback (matches consolidation house style).
- **Class:** `PFCBridgeClient` → `ItascaBridgeClient`.
- **Docstring/comment sweep:** ~100 infra/runtime references neutralized to engine-neutral wording; execution-runtime notes generalized to "the Itasca engine" with version-gating phrased as engine-version-gated (PFC/FLAC kept as concrete examples).
- **Latent multi-engine display bugs fixed** (surfaced by the sweep): `references/formatter.py` titles/version labels and the `browse_reference` version-unavailable message no longer hardcode `"PFC"` — the latter now uses the requested `software`. Previously these wrongly said "PFC" for FLAC/3DEC lookups.

## Deliberately preserved (PFC-as-engine)

`SUPPORTED_SOFTWARE` `"pfc"`, `DocVersion.PFC`, the PFC contact-type system (`contact.py`/`mappings.py`/`loader.py`), `(PFC, FLAC)` engine enumerations, and PFC reference examples.

## Out of scope (other PRs)

- Repo-coupled bootstrap URL (`yusong652/pfc-mcp/.../pfc-mcp-bootstrap.md`) → release-day.
- WebSocket transport wording / default `ws://` URL → PR2 (transport WS→HTTP+SSE).
- `CLAUDE.md` doc-paths + agentic guides → docs PR.

## Verification

- `ruff check` + `ruff format --check`: clean
- `mypy` (62 source files): clean
- `pytest tests/`: **159 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)