### PR TITLE
feat: flag figure-defined command docs as text-incomplete

### DIFF
--- a/scripts/corpus/flag_figure_defined.py
+++ b/scripts/corpus/flag_figure_defined.py
@@ -1,0 +1,198 @@
+"""Flag figure-defined command docs across the whole command corpus.
+
+Many Itasca primitive/geometry commands define their geometry -- reference-point
+ordering, ``size`` -> direction mapping, and ``dimension`` meaning -- ONLY in
+figures. The corpus is extracted from HTML ``<dt>``/``<dd>`` text (see
+``parse_pfc*.py``) and drops ``<img>`` thumbnails, so the text repeatedly defers
+to "the figures above" / "the reference images" without ever stating the
+convention. An agent reading the text alone cannot use these commands correctly
+(observed on ``zone create2d`` annular-sector / sector-quad: point order and the
+``s1 s2 s3`` directions are figure-only).
+
+This post-processing pass scans every command doc for figure-deferral phrases
+and, when found, annotates the affected version entry with a structured
+``figure_reference`` flag. The flag flows untouched through
+``CommandLoader._resolve_versioned_doc`` (which does ``resolved.update(version_doc)``)
+into the ``doc`` payload of ``itasca_browse_commands`` -- so the gap becomes
+visible to agents at query time, for *every* figure-defined command, without
+hand-authoring per-command content.
+
+It does not invent the missing geometry; it marks the text as incomplete and
+points at the reliable recovery path (probe the engine empirically).
+
+Idempotent: re-running recomputes the flag from scratch (stale flags are
+removed when the deferral text is gone).
+
+Usage:
+    uv run python scripts/corpus/flag_figure_defined.py
+    uv run python scripts/corpus/flag_figure_defined.py --check   # exit 1 if stale (CI guard)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+RESOURCES = Path(__file__).resolve().parents[2] / "src" / "itasca_mcp" / "knowledge" / "resources"
+
+FLAG_KEY = "figure_reference"
+
+# Phrases in the extracted text that defer to a figure/image the corpus dropped.
+# Case-insensitive. Kept deliberately specific so prose that merely mentions a
+# "figure of merit" etc. is not swept in.
+DEFERRAL_PATTERNS: tuple[str, ...] = (
+    r"refer to the figures?\b",
+    r"refer to figures?\b",
+    r"see the figures?\b",
+    r"\bfigures?\s+above\b",
+    r"\breference images?\b",
+    r"illustrated in the reference",
+    r"shown in the reference image",
+    r"click (?:on )?any thumbnail",
+    r"\bthumbnails?\b",
+)
+
+_COMPILED = [re.compile(p, re.IGNORECASE) for p in DEFERRAL_PATTERNS]
+
+NOTE = (
+    "This command's documentation refers to figures/images in the source manual that "
+    "are not captured in this text corpus. Geometric or parametric detail conveyed only "
+    "by those figures -- e.g. reference-point ordering (point 0..N), the size -> direction "
+    "mapping, dimension meaning, or split/subdivision patterns -- may therefore be missing "
+    "below. Do not guess it: confirm the specifics from the engine itself, e.g. build the "
+    "construct and read back the resulting gridpoints/zones via itasca_execute_code."
+)
+
+# Cap how many sample sentences we store, to keep the corpus from bloating.
+MAX_DEFERRALS = 6
+
+
+def _find_deferrals(text: str) -> list[str]:
+    """Return the distinct sentences in ``text`` that defer to a figure."""
+    hits: list[str] = []
+    for sentence in re.split(r"(?<=[.;])\s+", text or ""):
+        s = sentence.strip()
+        if not s:
+            continue
+        if any(rx.search(s) for rx in _COMPILED):
+            hits.append(s)
+    return hits
+
+
+def _collect_text(doc: dict[str, Any], version_doc: dict[str, Any]) -> list[str]:
+    """Gather every free-text field that an agent would read for one version."""
+    texts: list[str] = []
+    # Top-level description is shared across versions.
+    if isinstance(doc.get("description"), str):
+        texts.append(doc["description"])
+    if isinstance(version_doc.get("description"), str):
+        texts.append(version_doc["description"])
+    for kw in version_doc.get("keywords", []) or []:
+        if isinstance(kw, dict) and isinstance(kw.get("description"), str):
+            texts.append(kw["description"])
+    return texts
+
+
+def _build_flag(texts: list[str]) -> dict[str, Any] | None:
+    """Return the figure_reference flag for the given texts, or None."""
+    deferrals: list[str] = []
+    seen: set[str] = set()
+    for text in texts:
+        for hit in _find_deferrals(text):
+            if hit not in seen:
+                seen.add(hit)
+                deferrals.append(hit)
+    if not deferrals:
+        return None
+    return {
+        "text_incomplete": True,
+        "note": NOTE,
+        "deferrals": deferrals[:MAX_DEFERRALS],
+    }
+
+
+def _apply_to_doc(doc: dict[str, Any]) -> bool:
+    """Annotate ``doc`` in place. Return True if anything changed."""
+    changed = False
+    versions = doc.get("versions")
+
+    if isinstance(versions, dict):
+        # Versioned schema: flag each available version independently.
+        for _ver, version_doc in versions.items():
+            if not isinstance(version_doc, dict):
+                continue
+            if version_doc.get("available") is False:
+                # No content for this version; never carries a flag.
+                if version_doc.pop(FLAG_KEY, None) is not None:
+                    changed = True
+                continue
+            flag = _build_flag(_collect_text(doc, version_doc))
+            changed |= _set_or_clear(version_doc, flag)
+    else:
+        # Flat schema: flag at the top level.
+        flag = _build_flag(_collect_text(doc, doc))
+        changed |= _set_or_clear(doc, flag)
+
+    return changed
+
+
+def _set_or_clear(target: dict[str, Any], flag: dict[str, Any] | None) -> bool:
+    """Set ``FLAG_KEY`` to ``flag`` or remove it. Return True if it changed."""
+    if flag is None:
+        return target.pop(FLAG_KEY, None) is not None
+    if target.get(FLAG_KEY) == flag:
+        return False
+    target[FLAG_KEY] = flag
+    return True
+
+
+def iter_command_docs() -> list[Path]:
+    """All command-doc JSON files across every engine corpus."""
+    return sorted(RESOURCES.glob("*/command_docs/commands/**/*.json"))
+
+
+def main(argv: list[str]) -> int:
+    check_only = "--check" in argv
+    stale: list[Path] = []
+    flagged = 0
+
+    for path in iter_command_docs():
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        # Gate writes on a real content change so we never reflow (and churn the
+        # trailing-newline of) docs whose flag state is unaffected.
+        if _apply_to_doc(doc):
+            stale.append(path)
+            if not check_only:
+                path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+        # Count docs that ended up flagged (any version).
+        if _doc_is_flagged(doc):
+            flagged += 1
+
+    rel = RESOURCES
+    if check_only:
+        if stale:
+            print(f"[STALE] {len(stale)} command doc(s) need re-flagging:")
+            for p in stale:
+                print(f"  {p.relative_to(rel.parents[0])}")
+            print("Run: uv run python scripts/corpus/flag_figure_defined.py")
+            return 1
+        print(f"figure_reference flags up to date ({flagged} flagged docs).")
+        return 0
+
+    print(f"Updated {len(stale)} file(s); {flagged} command doc(s) now carry a figure_reference flag.")
+    return 0
+
+
+def _doc_is_flagged(doc: dict[str, Any]) -> bool:
+    versions = doc.get("versions")
+    if isinstance(versions, dict):
+        return any(isinstance(v, dict) and FLAG_KEY in v for v in versions.values())
+    return FLAG_KEY in doc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/densify.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/densify.json
@@ -49,7 +49,14 @@
           "description": "Tetrahedral blocks will be split by first making cuts through the midpoint of each edge. This results in four new tetrahedra and an octahedron in the center. The octahedron is then split into four tetrahedra with two further cuts along the diagonals (see the figure below). Note that if the tet keyword is given, the \\(segments\\) value is ignored for tetrahedral blocks. Blocks that are not tetrahedral are split normally along the global x,y and z axes."
         }
       ],
-      "examples": []
+      "examples": [],
+      "figure_reference": {
+        "text_incomplete": true,
+        "note": "This command's documentation refers to figures/images in the source manual that are not captured in this text corpus. Geometric or parametric detail conveyed only by those figures -- e.g. reference-point ordering (point 0..N), the size -> direction mapping, dimension meaning, or split/subdivision patterns -- may therefore be missing below. Do not guess it: confirm the specifics from the engine itself, e.g. build the construct and read back the resulting gridpoints/zones via itasca_execute_code.",
+        "deferrals": [
+          "The octahedron is then split into four tetrahedra with two further cuts along the diagonals (see the figure below)."
+        ]
+      }
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create.json
@@ -130,6 +130,15 @@
         ],
         "syntax_basis": "official FLAC3D 6.0 detailed command page",
         "target_version": "6.0"
+      },
+      "figure_reference": {
+        "text_incomplete": true,
+        "note": "This command's documentation refers to figures/images in the source manual that are not captured in this text corpus. Geometric or parametric detail conveyed only by those figures -- e.g. reference-point ordering (point 0..N), the size -> direction mapping, dimension meaning, or split/subdivision patterns -- may therefore be missing below. Do not guess it: confirm the specifics from the engine itself, e.g. build the construct and read back the resulting gridpoints/zones via itasca_execute_code.",
+        "deferrals": [
+          "Refer to the figures above for entries and dimensions.",
+          "For each shape, the entries and their associated zone directions are shown in the reference images (click any thumbnail above).",
+          "The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above)."
+        ]
       }
     },
     "7.0": {
@@ -266,6 +275,15 @@
         ],
         "syntax_basis": "official FLAC3D 7.0 detailed command page",
         "target_version": "7.0"
+      },
+      "figure_reference": {
+        "text_incomplete": true,
+        "note": "This command's documentation refers to figures/images in the source manual that are not captured in this text corpus. Geometric or parametric detail conveyed only by those figures -- e.g. reference-point ordering (point 0..N), the size -> direction mapping, dimension meaning, or split/subdivision patterns -- may therefore be missing below. Do not guess it: confirm the specifics from the engine itself, e.g. build the construct and read back the resulting gridpoints/zones via itasca_execute_code.",
+        "deferrals": [
+          "Refer to the figures above for entries and dimensions.",
+          "For each shape, the entries and their associated zone directions are shown in the reference images (click any thumbnail above).",
+          "The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above)."
+        ]
       }
     },
     "9.0": {
@@ -382,7 +400,17 @@
           "syntax": "sweep-axis",
           "description": "When this keyword is given, edge point 0 - point 2 is used as an axis about which edges point 1 - point 4 and point 3 - point 5 are swept. Without this keyword, the grid faces fall on the ( point 0 , point 1 , point 3 ) and ( point 2 , point 4 , point 5 ) planes. This keyword can only be used with the following keywords of the zone create command: cylinder , and cylindrical-shell ."
         }
-      ]
+      ],
+      "figure_reference": {
+        "text_incomplete": true,
+        "note": "This command's documentation refers to figures/images in the source manual that are not captured in this text corpus. Geometric or parametric detail conveyed only by those figures -- e.g. reference-point ordering (point 0..N), the size -> direction mapping, dimension meaning, or split/subdivision patterns -- may therefore be missing below. Do not guess it: confirm the specifics from the engine itself, e.g. build the construct and read back the resulting gridpoints/zones via itasca_execute_code.",
+        "deferrals": [
+          "Refer to the figures above for entries and dimensions.",
+          "The locations of these points are illustrated in the reference images (click on any thumbnail above to access).",
+          "For each shape, the entries and their associated zone directions are shown in the reference images (click any thumbnail above).",
+          "The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above)."
+        ]
+      }
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create2d.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create2d.json
@@ -105,7 +105,17 @@
           "syntax": "size <i1>[<i2>... ]",
           "description": "This specifies the number of zones for each shape. Up to three ( i3 ) may be needed for some shapes. The number required is listed in Summary of 2D Mesh Shape Properties above. The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above). If not specified, size values default to 10."
         }
-      ]
+      ],
+      "figure_reference": {
+        "text_incomplete": true,
+        "note": "This command's documentation refers to figures/images in the source manual that are not captured in this text corpus. Geometric or parametric detail conveyed only by those figures -- e.g. reference-point ordering (point 0..N), the size -> direction mapping, dimension meaning, or split/subdivision patterns -- may therefore be missing below. Do not guess it: confirm the specifics from the engine itself, e.g. build the construct and read back the resulting gridpoints/zones via itasca_execute_code.",
+        "deferrals": [
+          "Refer to the figures above for entries and dimensions.",
+          "The locations of these points are illustrated in the reference images (click on any thumbnail above to access).",
+          "For each shape, the entries and their associated zone directions are shown in the reference images (click any thumbnail above).",
+          "The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above)."
+        ]
+      }
     }
   }
 }

--- a/tests/test_figure_reference.py
+++ b/tests/test_figure_reference.py
@@ -1,0 +1,137 @@
+"""Tests for the figure_reference corpus-flagging pipeline.
+
+The ``scripts/corpus/flag_figure_defined.py`` pass marks command docs whose
+geometry/parameters are defined only in figures the text corpus dropped (e.g.
+``zone create2d`` primitives, whose reference-point ordering lives in
+thumbnails). These tests guard both the detection logic and the end-to-end
+surfacing of the flag through the loader (the path ``itasca_browse_commands``
+uses).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from itasca_mcp.knowledge.commands.loader import CommandLoader
+
+# Load the pipeline script as a module (it lives under scripts/, not the package).
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "corpus" / "flag_figure_defined.py"
+_spec = importlib.util.spec_from_file_location("flag_figure_defined", _SCRIPT)
+assert _spec and _spec.loader
+flag_figure_defined = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(flag_figure_defined)
+
+
+class TestDeferralDetection:
+    """Unit tests for the figure-deferral text detection."""
+
+    def test_detects_reference_image_idiom(self):
+        text = "The locations of these points are illustrated in the reference images."
+        assert flag_figure_defined._find_deferrals(text)
+
+    def test_detects_figures_above_idiom(self):
+        text = "Refer to the figures above for entries and dimensions."
+        assert flag_figure_defined._find_deferrals(text)
+
+    def test_detects_thumbnail_idiom(self):
+        text = "Click on any thumbnail above to access the enlargement."
+        assert flag_figure_defined._find_deferrals(text)
+
+    def test_ignores_plain_prose(self):
+        text = "Create a ball at the given position with the given radius."
+        assert flag_figure_defined._find_deferrals(text) == []
+
+    def test_build_flag_collects_distinct_sentences(self):
+        texts = [
+            "Refer to the figures above for entries.",
+            "Refer to the figures above for entries.",  # duplicate -> collapsed
+            "Shown in the reference images.",
+        ]
+        flag = flag_figure_defined._build_flag(texts)
+        assert flag is not None
+        assert flag["text_incomplete"] is True
+        assert len(flag["deferrals"]) == 2
+
+    def test_build_flag_none_when_clean(self):
+        assert flag_figure_defined._build_flag(["just plain text"]) is None
+
+
+class TestApplyIdempotent:
+    """The pass must be a stable fixed point."""
+
+    def test_apply_twice_is_stable(self):
+        doc = {
+            "description": "shape command",
+            "versions": {
+                "9.0": {
+                    "command": "zone create2d",
+                    "keywords": [{"name": "size", "description": "shown in the reference images above."}],
+                }
+            },
+        }
+        first = flag_figure_defined._apply_to_doc(doc)
+        second = flag_figure_defined._apply_to_doc(doc)
+        assert first is True
+        assert second is False  # nothing left to change
+        assert "figure_reference" in doc["versions"]["9.0"]
+
+    def test_stale_flag_removed_when_text_clean(self):
+        doc = {
+            "versions": {
+                "9.0": {
+                    "command": "x",
+                    "keywords": [{"name": "k", "description": "plain prose only."}],
+                    "figure_reference": {"text_incomplete": True, "note": "old", "deferrals": []},
+                }
+            }
+        }
+        changed = flag_figure_defined._apply_to_doc(doc)
+        assert changed is True
+        assert "figure_reference" not in doc["versions"]["9.0"]
+
+    def test_unavailable_version_never_flagged(self):
+        doc = {
+            "description": "shown in the reference images",  # deferral in shared text
+            "versions": {"6.0": {"available": False}},
+        }
+        flag_figure_defined._apply_to_doc(doc)
+        assert "figure_reference" not in doc["versions"]["6.0"]
+
+
+class TestCorpusUpToDate:
+    """The committed corpus must already carry the flags (CI guard == --check)."""
+
+    def test_committed_corpus_is_not_stale(self):
+        import json
+
+        stale = []
+        for path in flag_figure_defined.iter_command_docs():
+            doc = json.loads(path.read_text(encoding="utf-8"))
+            if flag_figure_defined._apply_to_doc(doc):
+                stale.append(path.name)
+        assert not stale, f"Run flag_figure_defined.py; stale: {stale}"
+
+
+class TestFlagSurfacesThroughLoader:
+    """End-to-end: the flag must reach the doc the browse tool returns."""
+
+    def setup_method(self):
+        CommandLoader.clear_cache()
+
+    def test_create2d_carries_figure_reference(self):
+        doc = CommandLoader.load_command_doc("zone", "create2d", "9.0", software="flac")
+        assert doc is not None
+        fr = doc.get("figure_reference")
+        assert fr is not None
+        assert fr["text_incomplete"] is True
+        assert any("reference image" in d.lower() or "figures above" in d.lower() for d in fr["deferrals"])
+
+    def test_plain_command_has_no_figure_reference(self):
+        doc = CommandLoader.load_command_doc("ball", "create", "7.0", software="pfc")
+        assert doc is not None
+        assert "figure_reference" not in doc
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Why

The command corpus is text-extracted from Itasca HTML `<dt>`/`<dd>` (see `scripts/corpus/parse_pfc*.py`); `<img>` thumbnails are dropped. For figure-defined primitive/geometry commands (`zone create2d`, FLAC3D `zone create`), the load-bearing geometry — reference-point ordering, `size`→direction mapping, `dimension` meaning — lives **only** in those figures. The extracted text just says "refer to the figures above / the reference images / click any thumbnail", so an agent reading text alone cannot use these commands and has to fall back to reading the on-disk PNG or probing the engine empirically.

This was hit in practice building a FLAC2D circular tunnel mesh: `annular-sector` / `sector-quad` point order is figure-only.

## What

`scripts/corpus/flag_figure_defined.py` — an engine-agnostic post-processing pass over every command doc (`*/command_docs/commands/**/*.json`). It detects figure-deferral phrases and writes a structured `figure_reference` flag (`text_incomplete`, `note`, `deferrals[]`) into each affected **version** entry.

The flag flows untouched through `CommandLoader._resolve_versioned_doc` (`resolved.update(version_doc)`) into the `doc` payload of `itasca_browse_commands` — so the gap is visible to agents at query time, for *every* figure-defined command, with **no per-command hand-authoring**. The `note` points at the reliable recovery path (build one primitive, read back gridpoints to deduce the convention). No loader/tool/formatter change needed — per the structured-field contract, no duplicate presentation field is added.

Idempotent; `--check` mode for CI staleness guard.

## Scope

Flags 3 docs in the current corpus:
- `flac zone create` (6.0/7.0/9.0)
- `flac zone create2d` (9.0)
- `3dec block densify`

## Tests

`tests/test_figure_reference.py` (12 cases): deferral detection, `_build_flag` dedup, idempotency, stale-flag removal, unavailable-version never flagged, end-to-end loader surfacing, and committed-corpus-freshness (acts as the CI `--check` guard). Full suite: 263 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)