### PR TITLE
refactor: switch bridge transport WS → HTTP+SSE (httpx client)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Guidance for coding agents working in the `pfc-mcp` repository.
 This repository has two runtime contexts:
 
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
-- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
+- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
@@ -18,7 +18,7 @@ End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first inst
 ### MCP side (`src/pfc_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via WebSocket client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
 - Dual execution model: synchronous REPL (`pfc_execute_code`) for quick queries, script-first async (`pfc_execute_task` + `pfc_check_task_status`) for long-running simulations
 
@@ -86,8 +86,10 @@ uv run pytest tests/test_tool_contracts.py
    - If moving shared helpers, keep thin compatibility re-exports when tests or downstream code rely on old import paths.
 
 5. Respect runtime constraints.
-   - MCP package uses modern deps (`websockets>=15`).
-   - Bridge side may require legacy-compatible deps (`websockets==9.1`) in PFC Python.
+   - MCP package talks to the bridge over HTTP (`httpx`).
+   - Bridge side is stdlib-only (HTTP + SSE via `http.server`): no third-party
+     runtime dependency, so it installs into any ITASCA embedded Python (3.6+)
+     with no version pins.
 
 ## Testing Expectations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Guidance for coding agents working in the `pfc-mcp` repository.
 This repository has two runtime contexts:
 
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
-- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
+- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 Treat these as separate deployment targets. End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones.
 
@@ -20,7 +20,7 @@ The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is depre
 ### MCP side (`src/pfc_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via WebSocket client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
 - Dual execution model: synchronous REPL (`pfc_execute_code`) for quick queries, script-first async (`pfc_execute_task` + `pfc_check_task_status`) for long-running simulations
 
@@ -96,8 +96,30 @@ uv run pytest tests/test_tool_contracts.py
    - If moving shared helpers, keep thin compatibility re-exports when tests or downstream code rely on old import paths.
 
 5. Respect runtime constraints.
-   - MCP package uses modern deps (`websockets>=15`).
-   - Bridge side may require legacy-compatible deps (`websockets==9.1`) in PFC Python.
+   - MCP package talks to the bridge over HTTP (`httpx`).
+   - Bridge side is stdlib-only (HTTP + SSE via `http.server`): no third-party
+     runtime dependency, so it installs into any ITASCA embedded Python (3.6+)
+     with no version pins.
+
+6. Judge each dependency by the complexity it carries, not by a blanket
+   "fewer deps is better" rule. The two runtime contexts land on opposite
+   answers for the same reason, not different ones:
+   - Keep a dependency when it owns hard correctness you would not write
+     better yourself. On the MCP side, FastMCP + Pydantic own tool-schema
+     declaration, JSON Schema generation, input validation, and alignment
+     with the MCP protocol — protocol-boundary complexity. Do not reimplement
+     it; do not drop these deps to chase minimalism.
+   - Drop a dependency when it is not carrying real complexity for your
+     semantics. The bridge transport is self-hosted on stdlib HTTP + SSE
+     because the interaction is just request → execute → result, with the
+     server->client push reduced to a payload-free doorbell — a transport
+     library's extra machinery (duplex/heartbeat/version negotiation) is not
+     load-bearing here, and a pinned dependency is itself a liability in the
+     engine's embedded Python.
+   - The rule of thumb: validation at the protocol boundary is outsourced;
+     the execution transport is self-hosted when the semantics are simple
+     enough to not need a library. Minimalism is a consequence of this test,
+     never the goal itself.
 
 ## Testing Expectations
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,7 +9,7 @@ Guidance for coding agents working in the `pfc-mcp` repository.
 This repository has two runtime contexts:
 
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
-- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
+- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
@@ -18,7 +18,7 @@ End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first inst
 ### MCP side (`src/pfc_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via WebSocket client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
 - Uses script-first execution model (`pfc_execute_task` + `pfc_check_task_status`)
 
@@ -85,8 +85,10 @@ uv run pytest tests/test_tool_contracts.py
    - If moving shared helpers, keep thin compatibility re-exports when tests or downstream code rely on old import paths.
 
 5. Respect runtime constraints.
-   - MCP package uses modern deps (`websockets>=15`).
-   - Bridge side may require legacy-compatible deps (`websockets==9.1`) in PFC Python.
+   - MCP package talks to the bridge over HTTP (`httpx`).
+   - Bridge side is stdlib-only (HTTP + SSE via `http.server`): no third-party
+     runtime dependency, so it installs into any ITASCA embedded Python (3.6+)
+     with no version pins.
 
 ## Testing Expectations
 

--- a/WARP.md
+++ b/WARP.md
@@ -9,7 +9,7 @@ Guidance for coding agents working in the `pfc-mcp` repository.
 This repository has two runtime contexts:
 
 - `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
-- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): WebSocket bridge running inside PFC GUI
+- `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
@@ -18,7 +18,7 @@ End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first inst
 ### MCP side (`src/pfc_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via WebSocket client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
 - Uses script-first execution model (`pfc_execute_task` + `pfc_check_task_status`)
 
@@ -85,8 +85,10 @@ uv run pytest tests/test_tool_contracts.py
    - If moving shared helpers, keep thin compatibility re-exports when tests or downstream code rely on old import paths.
 
 5. Respect runtime constraints.
-   - MCP package uses modern deps (`websockets>=15`).
-   - Bridge side may require legacy-compatible deps (`websockets==9.1`) in PFC Python.
+   - MCP package talks to the bridge over HTTP (`httpx`).
+   - Bridge side is stdlib-only (HTTP + SSE via `http.server`): no third-party
+     runtime dependency, so it installs into any ITASCA embedded Python (3.6+)
+     with no version pins.
 
 ## Testing Expectations
 

--- a/addon.py
+++ b/addon.py
@@ -10,7 +10,7 @@ What it does:
 1. Detects the currently installed `itasca-mcp-bridge`, if any
 2. Installs or upgrades `itasca-mcp-bridge` according to `AUTO_UPGRADE`
 3. Ensures the user site-packages directory is importable
-4. Imports `itasca_mcp_bridge` and `websockets`
+4. Imports `itasca_mcp_bridge`
 5. Starts the bridge
 
 Set `AUTO_UPGRADE = False` near the top if you want to pin the locally
@@ -153,14 +153,12 @@ def _import_bridge():
     _ensure_user_site_on_path()
     importlib.invalidate_caches()
 
-    for module_name in ("itasca_mcp_bridge", "websockets"):
-        if module_name in sys.modules:
-            del sys.modules[module_name]
+    if "itasca_mcp_bridge" in sys.modules:
+        del sys.modules["itasca_mcp_bridge"]
 
     import itasca_mcp_bridge
-    import websockets
 
-    return itasca_mcp_bridge, websockets
+    return itasca_mcp_bridge
 
 
 def _should_install(current_version):
@@ -199,10 +197,9 @@ def main():
                 "    python -m pip install --user itasca-mcp-bridge".format(code)
             )
 
-    itasca_mcp_bridge, websockets = _import_bridge()
+    itasca_mcp_bridge = _import_bridge()
 
     print("Using itasca-mcp-bridge:", getattr(itasca_mcp_bridge, "__version__", "unknown"))
-    print("Installed websockets:", getattr(websockets, "__version__", "unknown"))
     print("Starting bridge on port {} ...".format(PORT))
 
     # This script already handled install/upgrade above; tell start() to skip

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,7 +53,7 @@ Endpoints:
 
 | URL | When | What it is |
 | --- | --- | --- |
-| `ws://localhost:9001` | always | itasca-mcp-bridge — point your MCP client here |
+| `http://localhost:9001` | always | itasca-mcp-bridge — point your MCP client here |
 | `http://localhost:6080/vnc.html` | `--gui` only | PFC's Qt GUI in your browser via noVNC |
 
 Console mode (default) runs `pfc3d9_console` with the bridge on a blocking

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@
 #
 # After it boots:
 #   - GUI in browser:  http://localhost:6080/vnc.html
-#   - Bridge socket:   ws://localhost:9001
+#   - Bridge socket:   http://localhost:9001
 #
 # Stop with Ctrl-C (or `docker compose down` from another terminal).
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@
 #
 # Default (console mode, lighter):
 #   pfc3d9_console + bridge with blocking task pump.
-#   No X stack started -- ws://localhost:9001 only.
+#   No X stack started -- http://localhost:9001 only.
 #
 # GUI mode (set PFC_GUI=1):
 #   In-container X stack (Xvfb + fluxbox + x11vnc + noVNC) + pfc3d9_gui
@@ -23,7 +23,7 @@ cd /workspace 2>/dev/null || true
 # never runs its event loop, so mode=auto (bridge >= 0.1.4, PySide6 probe)
 # would attach a QTimer that never fires and return from start(), parking
 # the main thread at the console prompt -- which starves every bridge
-# thread and leaves ws://:9001 accepting TCP but never answering.
+# thread and leaves http://:9001 accepting TCP but never answering.
 BRIDGE_MODE=console
 if [ "${PFC_GUI:-}" = "1" ]; then
     BRIDGE_MODE=gui
@@ -63,7 +63,7 @@ if [ "${PFC_GUI:-}" = "1" ]; then
 
     echo "================================================================"
     echo "  GUI:     http://localhost:6080/vnc.html"
-    echo "  bridge:  ws://localhost:9001"
+    echo "  bridge:  http://localhost:9001"
     echo "================================================================"
 
     if [ "$#" -eq 0 ]; then
@@ -75,7 +75,7 @@ fi
 
 # ── Console mode (default) ────────────────────────────────────
 echo "================================================================"
-echo "  bridge:  ws://localhost:9001"
+echo "  bridge:  http://localhost:9001"
 echo "  (set PFC_GUI=1 to also expose the GUI via noVNC)"
 echo "================================================================"
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -28,7 +28,7 @@ echo "[run.sh] Bringing up pfc-mcp..."
 if [ "${PFC_GUI:-}" = "1" ]; then
     echo "  GUI:    http://localhost:6080/vnc.html"
 fi
-echo "  bridge: ws://localhost:9001"
+echo "  bridge: http://localhost:9001"
 echo "  stop with Ctrl-C"
 echo ""
 

--- a/docs/agentic/pfc-mcp-bootstrap.md
+++ b/docs/agentic/pfc-mcp-bootstrap.md
@@ -166,19 +166,6 @@ Verify import and version:
 
 Ignore pip upgrade warnings in this environment. Older embedded interpreters commonly use older pip builds.
 
-If websocket dependency errors appear, install the version that matches the embedded Python:
-
-```powershell
-# PFC 6.0/7.0
-& "{pfc_python}" -m pip install --user websockets==9.1
-
-# PFC 9.0
-& "{pfc_python}" -m pip install --user websockets==16.0
-```
-
-If PyPI is unreachable here too, add the same `--index-url` /
-`--trusted-host` Tsinghua-mirror flags shown above.
-
 ## Step 4 - Start Bridge in PFC GUI
 
 [AGENT]
@@ -215,7 +202,7 @@ installed version.
 Expected output includes:
 
 - `Itasca MCP Bridge Server`
-- `ws://localhost:9001`
+- `http://localhost:9001`
 - `Task loop running via Qt timer`
 
 ## Step 5 - Verify from MCP Client
@@ -253,8 +240,6 @@ Success example (shape may vary by client):
     <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/addon.py> into the
     PFC IPython console -- it installs (with mirror fallback) and starts the
     bridge in one go.
-- `No module named websockets`:
-  - Install `websockets==9.1` for PFC 6/7 or `websockets==16.0` for PFC 9 in the embedded Python environment.
 - `status remains pending / plot diagnostic timeout during solve`:
   - Upgrade to the latest `itasca-mcp-bridge` release.
 - `pip` upgrade warning after install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "fastmcp>=3.0.0",
     "pydantic>=2.12.0",
-    "websockets>=15.0.1",
+    "httpx>=0.27",
 ]
 readme = "README.md"
 

--- a/src/itasca_mcp/bridge/client.py
+++ b/src/itasca_mcp/bridge/client.py
@@ -1,4 +1,11 @@
-"""WebSocket client for communicating with the Itasca bridge server."""
+"""HTTP + SSE client for communicating with the itasca-mcp-bridge.
+
+Commands are plain ``POST /<command>`` request/response. The one
+server->client doorbell (``task_status_changed``) arrives on a single
+long-lived ``GET /events`` Server-Sent Events stream consumed in the
+background. The bridge speaks stdlib HTTP, so there is no third-party
+dependency on the engine side.
+"""
 
 import asyncio
 import json
@@ -6,7 +13,7 @@ import logging
 from typing import Any
 from uuid import uuid4
 
-import websockets
+import httpx
 
 from itasca_mcp.config import get_bridge_config
 
@@ -14,7 +21,7 @@ logger = logging.getLogger("itasca-mcp.bridge")
 
 
 class ItascaBridgeClient:
-    """Async request/response client for itasca-mcp-bridge WebSocket protocol."""
+    """Async request/response client for the itasca-mcp-bridge HTTP + SSE protocol."""
 
     def __init__(
         self,
@@ -30,108 +37,109 @@ class ItascaBridgeClient:
         self.request_timeout_s = request_timeout_s
         self.auto_reconnect = auto_reconnect
 
-        self._websocket: Any | None = None
-        self._receiver_task: asyncio.Task[Any] | None = None
-        self._pending_requests: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._client: httpx.AsyncClient | None = None
+        self._sse_task: asyncio.Task[Any] | None = None
         self._task_events: dict[str, asyncio.Event] = {}
         self._lock = asyncio.Lock()
 
     @property
     def connected(self) -> bool:
-        return self._websocket is not None
+        return self._client is not None
 
     async def connect(self) -> None:
         async with self._lock:
-            if self._websocket is not None:
+            if self._client is not None:
                 return
-            self._websocket = await websockets.connect(self.url, compression=None, max_size=50 * 2**20)
-            self._receiver_task = asyncio.create_task(self._receive_loop())
+            # Per-request timeouts are set on each POST; the SSE stream uses an
+            # unbounded read timeout because it stays open between doorbells.
+            self._client = httpx.AsyncClient(base_url=self.url)
+            self._sse_task = asyncio.create_task(self._sse_loop())
             logger.info("Connected to itasca-mcp-bridge at %s", self.url)
 
     async def disconnect(self) -> None:
         async with self._lock:
-            receiver_task = self._receiver_task
-            websocket = self._websocket
-            self._receiver_task = None
-            self._websocket = None
+            sse_task = self._sse_task
+            client = self._client
+            self._sse_task = None
+            self._client = None
 
-        if receiver_task is not None:
-            receiver_task.cancel()
+        if sse_task is not None:
+            sse_task.cancel()
             try:
-                await receiver_task
+                await sse_task
             except asyncio.CancelledError:
                 pass
 
-        if websocket is not None:
+        if client is not None:
             try:
-                await websocket.close()
+                await client.aclose()
             except Exception:
                 pass
-
-        self._fail_pending(ConnectionError("Connection closed"))
 
     async def _ensure_connected(self) -> None:
         if self.connected:
             return
         await self.connect()
 
-    def _fail_pending(self, exc: Exception) -> None:
-        pending = list(self._pending_requests.values())
-        self._pending_requests.clear()
-        for future in pending:
-            if not future.done():
-                future.set_exception(exc)
+    async def _sse_loop(self) -> None:
+        """Consume the server's SSE doorbell stream.
 
-    async def _receive_loop(self) -> None:
-        assert self._websocket is not None
-        try:
-            async for raw_message in self._websocket:
-                payload = json.loads(raw_message)
-                msg_type = payload.get("type")
+        The only load-bearing event is ``task_status_changed`` -> wake any
+        waiter registered via ``listen_for_task``. SSE is best-effort: a missed
+        doorbell is covered by the caller's mandatory status re-poll, so the
+        stream simply reconnects on drop.
+        """
+        sse_timeout = httpx.Timeout(self.request_timeout_s, read=None)
+        while True:
+            client = self._client
+            if client is None:
+                return
+            try:
+                async with client.stream("GET", "/events", timeout=sse_timeout) as response:
+                    async for line in response.aiter_lines():
+                        # SSE frames: "data: {json}" lines; ":" comment lines
+                        # are keepalives; blank lines separate events.
+                        if not line.startswith("data:"):
+                            continue
+                        raw = line[5:].strip()
+                        if not raw:
+                            continue
+                        try:
+                            payload = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        if payload.get("type") == "task_status_changed":
+                            event = self._task_events.get(payload.get("task_id", ""))
+                            if event is not None:
+                                event.set()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Bridge SSE stream dropped: %s", exc)
 
-                # Handle push notification for task completion
-                if msg_type == "task_status_changed":
-                    task_id = payload.get("task_id", "")
-                    event = self._task_events.get(task_id)
-                    if event:
-                        event.set()
-                    continue
-
-                if msg_type not in {"result", "execute_code_result"}:
-                    continue
-                request_id = payload.get("request_id")
-                if not request_id:
-                    continue
-                future = self._pending_requests.pop(request_id, None)
-                if future and not future.done():
-                    future.set_result(payload)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.warning("Bridge receive loop stopped: %s", exc)
-        finally:
-            async with self._lock:
-                self._websocket = None
-                self._receiver_task = None
-            self._fail_pending(ConnectionError("Bridge connection lost"))
+            if self._client is None:
+                return
+            await asyncio.sleep(self.reconnect_interval_s)
 
     async def _send_request(self, message: dict[str, Any], timeout_s: float) -> dict[str, Any]:
         await self._ensure_connected()
-        assert self._websocket is not None
+        assert self._client is not None
 
         request_id = message.get("request_id") or str(uuid4())
         message["request_id"] = request_id
-
-        loop = asyncio.get_event_loop()
-        future: asyncio.Future[dict[str, Any]] = loop.create_future()
-        self._pending_requests[request_id] = future
+        command = message["type"]
 
         try:
-            await self._websocket.send(json.dumps(message))
-            return await asyncio.wait_for(future, timeout=timeout_s)
-        except asyncio.TimeoutError as exc:
-            self._pending_requests.pop(request_id, None)
+            response = await self._client.post(f"/{command}", json=message, timeout=timeout_s)
+        except httpx.TimeoutException as exc:
             raise TimeoutError(f"Bridge request timed out after {timeout_s:.1f}s") from exc
+
+        # The bridge returns 200 for every envelope, including ok:false
+        # application errors. A non-2xx is a transport/protocol fault
+        # (malformed request, unknown command, internal crash).
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+        return payload
 
     async def _request_with_retry(
         self,
@@ -148,7 +156,6 @@ class ItascaBridgeClient:
                 return await self._send_request(message, timeout)
             except Exception as exc:
                 last_error = exc
-                await self.disconnect()
                 if not self.auto_reconnect or attempt >= attempts:
                     break
                 await asyncio.sleep(self.reconnect_interval_s)
@@ -253,16 +260,6 @@ class ItascaBridgeClient:
             operation_name="execute_code",
             timeout_s=timeout_s,
         )
-
-    async def get_working_directory(self) -> str | None:
-        response = await self._request_with_retry(
-            {"type": "get_working_directory"},
-            operation_name="get_working_directory",
-        )
-        if response.get("status") != "success":
-            return None
-        data = response.get("data") or {}
-        return data.get("working_directory")
 
 
 _client: ItascaBridgeClient | None = None

--- a/src/itasca_mcp/config.py
+++ b/src/itasca_mcp/config.py
@@ -43,7 +43,7 @@ class BridgeConfig:
 def get_bridge_config() -> BridgeConfig:
     """Load bridge config from environment variables."""
     return BridgeConfig(
-        url=os.getenv("ITASCA_MCP_BRIDGE_URL", "ws://localhost:9001"),
+        url=os.getenv("ITASCA_MCP_BRIDGE_URL", "http://localhost:9001"),
         reconnect_interval_s=_env_float("ITASCA_MCP_RECONNECT_INTERVAL_S", 0.5),
         max_retries=max(0, _env_int("ITASCA_MCP_MAX_RETRIES", 2)),
         request_timeout_s=max(1.0, _env_float("ITASCA_MCP_REQUEST_TIMEOUT_S", 10.0)),

--- a/src/itasca_mcp/server.py
+++ b/src/itasca_mcp/server.py
@@ -52,14 +52,14 @@ interrupt_task.register(mcp)
 execute_code.register(mcp)
 
 
-DEFAULT_BRIDGE_URL = "ws://localhost:9001"
+DEFAULT_BRIDGE_URL = "http://localhost:9001"
 
 
 def _override_bridge_port(url: str, port: int) -> str:
     """Return ``url`` with its port replaced, preserving scheme/host/path."""
     parts = urlsplit(url)
     host = parts.hostname or "localhost"
-    return urlunsplit((parts.scheme or "ws", f"{host}:{port}", parts.path, parts.query, parts.fragment))
+    return urlunsplit((parts.scheme or "http", f"{host}:{port}", parts.path, parts.query, parts.fragment))
 
 
 def main() -> None:
@@ -89,14 +89,14 @@ def main() -> None:
     parser.add_argument(
         "--bridge-url",
         default=None,
-        help="Bridge WebSocket URL (default: ws://localhost:9001, or ITASCA_MCP_BRIDGE_URL env)",
+        help="Bridge HTTP URL (default: http://localhost:9001, or ITASCA_MCP_BRIDGE_URL env)",
     )
     parser.add_argument(
         "--bridge-port",
         type=int,
         default=None,
         help=(
-            "Bridge WebSocket port; shorthand for --bridge-url ws://localhost:PORT. "
+            "Bridge HTTP port; shorthand for --bridge-url http://localhost:PORT. "
             "Overrides only the port of --bridge-url / ITASCA_MCP_BRIDGE_URL when both "
             "are given (default: 9001)"
         ),
@@ -112,7 +112,7 @@ def main() -> None:
     # Resolve the bridge URL from (in order of precedence) --bridge-url,
     # the ITASCA_MCP_BRIDGE_URL env, then the default. --bridge-port then
     # overrides just the port, so users can point at a non-default bridge
-    # port without spelling out the whole ws:// URL.
+    # port without spelling out the whole http:// URL.
     bridge_url = args.bridge_url or os.environ.get("ITASCA_MCP_BRIDGE_URL")
     if args.bridge_port is not None:
         if not 1 <= args.bridge_port <= 65535:

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -4,13 +4,15 @@ Verifies that each tool returns the expected field structure,
 ensuring the API contract between pfc-mcp and its consumers is stable.
 """
 
+import http.server
 import json
 import os
+import socketserver
+import threading
 import time
 from pathlib import Path
 
 import pytest
-import websockets
 
 from itasca_mcp.bridge.client import close_bridge_client
 from itasca_mcp.server import mcp
@@ -21,116 +23,161 @@ from itasca_mcp.server import mcp
 TASK_STORE = {}
 
 
-async def _mock_bridge_handler(websocket):
-    """Mock itasca-mcp-bridge that handles all task-related message types."""
-    async for raw in websocket:
-        req = json.loads(raw)
-        req_id = req.get("request_id", "unknown")
-        msg_type = req.get("type", "execute_task")
+def _build_response(msg_type, req):
+    """Build the mock bridge response for a single request (transport-agnostic)."""
+    req_id = req.get("request_id", "unknown")
 
-        if msg_type == "execute_task":
-            task_id = req.get("task_id", "000000")
-            TASK_STORE[task_id] = {
-                "status": "running",
-                "start_time": time.time(),
-                "script_path": req.get("script_path", ""),
-                "description": req.get("description", ""),
-            }
-            resp = {
+    if msg_type == "execute_task":
+        task_id = req.get("task_id", "000000")
+        TASK_STORE[task_id] = {
+            "status": "running",
+            "start_time": time.time(),
+            "script_path": req.get("script_path", ""),
+            "description": req.get("description", ""),
+        }
+        return {
+            "type": "result",
+            "request_id": req_id,
+            "status": "pending",
+            "message": f"Script submitted: {Path(req.get('script_path', '')).name}",
+        }
+
+    if msg_type == "check_task_status":
+        task_id = req.get("task_id", "")
+        stored = TASK_STORE.get(task_id)
+        if stored:
+            return {
                 "type": "result",
                 "request_id": req_id,
-                "status": "pending",
-                "message": f"Script submitted: {Path(req.get('script_path', '')).name}",
-            }
-
-        elif msg_type == "check_task_status":
-            task_id = req.get("task_id", "")
-            stored = TASK_STORE.get(task_id)
-            if stored:
-                resp = {
-                    "type": "result",
-                    "request_id": req_id,
-                    "status": stored["status"],
-                    "message": "ok",
-                    "data": {
-                        "task_id": task_id,
-                        "status": stored["status"],
-                        "start_time": stored["start_time"],
-                        "end_time": None,
-                        "elapsed_time": "5.0s",
-                        "script_path": stored["script_path"],
-                        "description": stored["description"],
-                        "output": "Cycle 100: unbalanced=1e-3\nCycle 200: unbalanced=5e-4\n",
-                        "result": None,
-                        "error": None,
-                    },
-                }
-            else:
-                resp = {
-                    "type": "result",
-                    "request_id": req_id,
-                    "status": "not_found",
-                    "message": f"Task not found: {task_id}",
-                    "data": None,
-                }
-
-        elif msg_type == "list_tasks":
-            tasks = [
-                {
-                    "task_id": tid,
-                    "status": t["status"],
-                    "source": "agent",
-                    "elapsed_time": "5.0s",
-                    "entry_script": t["script_path"],
-                    "description": t["description"],
-                }
-                for tid, t in TASK_STORE.items()
-            ]
-            resp = {
-                "type": "result",
-                "request_id": req_id,
-                "status": "success",
-                "message": f"Found {len(tasks)} task(s)",
-                "data": tasks,
-                "pagination": {
-                    "total_count": len(tasks),
-                    "displayed_count": len(tasks),
-                    "offset": 0,
-                    "limit": 32,
-                    "has_more": False,
-                },
-            }
-
-        elif msg_type == "interrupt_task":
-            resp = {
-                "type": "result",
-                "request_id": req_id,
-                "status": "success",
-                "message": f"Interrupt requested for task: {req.get('task_id')}",
-                "data": {"task_id": req.get("task_id"), "interrupt_requested": True},
-            }
-
-        elif msg_type == "execute_code":
-            resp = {
-                "type": "execute_code_result",
-                "request_id": req_id,
-                "status": "success",
-                "message": "Code executed",
+                "status": stored["status"],
+                "message": "ok",
                 "data": {
-                    "output": "42\n",
-                    "result": 42,
+                    "task_id": task_id,
+                    "status": stored["status"],
+                    "start_time": stored["start_time"],
+                    "end_time": None,
+                    "elapsed_time": "5.0s",
+                    "script_path": stored["script_path"],
+                    "description": stored["description"],
+                    "output": "Cycle 100: unbalanced=1e-3\nCycle 200: unbalanced=5e-4\n",
+                    "result": None,
+                    "error": None,
                 },
             }
+        return {
+            "type": "result",
+            "request_id": req_id,
+            "status": "not_found",
+            "message": f"Task not found: {task_id}",
+            "data": None,
+        }
 
-        else:
-            resp = {
-                "type": "result",
-                "request_id": req_id,
-                "status": "error",
-                "message": f"unsupported: {msg_type}",
+    if msg_type == "list_tasks":
+        tasks = [
+            {
+                "task_id": tid,
+                "status": t["status"],
+                "source": "agent",
+                "elapsed_time": "5.0s",
+                "entry_script": t["script_path"],
+                "description": t["description"],
             }
+            for tid, t in TASK_STORE.items()
+        ]
+        return {
+            "type": "result",
+            "request_id": req_id,
+            "status": "success",
+            "message": f"Found {len(tasks)} task(s)",
+            "data": tasks,
+            "pagination": {
+                "total_count": len(tasks),
+                "displayed_count": len(tasks),
+                "offset": 0,
+                "limit": 32,
+                "has_more": False,
+            },
+        }
 
-        await websocket.send(json.dumps(resp))
+    if msg_type == "interrupt_task":
+        return {
+            "type": "result",
+            "request_id": req_id,
+            "status": "success",
+            "message": f"Interrupt requested for task: {req.get('task_id')}",
+            "data": {"task_id": req.get("task_id"), "interrupt_requested": True},
+        }
+
+    if msg_type == "execute_code":
+        return {
+            "type": "execute_code_result",
+            "request_id": req_id,
+            "status": "success",
+            "message": "Code executed",
+            "data": {
+                "output": "42\n",
+                "result": 42,
+            },
+        }
+
+    return {
+        "type": "result",
+        "request_id": req_id,
+        "status": "error",
+        "message": f"unsupported: {msg_type}",
+    }
+
+
+class _MockBridgeHandler(http.server.BaseHTTPRequestHandler):
+    """Mock itasca-mcp-bridge over HTTP + SSE, mirroring the real transport.
+
+    ``POST /<command>`` dispatches to ``_build_response``; ``GET /events``
+    serves a keepalive-only SSE stream (no doorbells needed: the contract
+    tests re-poll status directly).
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        if self.path.split("?", 1)[0] != "/events":
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        try:
+            self.wfile.write(b": connected\n\n")
+            self.wfile.flush()
+            while not self.server.stop_event.is_set():
+                self.wfile.write(b": keepalive\n\n")
+                self.wfile.flush()
+                time.sleep(0.2)
+        except (BrokenPipeError, ConnectionResetError, ValueError, OSError):
+            pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length > 0 else b""
+        req = json.loads(raw.decode("utf-8")) if raw else {}
+        command = self.path.split("?", 1)[0].strip("/")
+        resp = _build_response(command, req)
+        body = json.dumps(resp).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class _ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
 
 
 @pytest.fixture()
@@ -138,11 +185,14 @@ async def mock_bridge(tmp_path):
     """Start mock bridge and configure environment."""
     TASK_STORE.clear()
 
-    server = await websockets.serve(_mock_bridge_handler, "127.0.0.1", 0)
-    port = server.sockets[0].getsockname()[1]
+    server = _ThreadingHTTPServer(("127.0.0.1", 0), _MockBridgeHandler)
+    server.stop_event = threading.Event()
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
 
     prev = os.environ.get("ITASCA_MCP_BRIDGE_URL")
-    os.environ["ITASCA_MCP_BRIDGE_URL"] = f"ws://127.0.0.1:{port}"
+    os.environ["ITASCA_MCP_BRIDGE_URL"] = f"http://127.0.0.1:{port}"
 
     await close_bridge_client()
 
@@ -153,8 +203,9 @@ async def mock_bridge(tmp_path):
         os.environ.pop("ITASCA_MCP_BRIDGE_URL", None)
     else:
         os.environ["ITASCA_MCP_BRIDGE_URL"] = prev
-    server.close()
-    await server.wait_closed()
+    server.stop_event.set()
+    server.shutdown()
+    server.server_close()
 
 
 # ── itasca_execute_task ─────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -744,8 +744,8 @@ name = "itasca-mcp"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "httpx" },
     { name = "pydantic" },
-    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -760,8 +760,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.12.0" },
-    { name = "websockets", specifier = ">=15.0.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
MCP-side counterpart to itasca-mcp-bridge PR #22 (HTTP + SSE transport). Pairs with the bridge change so the whole pipeline drops WebSocket for stdlib HTTP.

## MCP client
- `bridge/client.py`: `websockets` → `httpx.AsyncClient`. `POST /<command>` request/response; a background `GET /events` SSE loop consumes the `task_status_changed` doorbell (`listen_for_task` / `wait_for_task` unchanged; re-poll is the correctness backstop).
- `config.py` + server CLI + `DEFAULT_BRIDGE_URL`: `ws://` → `http://` (port unchanged, 9001).
- `pyproject.toml`: `websockets>=15` → `httpx>=0.27`.
- `tests/test_tool_contracts.py`: WS mock bridge re-implemented on a stdlib `ThreadingHTTPServer`.

## Cleanup
- `get_working_directory` client method removed (dead — no tool called it; agents query cwd via `execute_code`).
- Swept now-stale `websockets` residue: `addon.py` (a runtime break — it imported `websockets` after the bridge went zero-dep), `docker/` banners (`ws://` → `http://`), agent-facing docs (`CLAUDE`/`AGENTS`/`GEMINI`/`WARP` engineering rules, agentic bootstrap). Docs describe current state, no migration narrative.
- Pure install docs (bridge README, `docs/development/source-install.*`) deferred to the release-day docs pass.

## Submodule
- Pin bumped to the merged bridge transport commit `f14f6ae`.

## Verification
- 159 MCP tests + ruff/format/mypy green; bridge 92 tests green.
- Live-verified end-to-end against real PFC3D9: `execute_code` / `execute_task` / `check_task_status`, `pending → running → completed` and `→ failed`, concurrent POST-during-SSE, output interleaving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)