### PR TITLE
refactor: complete pfc-mcp → itasca-mcp rename cutover

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,7 @@ pfc-mcp-bridge/scratch/
 src/
 tests/
 docs/
-.pfc-mcp/
+.itasca-mcp/
 .pfc-mcp-bridge/
 
 # IDE / OS junk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,26 @@
 # AGENTS.md
 
-Guidance for coding agents working in the `pfc-mcp` repository.
+Guidance for coding agents working in the `itasca-mcp` repository.
 
 ## Project Overview
 
-`pfc-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
+`itasca-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
 
 This repository has two runtime contexts:
 
-- `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
+- `src/itasca_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
 ## Core Architecture
 
-### MCP side (`src/pfc_mcp`)
+### MCP side (`src/itasca_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`itasca_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
-- Dual execution model: synchronous REPL (`pfc_execute_code`) for quick queries, script-first async (`pfc_execute_task` + `pfc_check_task_status`) for long-running simulations
+- Dual execution model: synchronous REPL (`itasca_execute_code`) for quick queries, script-first async (`itasca_execute_task` + `itasca_check_task_status`) for long-running simulations
 
 ### Bridge side (`itasca-mcp-bridge` submodule)
 
@@ -32,8 +32,8 @@ End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first inst
 ## Repository Layout
 
 ```text
-pfc-mcp/
-├── src/pfc_mcp/
+itasca-mcp/
+├── src/itasca_mcp/
 │   ├── bridge/          # MCP-side bridge client/task manager
 │   ├── knowledge/       # command/API/reference search system
 │   ├── tools/           # MCP tool implementations
@@ -51,7 +51,7 @@ Run from repository root.
 ```bash
 uv sync
 uv sync --group dev
-uv run pfc-mcp
+uv run itasca-mcp
 uv run pytest tests/test_phase2_tools.py
 uv run pytest tests/test_tool_contracts.py
 ```
@@ -63,9 +63,9 @@ uv run pytest tests/test_tool_contracts.py
    - Do not introduce application/session policy into bridge runtime.
 
 2. Preserve execution semantics for each model.
-   - `pfc_execute_code` runs synchronous snippets and returns stdout/result immediately.
-   - `pfc_execute_task` submits scripts and returns quickly.
-   - Progress/result retrieval goes through `pfc_check_task_status`.
+   - `itasca_execute_code` runs synchronous snippets and returns stdout/result immediately.
+   - `itasca_execute_task` submits scripts and returns quickly.
+   - Progress/result retrieval goes through `itasca_check_task_status`.
 
 3. Maintain structured tool contracts.
    - Prefer stable machine-readable keys over ad-hoc text parsing.
@@ -102,9 +102,9 @@ Mock bridge based tests are preferred for deterministic CI.
 
 PFC searchable docs live under:
 
-- `src/pfc_mcp/knowledge/resources/command_docs/`
-- `src/pfc_mcp/knowledge/resources/python_sdk_docs/`
-- `src/pfc_mcp/knowledge/resources/references/`
+- `src/itasca_mcp/knowledge/resources/command_docs/`
+- `src/itasca_mcp/knowledge/resources/python_sdk_docs/`
+- `src/itasca_mcp/knowledge/resources/references/`
 
 When changing schema/content shape, verify browse/query tool behavior remains consistent.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `pfc-mcp` are documented here.
+All notable changes to `itasca-mcp` (formerly `pfc-mcp`) are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,14 @@
 # CLAUDE.md
 
-Guidance for coding agents working in the `pfc-mcp` repository.
+Guidance for coding agents working in the `itasca-mcp` repository.
 
 ## Project Overview
 
-`pfc-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
+`itasca-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
 
 This repository has two runtime contexts:
 
-- `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
+- `src/itasca_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 Treat these as separate deployment targets. End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones.
@@ -17,12 +17,12 @@ The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is depre
 
 ## Core Architecture
 
-### MCP side (`src/pfc_mcp`)
+### MCP side (`src/itasca_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`itasca_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
-- Dual execution model: synchronous REPL (`pfc_execute_code`) for quick queries, script-first async (`pfc_execute_task` + `pfc_check_task_status`) for long-running simulations
+- Dual execution model: synchronous REPL (`itasca_execute_code`) for quick queries, script-first async (`itasca_execute_task` + `itasca_check_task_status`) for long-running simulations
 
 ### Bridge side (`itasca-mcp-bridge` submodule)
 
@@ -35,8 +35,8 @@ The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is depre
 ## Repository Layout
 
 ```text
-pfc-mcp/
-├── src/pfc_mcp/
+itasca-mcp/
+├── src/itasca_mcp/
 │   ├── bridge/          # MCP-side bridge client/task manager
 │   ├── knowledge/       # command/API/reference search system
 │   ├── tools/           # MCP tool implementations
@@ -51,7 +51,7 @@ pfc-mcp/
 
 - Fresh clone needs `git clone --recurse-submodules <url>` or, after a non-recursive clone, `git submodule update --init --recursive`
 - After `git pull` on this repo, re-sync with `git submodule update --recursive` if the pin moved
-- To bump the bridge pin: `cd itasca-mcp-bridge`, fetch/checkout the new commit, then commit the gitlink update in this repo. Push order: bridge repo first (so the pinned commit exists on its origin), pfc-mcp second
+- To bump the bridge pin: `cd itasca-mcp-bridge`, fetch/checkout the new commit, then commit the gitlink update in this repo. Push order: bridge repo first (so the pinned commit exists on its origin), itasca-mcp second
 - "Modified content" / "untracked content" in `git status` for the submodule is normal during local bridge dev — only commit the gitlink when you actually want to bump the pin
 
 ## Development Commands
@@ -61,7 +61,7 @@ Run from repository root.
 ```bash
 uv sync
 uv sync --group dev
-uv run pfc-mcp
+uv run itasca-mcp
 uv run pytest tests/test_phase2_tools.py
 uv run pytest tests/test_tool_contracts.py
 ```
@@ -73,9 +73,9 @@ uv run pytest tests/test_tool_contracts.py
    - Do not introduce application/session policy into bridge runtime.
 
 2. Preserve execution semantics for each model.
-   - `pfc_execute_code` runs synchronous snippets and returns stdout/result immediately.
-   - `pfc_execute_task` submits scripts and returns quickly.
-   - Progress/result retrieval goes through `pfc_check_task_status`.
+   - `itasca_execute_code` runs synchronous snippets and returns stdout/result immediately.
+   - `itasca_execute_task` submits scripts and returns quickly.
+   - Progress/result retrieval goes through `itasca_check_task_status`.
 
 3. Maintain structured tool contracts.
    - Prefer stable machine-readable keys over ad-hoc text parsing.
@@ -132,19 +132,19 @@ Mock bridge based tests are preferred for deterministic CI.
 
 PFC searchable docs live under:
 
-- `src/pfc_mcp/knowledge/resources/command_docs/`
-- `src/pfc_mcp/knowledge/resources/python_sdk_docs/`
-- `src/pfc_mcp/knowledge/resources/references/`
+- `src/itasca_mcp/knowledge/resources/command_docs/`
+- `src/itasca_mcp/knowledge/resources/python_sdk_docs/`
+- `src/itasca_mcp/knowledge/resources/references/`
 
 When changing schema/content shape, verify browse/query tool behavior remains consistent.
 
 ## Release Process
 
-`pfc-mcp` is published to PyPI via GitHub Actions, triggered by pushing a `v*` tag (e.g. `v0.3.16`). Version source: `src/pfc_mcp/__init__.py` (hatch dynamic versioning).
+`itasca-mcp` is published to PyPI via GitHub Actions, triggered by pushing a `v*` tag (e.g. `v0.3.16`). Version source: `src/itasca_mcp/__init__.py` (hatch dynamic versioning).
 
-Steps to release `pfc-mcp`:
+Steps to release `itasca-mcp`:
 
-1. Bump `__version__` in `src/pfc_mcp/__init__.py` (the single source of truth).
+1. Bump `__version__` in `src/itasca_mcp/__init__.py` (the single source of truth).
 2. Curate `## [Unreleased]` in `CHANGELOG.md` from `git log` since the previous release (grouped per the convention comment at the top of that file), rename it to `## [x.y.z] - YYYY-MM-DD`, then start a fresh empty `## [Unreleased]`. The publish workflow extracts the section whose header matches the tag version exactly and fails if it is missing.
 3. Commit and push to `main`.
 4. Tag the commit: `git tag v0.x.x` and `git push origin v0.x.x`.
@@ -170,7 +170,7 @@ Use conventional prefixes seen in repository history, for example:
 Keep commit messages focused on why the change was needed.
 
 Documentation is first-class for this project -- agents rely on the docs and
-the agentic install guides to understand and operate pfc-mcp, so notable
+the agentic install guides to understand and operate itasca-mcp, so notable
 documentation/install-flow changes belong in the changelog alongside
 behaviour changes.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,26 +1,26 @@
 # GEMINI.md
 
-Guidance for coding agents working in the `pfc-mcp` repository.
+Guidance for coding agents working in the `itasca-mcp` repository.
 
 ## Project Overview
 
-`pfc-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
+`itasca-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
 
 This repository has two runtime contexts:
 
-- `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
+- `src/itasca_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
 ## Core Architecture
 
-### MCP side (`src/pfc_mcp`)
+### MCP side (`src/itasca_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`itasca_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
-- Uses script-first execution model (`pfc_execute_task` + `pfc_check_task_status`)
+- Uses script-first execution model (`itasca_execute_task` + `itasca_check_task_status`)
 
 ### Bridge side (`itasca-mcp-bridge` submodule)
 
@@ -32,8 +32,8 @@ End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first inst
 ## Repository Layout
 
 ```text
-pfc-mcp/
-├── src/pfc_mcp/
+itasca-mcp/
+├── src/itasca_mcp/
 │   ├── bridge/          # MCP-side bridge client/task manager
 │   ├── knowledge/       # command/API/reference search system
 │   ├── tools/           # MCP tool implementations
@@ -51,7 +51,7 @@ Run from repository root.
 ```bash
 uv sync
 uv sync --group dev
-uv run pfc-mcp
+uv run itasca-mcp
 uv run pytest tests/test_phase2_tools.py
 uv run pytest tests/test_tool_contracts.py
 ```
@@ -63,8 +63,8 @@ uv run pytest tests/test_tool_contracts.py
    - Do not introduce application/session policy into bridge runtime.
 
 2. Preserve script-only execution semantics.
-   - `pfc_execute_task` submits scripts and returns quickly.
-   - Progress/result retrieval goes through `pfc_check_task_status`.
+   - `itasca_execute_task` submits scripts and returns quickly.
+   - Progress/result retrieval goes through `itasca_check_task_status`.
 
 3. Maintain structured tool contracts.
    - Prefer stable machine-readable keys over ad-hoc text parsing.
@@ -101,9 +101,9 @@ Mock bridge based tests are preferred for deterministic CI.
 
 PFC searchable docs live under:
 
-- `src/pfc_mcp/knowledge/resources/command_docs/`
-- `src/pfc_mcp/knowledge/resources/python_sdk_docs/`
-- `src/pfc_mcp/knowledge/resources/references/`
+- `src/itasca_mcp/knowledge/resources/command_docs/`
+- `src/itasca_mcp/knowledge/resources/python_sdk_docs/`
+- `src/itasca_mcp/knowledge/resources/references/`
 
 When changing schema/content shape, verify browse/query tool behavior remains consistent.
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/header.gif" alt="pfc-mcp" width="70%">
+  <img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/header.gif" alt="itasca-mcp" width="70%">
 </p>
 
-# pfc-mcp
+# itasca-mcp
 
-[English](https://github.com/yusong652/pfc-mcp/blob/main/README.md) | [简体中文](https://github.com/yusong652/pfc-mcp/blob/main/README.zh-CN.md)
+[English](https://github.com/yusong652/itasca-mcp/blob/main/README.md) | [简体中文](https://github.com/yusong652/itasca-mcp/blob/main/README.zh-CN.md)
 
-[![PyPI](https://img.shields.io/pypi/v/pfc-mcp)](https://pypi.org/project/pfc-mcp/)
-[![Downloads](https://static.pepy.tech/badge/pfc-mcp)](https://pepy.tech/project/pfc-mcp)
-[![GitHub stars](https://img.shields.io/github/stars/yusong652/pfc-mcp)](https://github.com/yusong652/pfc-mcp/stargazers)
+[![PyPI](https://img.shields.io/pypi/v/itasca-mcp)](https://pypi.org/project/itasca-mcp/)
+[![Downloads](https://static.pepy.tech/badge/itasca-mcp)](https://pepy.tech/project/itasca-mcp)
+[![GitHub stars](https://img.shields.io/github/stars/yusong652/itasca-mcp)](https://github.com/yusong652/itasca-mcp/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 
 `pfc3d>model new ;now, with LLM.`
 
-**pfc-mcp** connects AI agents to [ITASCA PFC](https://www.itascacg.com/software/pfc) — Itasca's discrete element method (DEM) code — through the [Model Context Protocol](https://modelcontextprotocol.io/). Browse documentation, run simulations, and execute code, all through natural conversation.
+**itasca-mcp** connects AI agents to [ITASCA PFC](https://www.itascacg.com/software/pfc) — Itasca's discrete element method (DEM) code — through the [Model Context Protocol](https://modelcontextprotocol.io/). Browse documentation, run simulations, and execute code, all through natural conversation.
 
 `pfc3d>model solve ;LLM solves.`
 
-![pfc-mcp demo](https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/pfc-mcp.gif)
+![itasca-mcp demo](https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/itasca-mcp.gif)
 
 ## Tools (10)
 
@@ -39,7 +39,7 @@ Copy this to your AI agent and let it self-configure:
 
 ```text
 Fetch and follow this bootstrap guide end-to-end:
-https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap.md
+https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap.md
 ```
 
 ### Manual Setup
@@ -49,9 +49,9 @@ https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bo
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "command": "uvx",
-      "args": ["pfc-mcp"]
+      "args": ["itasca-mcp"]
     }
   }
 }
@@ -64,11 +64,11 @@ Download [`addon.py`](addon.py), then use either of these two flows inside PFC:
 - Copy the file contents into the PFC IPython console and run them
 - Or download the file and execute it in PFC GUI
 
-<img src="https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/addon.gif" alt="addon.py demo" width="60%">
+<img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/addon.gif" alt="addon.py demo" width="60%">
 
 ### Verify
 
-Restart your AI agent (Claude Code, Codex CLI, Gemini CLI, etc.) and ask it to call `pfc_execute_code` to verify the connection.
+Restart your AI agent (Claude Code, Codex CLI, Gemini CLI, etc.) and ask it to call `itasca_execute_code` to verify the connection.
 
 ## Daily Startup
 
@@ -92,14 +92,14 @@ itasca_mcp_bridge.start()
 
 ## Troubleshooting
 
-See [Troubleshooting](docs/agentic/pfc-mcp-bootstrap.md#troubleshooting) in the bootstrap guide.
+See [Troubleshooting](docs/agentic/itasca-mcp-bootstrap.md#troubleshooting) in the bootstrap guide.
 
 ## Development
 
 See [Developer Guide: Install and Run from Source](docs/development/source-install.md).
 
-<a href="https://glama.ai/mcp/servers/yusong652/pfc-mcp">
-  <img width="200" height="105" src="https://glama.ai/mcp/servers/yusong652/pfc-mcp/badge" alt="pfc-mcp MCP server" />
+<a href="https://glama.ai/mcp/servers/yusong652/itasca-mcp">
+  <img width="200" height="105" src="https://glama.ai/mcp/servers/yusong652/itasca-mcp/badge" alt="itasca-mcp MCP server" />
 </a>
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,24 +1,24 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/header.gif" alt="pfc-mcp" width="70%">
+  <img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/header.gif" alt="itasca-mcp" width="70%">
 </p>
 
-# pfc-mcp
+# itasca-mcp
 
-[English](https://github.com/yusong652/pfc-mcp/blob/main/README.md) | [简体中文](https://github.com/yusong652/pfc-mcp/blob/main/README.zh-CN.md)
+[English](https://github.com/yusong652/itasca-mcp/blob/main/README.md) | [简体中文](https://github.com/yusong652/itasca-mcp/blob/main/README.zh-CN.md)
 
-[![PyPI](https://img.shields.io/pypi/v/pfc-mcp)](https://pypi.org/project/pfc-mcp/)
-[![Downloads](https://static.pepy.tech/badge/pfc-mcp)](https://pepy.tech/project/pfc-mcp)
-[![GitHub stars](https://img.shields.io/github/stars/yusong652/pfc-mcp)](https://github.com/yusong652/pfc-mcp/stargazers)
+[![PyPI](https://img.shields.io/pypi/v/itasca-mcp)](https://pypi.org/project/itasca-mcp/)
+[![Downloads](https://static.pepy.tech/badge/itasca-mcp)](https://pepy.tech/project/itasca-mcp)
+[![GitHub stars](https://img.shields.io/github/stars/yusong652/itasca-mcp)](https://github.com/yusong652/itasca-mcp/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
 
 `pfc3d>model new ;now, with LLM.`
 
-**pfc-mcp** 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 将 AI 智能体连接到 [ITASCA PFC](https://www.itascacg.com/software/pfc) —— Itasca 的离散元方法（DEM）软件。通过自然语言对话即可浏览文档、运行仿真和执行代码。
+**itasca-mcp** 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 将 AI 智能体连接到 [ITASCA PFC](https://www.itascacg.com/software/pfc) —— Itasca 的离散元方法（DEM）软件。通过自然语言对话即可浏览文档、运行仿真和执行代码。
 
 `pfc3d>model solve ;LLM solves.`
 
-![pfc-mcp demo](https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/pfc-mcp.gif)
+![itasca-mcp demo](https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/itasca-mcp.gif)
 
 ## 工具（10）
 
@@ -39,7 +39,7 @@
 
 ```text
 请全程用中文与我交流。然后获取并完整按照这份引导指南执行（指南为英文，照其步骤操作即可）：
-https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap.md
+https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap.md
 ```
 
 ### 手动配置
@@ -49,9 +49,9 @@ https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bo
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "command": "uvx",
-      "args": ["pfc-mcp"]
+      "args": ["itasca-mcp"]
     }
   }
 }
@@ -64,11 +64,11 @@ https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bo
 - 把这个文件的内容复制到 PFC 的 IPython 控制台里运行
 - 或者先把这个文件下载到本地，再在 PFC GUI 里执行它
 
-<img src="https://raw.githubusercontent.com/yusong652/pfc-mcp/assets/addon.gif" alt="addon.py 演示" width="60%">
+<img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/addon.gif" alt="addon.py 演示" width="60%">
 
 ### 验证
 
-重启你的 AI 智能体（Claude Code、Codex CLI、Gemini CLI 等），让它调用 `pfc_execute_code` 来验证连接是否正常。
+重启你的 AI 智能体（Claude Code、Codex CLI、Gemini CLI 等），让它调用 `itasca_execute_code` 来验证连接是否正常。
 
 ## 日常启动
 
@@ -92,14 +92,14 @@ itasca_mcp_bridge.start()
 
 ## 故障排查
 
-详见 bootstrap 指南中的[故障排查章节](docs/agentic/pfc-mcp-bootstrap.md#troubleshooting)。
+详见 bootstrap 指南中的[故障排查章节](docs/agentic/itasca-mcp-bootstrap.md#troubleshooting)。
 
 ## 开发
 
 详见 [开发者指南：从源码安装与运行](docs/development/source-install.zh-CN.md)。
 
-<a href="https://glama.ai/mcp/servers/yusong652/pfc-mcp">
-  <img width="200" height="105" src="https://glama.ai/mcp/servers/yusong652/pfc-mcp/badge" alt="pfc-mcp MCP server" />
+<a href="https://glama.ai/mcp/servers/yusong652/itasca-mcp">
+  <img width="200" height="105" src="https://glama.ai/mcp/servers/yusong652/itasca-mcp/badge" alt="itasca-mcp MCP server" />
 </a>
 
 ## 贡献

--- a/WARP.md
+++ b/WARP.md
@@ -1,26 +1,26 @@
 # WARP.md
 
-Guidance for coding agents working in the `pfc-mcp` repository.
+Guidance for coding agents working in the `itasca-mcp` repository.
 
 ## Project Overview
 
-`pfc-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
+`itasca-mcp` provides an MCP server for ITASCA PFC workflows. The bridge runtime that runs inside PFC GUI lives in the [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo and is consumed here as a git submodule.
 
 This repository has two runtime contexts:
 
-- `src/pfc_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
+- `src/itasca_mcp/` (Python >= 3.10): MCP server package used by clients/tooling
 - `itasca-mcp-bridge/` (submodule, PFC embedded Python often 3.6): HTTP bridge running inside PFC GUI
 
 End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first install happens via the agentic bootstrap's terminal pip step or `addon.py`, and from then on `itasca_mcp_bridge.start()` self-upgrades on every start. The submodule exists only so contributors can edit bridge code alongside MCP code without two clones. The legacy `pfc-mcp-bridge` PyPI package (last release `bridge-v0.3.3`) is deprecated.
 
 ## Core Architecture
 
-### MCP side (`src/pfc_mcp`)
+### MCP side (`src/itasca_mcp`)
 
 - Exposes documentation tools and execution tools through FastMCP
-- Communicates with bridge via HTTP client (`pfc_mcp.bridge.client`)
+- Communicates with bridge via HTTP client (`itasca_mcp.bridge.client`)
 - Returns a unified tool envelope: `ok`, `data`, `error`
-- Uses script-first execution model (`pfc_execute_task` + `pfc_check_task_status`)
+- Uses script-first execution model (`itasca_execute_task` + `itasca_check_task_status`)
 
 ### Bridge side (`itasca-mcp-bridge` submodule)
 
@@ -32,8 +32,8 @@ End users get the bridge from PyPI (`pip install itasca-mcp-bridge`): first inst
 ## Repository Layout
 
 ```text
-pfc-mcp/
-├── src/pfc_mcp/
+itasca-mcp/
+├── src/itasca_mcp/
 │   ├── bridge/          # MCP-side bridge client/task manager
 │   ├── knowledge/       # command/API/reference search system
 │   ├── tools/           # MCP tool implementations
@@ -51,7 +51,7 @@ Run from repository root.
 ```bash
 uv sync
 uv sync --group dev
-uv run pfc-mcp
+uv run itasca-mcp
 uv run pytest tests/test_phase2_tools.py
 uv run pytest tests/test_tool_contracts.py
 ```
@@ -63,8 +63,8 @@ uv run pytest tests/test_tool_contracts.py
    - Do not introduce application/session policy into bridge runtime.
 
 2. Preserve script-only execution semantics.
-   - `pfc_execute_task` submits scripts and returns quickly.
-   - Progress/result retrieval goes through `pfc_check_task_status`.
+   - `itasca_execute_task` submits scripts and returns quickly.
+   - Progress/result retrieval goes through `itasca_check_task_status`.
 
 3. Maintain structured tool contracts.
    - Prefer stable machine-readable keys over ad-hoc text parsing.
@@ -101,9 +101,9 @@ Mock bridge based tests are preferred for deterministic CI.
 
 PFC searchable docs live under:
 
-- `src/pfc_mcp/knowledge/resources/command_docs/`
-- `src/pfc_mcp/knowledge/resources/python_sdk_docs/`
-- `src/pfc_mcp/knowledge/resources/references/`
+- `src/itasca_mcp/knowledge/resources/command_docs/`
+- `src/itasca_mcp/knowledge/resources/python_sdk_docs/`
+- `src/itasca_mcp/knowledge/resources/references/`
 
 When changing schema/content shape, verify browse/query tool behavior remains consistent.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,10 +18,10 @@
 # Build (Apple Silicon -> emulate x86_64 via Rosetta):
 #   docker build --platform=linux/amd64 \
 #       --build-context itasca-deb=$HOME/Downloads \
-#       -t pfc-mcp:dev -f docker/Dockerfile .
+#       -t itasca-mcp:dev -f docker/Dockerfile .
 #
 # Run, exposing the bridge WS port to the host:
-#   docker run --rm -it --platform=linux/amd64 -p 9001:9001 pfc-mcp:dev
+#   docker run --rm -it --platform=linux/amd64 -p 9001:9001 itasca-mcp:dev
 
 # ---------- Stage 1: install PFC engine ----------
 # Ubuntu 22.04 is required because the Itasca binaries link against glibc 2.32+
@@ -66,7 +66,7 @@ RUN --mount=type=bind,from=itasca-deb,target=/itasca-deb \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # ---------- Stage 2: GUI stack + bridge ----------
-FROM pfc-engine AS pfc-mcp
+FROM pfc-engine AS itasca-mcp
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # PFC headless dev container
 
 Runs the Itasca PFC Linux engine in console mode plus `itasca-mcp-bridge`, so
-Mac users can develop and test pfc-mcp without a Windows + USB-key setup.
+Mac users can develop and test itasca-mcp without a Windows + USB-key setup.
 Demo mode (no license required) caps models at 1000 balls/clumps + 1000
 rigid blocks + 10 DFNs — enough for bridge integration testing.
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build pfc-mcp:dev and immediately reclaim space from layers orphaned by
+# Build itasca-mcp:dev and immediately reclaim space from layers orphaned by
 # the rebuild. Without this, every iteration on the Dockerfile leaves the
 # previous engine layer (~12 GB extracted) hanging around as a dangling
 # image, eventually filling Docker's VM disk.
@@ -12,7 +12,7 @@
 set -e
 
 PLATFORM=linux/amd64
-TAG=pfc-mcp:dev
+TAG=itasca-mcp:dev
 DEB_DIR="${ITASCA_DEB_DIR:-$HOME/Downloads}"
 DEB_FILE="$DEB_DIR/itascasoftware.latest.deb"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# Compose file for the pfc-mcp dev container.
+# Compose file for the itasca-mcp dev container.
 #
 # Usage (run from repo root):
 #   docker compose -f docker/docker-compose.yml up --build
@@ -22,7 +22,7 @@ services:
       # ITASCA_DEB_DIR=/path/to/dir before invoking compose.
       additional_contexts:
         itasca-deb: ${ITASCA_DEB_DIR:-${HOME}/Downloads}
-    image: pfc-mcp:dev
+    image: itasca-mcp:dev
     platform: linux/amd64
     # Invoke the bind-mounted entrypoint via bash so a missing exec bit on
     # the host file (Edit/Write tools don't preserve it) doesn't kill the

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Bring up the pfc-mcp dev container with the right ports/volumes/platform.
+# Bring up the itasca-mcp dev container with the right ports/volumes/platform.
 # Wraps `docker compose` so the long flag list lives in docker-compose.yml.
 #
 # Usage:  ./docker/run.sh           # console mode (default, faster)
@@ -24,7 +24,7 @@ fi
 # volumes (workspace, bridge source) are untouched.
 docker compose -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
 
-echo "[run.sh] Bringing up pfc-mcp..."
+echo "[run.sh] Bringing up itasca-mcp..."
 if [ "${PFC_GUI:-}" = "1" ]; then
     echo "  GUI:    http://localhost:6080/vnc.html"
 fi

--- a/docs/agentic/itasca-mcp-bootstrap-claude.md
+++ b/docs/agentic/itasca-mcp-bootstrap-claude.md
@@ -1,15 +1,15 @@
-# pfc-mcp Bootstrap (Claude Code)
+# itasca-mcp Bootstrap (Claude Code)
 
 Use this profile when the client uses `.mcp.json` style MCP config.
 
-For Codex, use `docs/agentic/pfc-mcp-bootstrap-codex.md` instead.
+For Codex, use `docs/agentic/itasca-mcp-bootstrap-codex.md` instead.
 
 ## Step 1 (Claude Code) - Configure MCP
 
 [AGENT]
 
 Default target: user-level MCP config (global, available across all working directories).
-Preferred mechanism: `claude mcp add --scope user pfc-mcp -- uvx pfc-mcp` (idempotent; handles merge; no need to locate the config file).
+Preferred mechanism: `claude mcp add --scope user itasca-mcp -- uvx itasca-mcp` (idempotent; handles merge; no need to locate the config file).
 Fall back to workspace `.mcp.json` only if the user-scope config is unavailable or write-blocked.
 
 Add/merge this MCP entry:
@@ -17,10 +17,10 @@ Add/merge this MCP entry:
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["pfc-mcp"]
+      "args": ["itasca-mcp"]
     }
   }
 }
@@ -31,10 +31,10 @@ If `uvx` is unavailable, fallback to:
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "stdio",
       "command": "uv",
-      "args": ["tool", "run", "pfc-mcp"]
+      "args": ["tool", "run", "itasca-mcp"]
     }
   }
 }
@@ -44,4 +44,4 @@ If `uvx` is unavailable, fallback to:
 
 After Step 1, continue from Step 2 in:
 
-- `docs/agentic/pfc-mcp-bootstrap.md`
+- `docs/agentic/itasca-mcp-bootstrap.md`

--- a/docs/agentic/itasca-mcp-bootstrap-codex.md
+++ b/docs/agentic/itasca-mcp-bootstrap-codex.md
@@ -1,4 +1,4 @@
-# pfc-mcp Bootstrap (Codex)
+# itasca-mcp Bootstrap (Codex)
 
 Use this profile when the client is OpenAI Codex CLI/IDE.
 
@@ -6,30 +6,30 @@ Use this profile when the client is OpenAI Codex CLI/IDE.
 
 [AGENT]
 
-> **Codex IDE / GUI users (the common case):** The Codex IDE extension (VS Code / Cursor) and the CLI share the *same* `~/.codex/config.toml`. Configure it once — `codex mcp add` from any terminal, or by editing the file — and `pfc-mcp` is available in the GUI too; there is no separate GUI setup. In the IDE the file opens via the gear icon → Codex Settings → Open config.toml. Caveat: the IDE sometimes does not detect a newly added MCP server until you reload the window / restart Codex (openai/codex #6465, #7820).
+> **Codex IDE / GUI users (the common case):** The Codex IDE extension (VS Code / Cursor) and the CLI share the *same* `~/.codex/config.toml`. Configure it once — `codex mcp add` from any terminal, or by editing the file — and `itasca-mcp` is available in the GUI too; there is no separate GUI setup. In the IDE the file opens via the gear icon → Codex Settings → Open config.toml. Caveat: the IDE sometimes does not detect a newly added MCP server until you reload the window / restart Codex (openai/codex #6465, #7820).
 
 **Primary (CLI):** `codex mcp add` writes the user-level config (`~/.codex/config.toml`, shared by all projects). There is no scope flag — it is user-scoped by design. The `--` separator is required:
 
 ```bash
-codex mcp add pfc-mcp -- uvx pfc-mcp
+codex mcp add itasca-mcp -- uvx itasca-mcp
 ```
 
-If `uvx` is unavailable: `codex mcp add pfc-mcp -- uv tool run pfc-mcp`. Verify the subcommand exists with `codex mcp --help` (the `codex mcp` suite is part of the Rust-series CLI; legacy builds may lack it).
+If `uvx` is unavailable: `codex mcp add itasca-mcp -- uv tool run itasca-mcp`. Verify the subcommand exists with `codex mcp --help` (the `codex mcp` suite is part of the Rust-series CLI; legacy builds may lack it).
 
 **Fallback (edit user config file):** `~/.codex/config.toml` — Windows: `%USERPROFILE%\.codex\config.toml` (OpenAI does not document the Windows path; set the `CODEX_HOME` env var to pin the directory if you need determinism). It is TOML, not JSON. A project-scoped `.codex/config.toml` also exists but is trusted-projects-only and is NOT written by `codex mcp add` — do not use it as the default. Add/merge this entry:
 
 ```toml
-[mcp_servers.pfc-mcp]
+[mcp_servers.itasca-mcp]
 command = "uvx"
-args = ["pfc-mcp"]
+args = ["itasca-mcp"]
 ```
 
 If `uvx` is unavailable, fallback to:
 
 ```toml
-[mcp_servers.pfc-mcp]
+[mcp_servers.itasca-mcp]
 command = "uv"
-args = ["tool", "run", "pfc-mcp"]
+args = ["tool", "run", "itasca-mcp"]
 ```
 
 [USER ACTION REQUIRED]
@@ -45,4 +45,4 @@ Optional verification:
 
 After Step 1, continue from Step 2 in:
 
-- `docs/agentic/pfc-mcp-bootstrap.md`
+- `docs/agentic/itasca-mcp-bootstrap.md`

--- a/docs/agentic/itasca-mcp-bootstrap-copilot.md
+++ b/docs/agentic/itasca-mcp-bootstrap-copilot.md
@@ -1,4 +1,4 @@
-# pfc-mcp Bootstrap (GitHub Copilot CLI)
+# itasca-mcp Bootstrap (GitHub Copilot CLI)
 
 Use this profile when the client is GitHub Copilot CLI.
 
@@ -9,10 +9,10 @@ Use this profile when the client is GitHub Copilot CLI.
 **Primary (CLI):** `copilot mcp add` always writes the user-level config (global, all working directories). There is no scope flag — it is user-scoped by design:
 
 ```bash
-copilot mcp add pfc-mcp --type local -- uvx pfc-mcp
+copilot mcp add itasca-mcp --type local -- uvx itasca-mcp
 ```
 
-If `uvx` is unavailable: `copilot mcp add pfc-mcp --type local -- uv tool run pfc-mcp`.
+If `uvx` is unavailable: `copilot mcp add itasca-mcp --type local -- uv tool run itasca-mcp`.
 
 (The "Adding MCP servers" how-to page omits `copilot mcp add`; the CLI command reference documents it. If the subcommand is missing on the installed build, use the file fallback below — it works on any version.)
 
@@ -21,10 +21,10 @@ If `uvx` is unavailable: `copilot mcp add pfc-mcp --type local -- uv tool run pf
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "local",
       "command": "uvx",
-      "args": ["pfc-mcp"]
+      "args": ["itasca-mcp"]
     }
   }
 }
@@ -35,10 +35,10 @@ If `uvx` is unavailable, fallback to:
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "local",
       "command": "uv",
-      "args": ["tool", "run", "pfc-mcp"]
+      "args": ["tool", "run", "itasca-mcp"]
     }
   }
 }
@@ -54,4 +54,4 @@ Always close and restart the Copilot CLI session before continuing. Exit the cur
 
 After Step 1, continue from Step 2 in:
 
-- `docs/agentic/pfc-mcp-bootstrap.md`
+- `docs/agentic/itasca-mcp-bootstrap.md`

--- a/docs/agentic/itasca-mcp-bootstrap-gemini.md
+++ b/docs/agentic/itasca-mcp-bootstrap-gemini.md
@@ -1,4 +1,4 @@
-# pfc-mcp Bootstrap (Gemini CLI)
+# itasca-mcp Bootstrap (Gemini CLI)
 
 Use this profile when the client is Gemini CLI.
 
@@ -9,7 +9,7 @@ Use this profile when the client is Gemini CLI.
 **Primary (CLI, user scope):**
 
 ```bash
-gemini mcp add --scope user pfc-mcp uvx pfc-mcp
+gemini mcp add --scope user itasca-mcp uvx itasca-mcp
 ```
 
 `--scope user` is REQUIRED. Without it the default scope is `project` (writes only `./.gemini/settings.json`), which reintroduces the "switch working directory → tool disappears" footgun. Requires Gemini CLI >= v0.36; if `mcp add` or the flag is missing, run `gemini mcp add --help` to confirm, then use the fallback.
@@ -19,9 +19,9 @@ gemini mcp add --scope user pfc-mcp uvx pfc-mcp
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "command": "uvx",
-      "args": ["pfc-mcp"]
+      "args": ["itasca-mcp"]
     }
   }
 }
@@ -32,9 +32,9 @@ If `uvx` is unavailable, fallback to:
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "pfc-mcp"]
+      "args": ["tool", "run", "itasca-mcp"]
     }
   }
 }
@@ -46,10 +46,10 @@ Last resort: if the user config file itself is unavailable or write-blocked, use
 
 Always close and reopen Gemini CLI session before continuing.
 
-Then continue to Step 2 and verify with `pfc_list_tasks` at the end of bootstrap.
+Then continue to Step 2 and verify with `itasca_list_tasks` at the end of bootstrap.
 
 ## Continue with common bootstrap
 
 After Step 1, continue from Step 2 in:
 
-- `docs/agentic/pfc-mcp-bootstrap.md`
+- `docs/agentic/itasca-mcp-bootstrap.md`

--- a/docs/agentic/itasca-mcp-bootstrap-opencode.md
+++ b/docs/agentic/itasca-mcp-bootstrap-opencode.md
@@ -1,4 +1,4 @@
-# pfc-mcp Bootstrap (OpenCode)
+# itasca-mcp Bootstrap (OpenCode)
 
 Use this profile when the client is OpenCode.
 
@@ -21,9 +21,9 @@ Add/merge this MCP entry:
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "local",
-      "command": ["uvx", "pfc-mcp"],
+      "command": ["uvx", "itasca-mcp"],
       "enabled": true
     }
   }
@@ -36,9 +36,9 @@ If `uvx` is unavailable, fallback to:
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "local",
-      "command": ["uv", "tool", "run", "pfc-mcp"],
+      "command": ["uv", "tool", "run", "itasca-mcp"],
       "enabled": true
     }
   }
@@ -51,10 +51,10 @@ Optional verification:
 opencode mcp list
 ```
 
-Confirm `pfc-mcp` is listed and enabled.
+Confirm `itasca-mcp` is listed and enabled.
 
 ## Continue with common bootstrap
 
 After Step 1, continue from Step 2 in:
 
-- `docs/agentic/pfc-mcp-bootstrap.md`
+- `docs/agentic/itasca-mcp-bootstrap.md`

--- a/docs/agentic/itasca-mcp-bootstrap-toyoura-nagisa.md
+++ b/docs/agentic/itasca-mcp-bootstrap-toyoura-nagisa.md
@@ -1,4 +1,4 @@
-# pfc-mcp Bootstrap (toyoura-nagisa)
+# itasca-mcp Bootstrap (toyoura-nagisa)
 
 Use this profile when the client is toyoura-nagisa.
 
@@ -14,10 +14,10 @@ Add/merge this entry under `mcpServers`:
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["pfc-mcp"],
+      "args": ["itasca-mcp"],
       "enabled": true,
       "description": "PFC MCP server"
     }
@@ -30,10 +30,10 @@ If `uvx` is unavailable, fallback to:
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "type": "stdio",
       "command": "uv",
-      "args": ["tool", "run", "pfc-mcp"],
+      "args": ["tool", "run", "itasca-mcp"],
       "enabled": true,
       "description": "PFC MCP server"
     }
@@ -51,4 +51,4 @@ Always close and reopen the toyoura-nagisa session (or restart backend process) 
 
 After Step 1, continue from Step 2 in:
 
-- `docs/agentic/pfc-mcp-bootstrap.md`
+- `docs/agentic/itasca-mcp-bootstrap.md`

--- a/docs/agentic/itasca-mcp-bootstrap.md
+++ b/docs/agentic/itasca-mcp-bootstrap.md
@@ -1,13 +1,13 @@
-# pfc-mcp Agent Bootstrap Guide
+# itasca-mcp Agent Bootstrap Guide
 
-Use this guide when an agent needs to set up `pfc-mcp` execution end-to-end on a Windows machine.
+Use this guide when an agent needs to set up `itasca-mcp` execution end-to-end on a Windows machine.
 
 ## Target Outcome
 
-1. MCP client is configured to run `pfc-mcp`.
+1. MCP client is configured to run `itasca-mcp`.
 2. `itasca-mcp-bridge` is installed in the correct PFC embedded Python environment.
 3. Bridge is started in PFC GUI via `itasca_mcp_bridge.start()`.
-4. MCP execution tools are verified with `pfc_execute_code`.
+4. MCP execution tools are verified with `itasca_execute_code`.
 
 ## Agent Execution Rules
 
@@ -26,37 +26,37 @@ Use this guide when an agent needs to set up `pfc-mcp` execution end-to-end on a
 
 Use the client-specific Step 1 profile:
 
-- OpenCode: <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap-opencode.md>
-- Claude Code: <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap-claude.md>
-- Codex: <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap-codex.md>
-- Gemini CLI: <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap-gemini.md>
-- GitHub Copilot CLI: <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap-copilot.md>
-- toyoura-nagisa: <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap-toyoura-nagisa.md>
+- OpenCode: <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap-opencode.md>
+- Claude Code: <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap-claude.md>
+- Codex: <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap-codex.md>
+- Gemini CLI: <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap-gemini.md>
+- GitHub Copilot CLI: <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap-copilot.md>
+- toyoura-nagisa: <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap-toyoura-nagisa.md>
 
 If raw URL fetch is unavailable, use repository-relative paths:
 
-- `docs/agentic/pfc-mcp-bootstrap-opencode.md`
-- `docs/agentic/pfc-mcp-bootstrap-claude.md`
-- `docs/agentic/pfc-mcp-bootstrap-codex.md`
-- `docs/agentic/pfc-mcp-bootstrap-gemini.md`
-- `docs/agentic/pfc-mcp-bootstrap-copilot.md`
-- `docs/agentic/pfc-mcp-bootstrap-toyoura-nagisa.md`
+- `docs/agentic/itasca-mcp-bootstrap-opencode.md`
+- `docs/agentic/itasca-mcp-bootstrap-claude.md`
+- `docs/agentic/itasca-mcp-bootstrap-codex.md`
+- `docs/agentic/itasca-mcp-bootstrap-gemini.md`
+- `docs/agentic/itasca-mcp-bootstrap-copilot.md`
+- `docs/agentic/itasca-mcp-bootstrap-toyoura-nagisa.md`
 
 Apply this MCP launch contract in your client's native config format:
 
-- server id/name: `pfc-mcp`
-- primary launch command: `uvx pfc-mcp`
-- fallback launch command: `uv tool run pfc-mcp`
+- server id/name: `itasca-mcp`
+- primary launch command: `uvx itasca-mcp`
+- fallback launch command: `uv tool run itasca-mcp`
 - enable server in client config
 - prefer user/global-level config by default; fall back to workspace-level config only if the global config is unavailable or write-blocked
 
-> Rationale: `pfc-mcp` bridges a machine-local PFC GUI over a localhost bridge, so the capability is machine-scoped, not project-scoped. A PFC working directory is a simulation workspace and is rarely a shared repo, so workspace-scoped config mainly creates a "switch working directory → tool disappears, must re-run bootstrap" footgun. Keep the config global so it survives directory changes; the per-client profile names the exact user-scope target and the preferred CLI where one exists.
+> Rationale: `itasca-mcp` bridges a machine-local PFC GUI over a localhost bridge, so the capability is machine-scoped, not project-scoped. A PFC working directory is a simulation workspace and is rarely a shared repo, so workspace-scoped config mainly creates a "switch working directory → tool disappears, must re-run bootstrap" footgun. Keep the config global so it survives directory changes; the per-client profile names the exact user-scope target and the preferred CLI where one exists.
 
 When editing MCP config, use this order:
 
 1. If config file does not exist, create it.
-2. If config exists but has no `pfc-mcp` entry, merge/add only that entry.
-3. If `pfc-mcp` already exists, validate/update only MCP launch fields (`command`, `args`, and client-specific extras).
+2. If config exists but has no `itasca-mcp` entry, merge/add only that entry.
+3. If `itasca-mcp` already exists, validate/update only MCP launch fields (`command`, `args`, and client-specific extras).
 4. Do not overwrite unrelated MCP servers.
 
 ## Step 2 - Resolve `pfc_path`
@@ -211,7 +211,7 @@ Expected output includes:
 
 Then reconnect MCP client and call:
 
-- `pfc_execute_code` with a simple snippet, e.g. `print('hello from PFC')`
+- `itasca_execute_code` with a simple snippet, e.g. `print('hello from PFC')`
 
 If `pfc_*` MCP tools are not visible in the client, ask user to fully restart client session first, then retry.
 
@@ -237,7 +237,7 @@ Success example (shape may vary by client):
   - Bridge package not installed in PFC embedded Python (or installed into the
     wrong interpreter). Re-run Step 3 against the resolved `pfc_python`.
   - One-shot fallback: paste the contents of
-    <https://raw.githubusercontent.com/yusong652/pfc-mcp/main/addon.py> into the
+    <https://raw.githubusercontent.com/yusong652/itasca-mcp/main/addon.py> into the
     PFC IPython console -- it installs (with mirror fallback) and starts the
     bridge in one go.
 - `status remains pending / plot diagnostic timeout during solve`:

--- a/docs/development/source-install.md
+++ b/docs/development/source-install.md
@@ -1,15 +1,15 @@
 # Developer Guide: Install and Run from Source
 
-This guide is for contributors who want to run `pfc-mcp` from a local checkout, test changes before publishing to PyPI, or install the bridge from local source into a PFC embedded Python environment.
+This guide is for contributors who want to run `itasca-mcp` from a local checkout, test changes before publishing to PyPI, or install the bridge from local source into a PFC embedded Python environment.
 
 ## Runtime Split
 
 This repository contains two separate runtimes:
 
-- `pfc-mcp`
-  The MCP server package under [`src/pfc_mcp`](../../src/pfc_mcp), running on standard Python `>=3.10`
+- `itasca-mcp`
+  The MCP server package under [`src/itasca_mcp`](../../src/itasca_mcp), running on standard Python `>=3.10`
 - `itasca-mcp-bridge`
-  The bridge package under [`itasca-mcp-bridge`](../../itasca-mcp-bridge), running inside PFC embedded Python. This directory is a **git submodule**: its own repository ([`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge)) with an independent release cycle. `pfc-mcp` only records *which* bridge commit to use, not the bridge's files.
+  The bridge package under [`itasca-mcp-bridge`](../../itasca-mcp-bridge), running inside PFC embedded Python. This directory is a **git submodule**: its own repository ([`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge)) with an independent release cycle. `itasca-mcp` only records *which* bridge commit to use, not the bridge's files.
 
 Treat them as separate installation targets even though they appear in the same working tree.
 
@@ -18,7 +18,7 @@ Treat them as separate installation targets even though they appear in the same 
 Clone with the bridge submodule (it is required for Steps 3–7):
 
 ```bash
-git clone --recurse-submodules https://github.com/yusong652/pfc-mcp.git
+git clone --recurse-submodules https://github.com/yusong652/itasca-mcp.git
 ```
 
 Already cloned without `--recurse-submodules`? `itasca-mcp-bridge/` is empty until you initialize it:
@@ -41,22 +41,22 @@ uv run pytest tests
 
 ### Working with the bridge submodule
 
-`itasca-mcp-bridge/` is a pinned pointer (a gitlink, mode `160000`) to one commit of the separate [`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo — `pfc-mcp` tracks a single SHA there, not the bridge's source files. Practical consequences:
+`itasca-mcp-bridge/` is a pinned pointer (a gitlink, mode `160000`) to one commit of the separate [`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) repo — `itasca-mcp` tracks a single SHA there, not the bridge's source files. Practical consequences:
 
-- **After pulling `pfc-mcp`**, re-sync the pin — the submodule working tree does not move on its own:
+- **After pulling `itasca-mcp`**, re-sync the pin — the submodule working tree does not move on its own:
 
   ```bash
   git submodule update --init --recursive
   ```
 
-- **To bump the bridge version**, check out the desired commit inside `itasca-mcp-bridge/`, then stage the moved pointer explicitly in `pfc-mcp`:
+- **To bump the bridge version**, check out the desired commit inside `itasca-mcp-bridge/`, then stage the moved pointer explicitly in `itasca-mcp`:
 
   ```bash
   git add itasca-mcp-bridge && git commit -m "chore: bump itasca-mcp-bridge pin"
   ```
 
 - **Push order matters**: push the bridge repo first. The pinned commit must already exist on the public bridge repo, or other clones cannot fetch it.
-- `git status` showing `modified: itasca-mcp-bridge (untracked content)` usually just means the submodule working tree has local/untracked files relative to the pin — not that `pfc-mcp` is tracking bridge sources. Bump the pin only when you intend to.
+- `git status` showing `modified: itasca-mcp-bridge (untracked content)` usually just means the submodule working tree has local/untracked files relative to the pin — not that `itasca-mcp` is tracking bridge sources. Bump the pin only when you intend to.
 
 ## 2. Point Your MCP Client at the Local Checkout
 
@@ -65,9 +65,9 @@ If you want your MCP client to use local source instead of the published PyPI pa
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/pfc-mcp", "pfc-mcp", "--bridge-url", "ws://localhost:9001"]
+      "args": ["run", "--directory", "/path/to/itasca-mcp", "itasca-mcp", "--bridge-url", "ws://localhost:9001"]
     }
   }
 }
@@ -75,7 +75,7 @@ If you want your MCP client to use local source instead of the published PyPI pa
 
 The `--bridge-url` argument is optional (defaults to `ws://localhost:9001`). To
 connect to a bridge on a non-default port, pass `--bridge-port` instead of
-spelling out the whole URL — e.g. `"args": [..., "pfc-mcp", "--bridge-port", "9002"]`
+spelling out the whole URL — e.g. `"args": [..., "itasca-mcp", "--bridge-port", "9002"]`
 when the bridge was started with `itasca_mcp_bridge.start(port=9002)`.
 
 This is the simplest way to test MCP-side changes without building or publishing packages.
@@ -85,7 +85,7 @@ This is the simplest way to test MCP-side changes without building or publishing
 If you only need bridge-side changes to take effect in PFC, you do not need to install the bridge package at all. In the PFC IPython console:
 
 ```python
-%run C:/path/to/pfc-mcp/itasca-mcp-bridge/start_bridge.py
+%run C:/path/to/itasca-mcp/itasca-mcp-bridge/start_bridge.py
 ```
 
 Notes:
@@ -108,8 +108,8 @@ Pick the correct interpreter for your PFC version:
 Example commands:
 
 ```powershell
-& "C:\Program Files\Itasca\PFC700\exe64\python36\python.exe" -m pip install --user -e C:\path\to\pfc-mcp\itasca-mcp-bridge
-& "C:\Program Files\Itasca\ItascaSoftware900\exe64\python310\python.exe" -m pip install --user -e C:\path\to\pfc-mcp\itasca-mcp-bridge
+& "C:\Program Files\Itasca\PFC700\exe64\python36\python.exe" -m pip install --user -e C:\path\to\itasca-mcp\itasca-mcp-bridge
+& "C:\Program Files\Itasca\ItascaSoftware900\exe64\python310\python.exe" -m pip install --user -e C:\path\to\itasca-mcp\itasca-mcp-bridge
 ```
 
 Why use the embedded interpreter from a terminal:
@@ -141,7 +141,7 @@ Then start the bridge in PFC and verify from your MCP client:
 
 1. Start the bridge in PFC with `itasca_mcp_bridge.start()` or `%run .../start_bridge.py`
 2. Restart the MCP client session
-3. Call `pfc_list_tasks`
+3. Call `itasca_list_tasks`
 
 ## 7. Recommended Dev Loop
 

--- a/docs/development/source-install.zh-CN.md
+++ b/docs/development/source-install.zh-CN.md
@@ -6,10 +6,10 @@
 
 这个仓库实际上包含两个独立运行时：
 
-- `pfc-mcp`
-  位于 [`src/pfc_mcp`](../../src/pfc_mcp) 的 MCP 服务端包，运行在标准 Python `>=3.10`
+- `itasca-mcp`
+  位于 [`src/itasca_mcp`](../../src/itasca_mcp) 的 MCP 服务端包，运行在标准 Python `>=3.10`
 - `itasca-mcp-bridge`
-  位于 [`itasca-mcp-bridge`](../../itasca-mcp-bridge) 的 bridge 包，运行在 PFC 内嵌 Python 中。这个目录是一个 **git submodule**，指向独立仓库 [`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge)，有自己的发布周期。`pfc-mcp` 只记录使用哪一个 bridge commit，不保存 bridge 源码本身。
+  位于 [`itasca-mcp-bridge`](../../itasca-mcp-bridge) 的 bridge 包，运行在 PFC 内嵌 Python 中。这个目录是一个 **git submodule**，指向独立仓库 [`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge)，有自己的发布周期。`itasca-mcp` 只记录使用哪一个 bridge commit，不保存 bridge 源码本身。
 
 虽然它们在同一个工作树里，但安装和验证时应当视为两个独立目标。
 
@@ -18,7 +18,7 @@
 带上 bridge submodule 一起克隆（第 3–7 步会用到）：
 
 ```bash
-git clone --recurse-submodules https://github.com/yusong652/pfc-mcp.git
+git clone --recurse-submodules https://github.com/yusong652/itasca-mcp.git
 ```
 
 如果之前已经不带 `--recurse-submodules` 克隆过了，`itasca-mcp-bridge/` 会是空的，需要初始化：
@@ -41,22 +41,22 @@ uv run pytest tests
 
 ### 关于 bridge submodule 的日常操作
 
-`itasca-mcp-bridge/` 是一个固定 commit 的指针（gitlink，mode `160000`），指向独立仓库 [`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) 的某一个 SHA——`pfc-mcp` 跟踪的是这一个 SHA，不是 bridge 的源文件。实际工作中要注意：
+`itasca-mcp-bridge/` 是一个固定 commit 的指针（gitlink，mode `160000`），指向独立仓库 [`yusong652/itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) 的某一个 SHA——`itasca-mcp` 跟踪的是这一个 SHA，不是 bridge 的源文件。实际工作中要注意：
 
-- **拉了 `pfc-mcp` 之后**，submodule 工作树不会自动跟着移动，需要重新同步：
+- **拉了 `itasca-mcp` 之后**，submodule 工作树不会自动跟着移动，需要重新同步：
 
   ```bash
   git submodule update --init --recursive
   ```
 
-- **要升级 bridge 版本**，先在 `itasca-mcp-bridge/` 里 checkout 目标 commit，然后在 `pfc-mcp` 里把这个指针 stage 出来：
+- **要升级 bridge 版本**，先在 `itasca-mcp-bridge/` 里 checkout 目标 commit，然后在 `itasca-mcp` 里把这个指针 stage 出来：
 
   ```bash
   git add itasca-mcp-bridge && git commit -m "chore: bump itasca-mcp-bridge pin"
   ```
 
-- **push 顺序很重要**：先 push bridge 仓库——pin 指向的 commit 必须先在公开 bridge repo 上存在，否则别人 clone 你的 `pfc-mcp` 时拉不到。
-- `git status` 看到 `modified: itasca-mcp-bridge (untracked content)` 通常只是 submodule 工作树里多了些本地或未跟踪文件，并不代表 `pfc-mcp` 在跟踪 bridge 源码。除非你**确实要**升级 pin，否则不要 commit 这条 gitlink 变动。
+- **push 顺序很重要**：先 push bridge 仓库——pin 指向的 commit 必须先在公开 bridge repo 上存在，否则别人 clone 你的 `itasca-mcp` 时拉不到。
+- `git status` 看到 `modified: itasca-mcp-bridge (untracked content)` 通常只是 submodule 工作树里多了些本地或未跟踪文件，并不代表 `itasca-mcp` 在跟踪 bridge 源码。除非你**确实要**升级 pin，否则不要 commit 这条 gitlink 变动。
 
 ## 2. 让 MCP 客户端指向本地源码
 
@@ -65,9 +65,9 @@ uv run pytest tests
 ```json
 {
   "mcpServers": {
-    "pfc-mcp": {
+    "itasca-mcp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/pfc-mcp", "pfc-mcp", "--bridge-url", "ws://localhost:9001"]
+      "args": ["run", "--directory", "/path/to/itasca-mcp", "itasca-mcp", "--bridge-url", "ws://localhost:9001"]
     }
   }
 }
@@ -76,7 +76,7 @@ uv run pytest tests
 `--bridge-url` 参数是可选的（默认 `ws://localhost:9001`）。若 bridge 跑在非默认端口上，
 直接用 `--bridge-port` 即可，无需写出整条 URL——例如 bridge 以
 `itasca_mcp_bridge.start(port=9002)` 启动时，配置写
-`"args": [..., "pfc-mcp", "--bridge-port", "9002"]`。
+`"args": [..., "itasca-mcp", "--bridge-port", "9002"]`。
 
 这是验证 MCP 侧改动最简单的方式，不需要先构建或发布包。
 
@@ -85,7 +85,7 @@ uv run pytest tests
 如果你只是想让 bridge 侧代码修改在 PFC 中生效，其实不需要先安装 bridge 包。在 PFC 的 IPython 控制台里执行：
 
 ```python
-%run C:/path/to/pfc-mcp/itasca-mcp-bridge/start_bridge.py
+%run C:/path/to/itasca-mcp/itasca-mcp-bridge/start_bridge.py
 ```
 
 注意：
@@ -108,8 +108,8 @@ uv run pytest tests
 示例命令：
 
 ```powershell
-& "C:\Program Files\Itasca\PFC700\exe64\python36\python.exe" -m pip install --user -e C:\path\to\pfc-mcp\itasca-mcp-bridge
-& "C:\Program Files\Itasca\ItascaSoftware900\exe64\python310\python.exe" -m pip install --user -e C:\path\to\pfc-mcp\itasca-mcp-bridge
+& "C:\Program Files\Itasca\PFC700\exe64\python36\python.exe" -m pip install --user -e C:\path\to\itasca-mcp\itasca-mcp-bridge
+& "C:\Program Files\Itasca\ItascaSoftware900\exe64\python310\python.exe" -m pip install --user -e C:\path\to\itasca-mcp\itasca-mcp-bridge
 ```
 
 为什么推荐在终端里直接调用内嵌解释器：
@@ -141,7 +141,7 @@ bridge 包会自动拉取匹配的 `websockets` 版本：
 
 1. 在 PFC 中执行 `itasca_mcp_bridge.start()` 或 `%run .../start_bridge.py`
 2. 重启 MCP 客户端会话
-3. 调用 `pfc_list_tasks`
+3. 调用 `itasca_list_tasks`
 
 ## 7. 推荐开发循环
 

--- a/scripts/corpus/STRUCTURE_DESIGN.md
+++ b/scripts/corpus/STRUCTURE_DESIGN.md
@@ -245,7 +245,7 @@ Each Python SDK doc includes:
 
 ## Scoring System (for Search)
 
-Similar to `pfc_query_python_api.py`:
+Similar to `itasca_query_python_api.py`:
 
 ```python
 # Score ranges:
@@ -258,7 +258,7 @@ Similar to `pfc_query_python_api.py`:
 HIGH_CONFIDENCE_THRESHOLD = 700
 ```
 
-## Example Usage in pfc_query_command Tool
+## Example Usage in itasca_query_command Tool
 
 ```python
 # User query: "generate balls cubic"
@@ -295,4 +295,4 @@ Each JSON file should be validated against a JSON schema to ensure consistency:
 
 **Design Version**: 1.0
 **Created**: 2025-01-21
-**Purpose**: Foundation for `pfc_query_command` tool implementation
+**Purpose**: Foundation for `itasca_query_command` tool implementation

--- a/scripts/corpus/generate_3dec_boundary_conditions.py
+++ b/scripts/corpus/generate_3dec_boundary_conditions.py
@@ -19,7 +19,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "3dec/references"
 CAT_DIR = OUT / "boundary-conditions"
 CMD_INDEX = RES / "3dec/command_docs/index.json"

--- a/scripts/corpus/generate_3dec_fish_intrinsics.py
+++ b/scripts/corpus/generate_3dec_fish_intrinsics.py
@@ -26,7 +26,7 @@ from typing import Any
 DOCROOT = Path("C:/Program Files/Itasca/ItascaSoftware900/exe64/doc/3dec/block/doc/manual")
 BLOCK_FISH = DOCROOT / "block_manual/block_fish"
 FLOW_FISH = DOCROOT / "flow_manual/flow_fish"
-OUT = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/3dec/references")
+OUT = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/3dec/references")
 CAT_DIR = OUT / "fish-intrinsics"
 
 # Curated items. Each family's ``examples`` are real intrinsic names (validated

--- a/scripts/corpus/generate_3dec_geometry_data_table.py
+++ b/scripts/corpus/generate_3dec_geometry_data_table.py
@@ -16,7 +16,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "3dec/references"
 CAT_DIR = OUT / "geometry-data-table"
 CMD_INDEX = RES / "3dec/command_docs/index.json"

--- a/scripts/corpus/generate_3dec_histories_and_results.py
+++ b/scripts/corpus/generate_3dec_histories_and_results.py
@@ -25,7 +25,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "3dec/references"
 CAT_DIR = OUT / "histories-and-results"
 CMD_INDEX = RES / "3dec/command_docs/index.json"

--- a/scripts/corpus/generate_3dec_index.py
+++ b/scripts/corpus/generate_3dec_index.py
@@ -22,7 +22,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMANDS_DIR = RESOURCES / "3dec" / "command_docs" / "commands"
 FLAC_INDEX = RESOURCES / "flac" / "command_docs" / "index.json"
 OUT_INDEX = RESOURCES / "3dec" / "command_docs" / "index.json"

--- a/scripts/corpus/generate_3dec_initial_conditions.py
+++ b/scripts/corpus/generate_3dec_initial_conditions.py
@@ -23,7 +23,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "3dec/references"
 CAT_DIR = OUT / "initial-conditions"
 CMD_INDEX = RES / "3dec/command_docs/index.json"

--- a/scripts/corpus/generate_3dec_joint_models.py
+++ b/scripts/corpus/generate_3dec_joint_models.py
@@ -33,7 +33,7 @@ from typing import Any
 
 DOC = Path("C:/Program Files/Itasca/ItascaSoftware900/exe64/doc/3dec/docproject/source/theory")
 SRC_BASE = "https://docs.itascacg.com/itasca900/3dec/docproject/source/theory"
-OUT = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/3dec/references")
+OUT = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/3dec/references")
 CAT_DIR = OUT / "joint-models"
 
 # keyword (as `block contact jmodel assign <keyword>`) -> spec.
@@ -284,8 +284,8 @@ def main() -> None:
         },
         "notes": [
             "References are syntax elements used within commands, not standalone commands",
-            "Use pfc_browse_commands (software='3dec') for command syntax",
-            "Use pfc_browse_reference (software='3dec') for reference documentation",
+            "Use itasca_browse_commands (software='3dec') for command syntax",
+            "Use itasca_browse_reference (software='3dec') for reference documentation",
         ],
     }
     OUT.joinpath("index.json").write_text(json.dumps(top, indent=2, ensure_ascii=False) + "\n", "utf-8")

--- a/scripts/corpus/generate_3dec_plot_items.py
+++ b/scripts/corpus/generate_3dec_plot_items.py
@@ -24,7 +24,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "3dec/references"
 CAT_DIR = OUT / "plot-items"
 

--- a/scripts/corpus/generate_3dec_python_skeleton.py
+++ b/scripts/corpus/generate_3dec_python_skeleton.py
@@ -2,7 +2,7 @@
 
 3DEC's engine-specific Python modules (itasca.block, itasca.flowplane, ...) are
 hand-authored docs and are deferred to a later pass. For now we ship a minimal
-skeleton so pfc_query_python_api / pfc_browse_python_api answer software="3dec"
+skeleton so itasca_query_python_api / itasca_browse_python_api answer software="3dec"
 without erroring: it exposes only the shared `itasca` core module, which already
 lives once in _common/ and is reused verbatim (same as FLAC's index does).
 
@@ -17,7 +17,7 @@ import json
 import shutil
 from pathlib import Path
 
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 FLAC_PY = RESOURCES / "flac" / "python_sdk_docs"
 OUT_PY = RESOURCES / "3dec" / "python_sdk_docs"
 

--- a/scripts/corpus/generate_massflow_index.py
+++ b/scripts/corpus/generate_massflow_index.py
@@ -23,7 +23,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMANDS_DIR = RESOURCES / "massflow" / "command_docs" / "commands"
 FLAC_INDEX = RESOURCES / "flac" / "command_docs" / "index.json"
 OUT_INDEX = RESOURCES / "massflow" / "command_docs" / "index.json"

--- a/scripts/corpus/generate_massflow_plot_items.py
+++ b/scripts/corpus/generate_massflow_plot_items.py
@@ -26,7 +26,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "massflow/references"
 CAT_DIR = OUT / "plot-items"
 

--- a/scripts/corpus/generate_massflow_python_skeleton.py
+++ b/scripts/corpus/generate_massflow_python_skeleton.py
@@ -1,8 +1,8 @@
 """Generate the MassFlow Python SDK skeleton index.
 
 MassFlow's engine-specific Python modules are hand-authored docs deferred to a
-later pass. For now we ship a minimal skeleton so pfc_query_python_api /
-pfc_browse_python_api answer software="massflow" without erroring: it exposes
+later pass. For now we ship a minimal skeleton so itasca_query_python_api /
+itasca_browse_python_api answer software="massflow" without erroring: it exposes
 only the shared `itasca` core module, which already lives once in _common/ and
 is reused verbatim (same as FLAC/3DEC/MPoint skeletons do).
 
@@ -14,7 +14,7 @@ import json
 import shutil
 from pathlib import Path
 
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 FLAC_PY = RESOURCES / "flac" / "python_sdk_docs"
 OUT_PY = RESOURCES / "massflow" / "python_sdk_docs"
 

--- a/scripts/corpus/generate_mpoint_conditions.py
+++ b/scripts/corpus/generate_mpoint_conditions.py
@@ -24,7 +24,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "mpoint/references"
 CMD_INDEX = RES / "mpoint/command_docs/index.json"
 

--- a/scripts/corpus/generate_mpoint_fish_intrinsics.py
+++ b/scripts/corpus/generate_mpoint_fish_intrinsics.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 DOCROOT = Path("C:/Program Files/Itasca/Itasca Software Subscription/exe64/doc/mpm")
-OUT = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/mpoint/references")
+OUT = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/mpoint/references")
 CAT_DIR = OUT / "fish-intrinsics"
 
 ITEMS: list[dict[str, Any]] = [

--- a/scripts/corpus/generate_mpoint_index.py
+++ b/scripts/corpus/generate_mpoint_index.py
@@ -19,7 +19,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMANDS_DIR = RESOURCES / "mpoint" / "command_docs" / "commands"
 FLAC_INDEX = RESOURCES / "flac" / "command_docs" / "index.json"
 OUT_INDEX = RESOURCES / "mpoint" / "command_docs" / "index.json"

--- a/scripts/corpus/generate_mpoint_plot_items.py
+++ b/scripts/corpus/generate_mpoint_plot_items.py
@@ -29,7 +29,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT = RES / "mpoint/references"
 CAT_DIR = OUT / "plot-items"
 
@@ -457,8 +457,8 @@ def main() -> None:
             },
             "notes": [
                 "References are syntax elements used within commands, not standalone commands",
-                "Use pfc_browse_commands (software='mpoint') for command syntax",
-                "Use pfc_browse_reference (software='mpoint') for reference documentation",
+                "Use itasca_browse_commands (software='mpoint') for command syntax",
+                "Use itasca_browse_reference (software='mpoint') for reference documentation",
             ],
         }
     top.setdefault("categories", {})["plot-items"] = {

--- a/scripts/corpus/generate_mpoint_python_skeleton.py
+++ b/scripts/corpus/generate_mpoint_python_skeleton.py
@@ -2,7 +2,7 @@
 
 MPoint's engine-specific Python modules (itasca.mpoint, ...) are hand-authored
 docs deferred to a later pass. For now we ship a minimal skeleton so
-pfc_query_python_api / pfc_browse_python_api answer software="mpoint" without
+itasca_query_python_api / itasca_browse_python_api answer software="mpoint" without
 erroring: it exposes only the shared `itasca` core module, which already lives
 once in _common/ and is reused verbatim (same as FLAC/3DEC skeletons do).
 
@@ -14,7 +14,7 @@ import json
 import shutil
 from pathlib import Path
 
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 FLAC_PY = RESOURCES / "flac" / "python_sdk_docs"
 OUT_PY = RESOURCES / "mpoint" / "python_sdk_docs"
 

--- a/scripts/corpus/parse_3dec900.py
+++ b/scripts/corpus/parse_3dec900.py
@@ -43,7 +43,7 @@ except ModuleNotFoundError:
 # ---------------------------------------------------------------------------
 
 DEC900_DOC = Path("C:/Program Files/Itasca/ItascaSoftware900/exe64/doc/3dec")
-COMMANDS_DIR = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands")
+COMMANDS_DIR = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands")
 
 # File-name prefix -> 3DEC-proprietary category. Order matters only for clarity;
 # prefixes are mutually exclusive ("cmd_block." never matches cmd_feblock.*).

--- a/scripts/corpus/parse_3dec_python.py
+++ b/scripts/corpus/parse_3dec_python.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from typing import Any
 
 DOC = Path("C:/Program Files/Itasca/ItascaSoftware900/exe64/doc/common/docproject/source/manual/scripting/python/doc")
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT_PY = RESOURCES / "3dec" / "python_sdk_docs"
 SRC_BASE = "https://docs.itascacg.com/itasca900/common/docproject/source/manual/scripting/python/doc"
 

--- a/scripts/corpus/parse_3dec_structural_properties.py
+++ b/scripts/corpus/parse_3dec_structural_properties.py
@@ -25,7 +25,7 @@ from typing import Any
 
 SEL = Path("C:/Program Files/Itasca/ItascaSoftware900/exe64/doc/common/sel/doc/manual/sel_manual")
 SRC_BASE = "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual"
-OUT = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/3dec/references")
+OUT = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/3dec/references")
 CAT_DIR = OUT / "structural-properties"
 
 # SEL types 3DEC exposes (itasca.structure: Beam/Cable/Geogrid/Liner/Pile/Shell).

--- a/scripts/corpus/parse_massflow.py
+++ b/scripts/corpus/parse_massflow.py
@@ -46,7 +46,7 @@ except ModuleNotFoundError:
 # ---------------------------------------------------------------------------
 
 MASSFLOW_DOC = Path("C:/Program Files/Itasca/Itasca Software Subscription/exe64/doc/massflow")
-COMMANDS_DIR = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/massflow/command_docs/commands")
+COMMANDS_DIR = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/massflow/command_docs/commands")
 
 PREFIX_TO_CATEGORY = {
     "cmd_massflow.": "massflow",

--- a/scripts/corpus/parse_massflow_python.py
+++ b/scripts/corpus/parse_massflow_python.py
@@ -40,7 +40,7 @@ DOC = Path(
     "C:/Program Files/Itasca/Itasca Software Subscription/exe64/doc"
     "/common/docproject/source/manual/scripting/python/doc"
 )
-RESOURCES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RESOURCES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 OUT_PY = RESOURCES / "massflow" / "python_sdk_docs"
 SRC_BASE = "https://docs.itascacg.com/itasca900/common/docproject/source/manual/scripting/python/doc"
 ENGINE = "massflow"

--- a/scripts/corpus/parse_mpoint.py
+++ b/scripts/corpus/parse_mpoint.py
@@ -37,7 +37,7 @@ except ModuleNotFoundError:
 # ---------------------------------------------------------------------------
 
 MPM_DOC = Path("C:/Program Files/Itasca/Itasca Software Subscription/exe64/doc/mpm")
-COMMANDS_DIR = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/mpoint/command_docs/commands")
+COMMANDS_DIR = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/mpoint/command_docs/commands")
 
 PREFIX_TO_CATEGORY = {
     "cmd_mpoint.": "mpoint",

--- a/scripts/corpus/parse_pfc600.py
+++ b/scripts/corpus/parse_pfc600.py
@@ -15,7 +15,7 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 PFC600_DOC = Path("C:/Program Files/Itasca/PFC600/exe64/doc")
-COMMANDS_DIR = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/command_docs/commands")
+COMMANDS_DIR = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/command_docs/commands")
 
 # Map category -> (html_dir, filename_pattern, id_prefix)
 #   html_dir: absolute Path to the folder containing HTML command files

--- a/scripts/corpus/parse_pfc700.py
+++ b/scripts/corpus/parse_pfc700.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
 
 
 PFC700_DOC = Path("C:/Program Files/Itasca/PFC700/exe64/doc")
-COMMANDS_DIR = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/command_docs/commands")
+COMMANDS_DIR = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/command_docs/commands")
 
 
 CATEGORY_CONFIG = {

--- a/scripts/corpus/parse_pfc900.py
+++ b/scripts/corpus/parse_pfc900.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
 # ---------------------------------------------------------------------------
 
 PFC900_DOC = Path("C:/Program Files/Itasca/ItascaSoftware900/exe64/doc")
-COMMANDS_DIR = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources/command_docs/commands")
+COMMANDS_DIR = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources/command_docs/commands")
 
 # Map category -> (html_dir, filename_pattern, id_prefix)
 #   html_dir: absolute Path to the folder containing HTML command files

--- a/scripts/corpus/wire_common_constitutive_models.py
+++ b/scripts/corpus/wire_common_constitutive_models.py
@@ -21,7 +21,7 @@ Usage:
 import json
 from pathlib import Path
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMON_REL = "_common/references/constitutive-models"
 FLAC_CAT = RES / "flac/references/constitutive-models/index.json"
 TDEC_REFS = RES / "3dec/references"

--- a/scripts/corpus/wire_common_range_elements.py
+++ b/scripts/corpus/wire_common_range_elements.py
@@ -19,7 +19,7 @@ Usage:
 import json
 from pathlib import Path
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMON_REL = "_common/references/range-elements"
 COMMON_DIR = RES / COMMON_REL
 

--- a/scripts/corpus/wire_massflow_common_references.py
+++ b/scripts/corpus/wire_massflow_common_references.py
@@ -24,7 +24,7 @@ Usage:
 import json
 from pathlib import Path
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMON_CM_REL = "_common/references/constitutive-models"
 COMMON_CM_DIR = RES / COMMON_CM_REL
 FLAC_CM = RES / "flac/references/constitutive-models/index.json"

--- a/scripts/corpus/wire_mpoint_common_references.py
+++ b/scripts/corpus/wire_mpoint_common_references.py
@@ -24,7 +24,7 @@ Usage:
 import json
 from pathlib import Path
 
-RES = Path("C:/Dev/Han/pfc-mcp/src/itasca_mcp/knowledge/resources")
+RES = Path("C:/Dev/Han/itasca-mcp/src/itasca_mcp/knowledge/resources")
 COMMON_CM_REL = "_common/references/constitutive-models"
 COMMON_CM_DIR = RES / COMMON_CM_REL
 FLAC_CM = RES / "flac/references/constitutive-models/index.json"

--- a/src/itasca_mcp/tools/execute_task.py
+++ b/src/itasca_mcp/tools/execute_task.py
@@ -67,7 +67,7 @@ def register(mcp: FastMCP) -> None:
         confirm its version with itasca_execute_code (`import
         itasca_mcp_bridge; print(itasca_mcp_bridge.__version__)`). To
         upgrade, fetch and follow the bootstrap guide, then resubmit:
-        https://raw.githubusercontent.com/yusong652/pfc-mcp/main/docs/agentic/pfc-mcp-bootstrap.md
+        https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-mcp-bootstrap.md
         """
         try:
             client = await get_bridge_client()

--- a/tests/test_tool_contracts.py
+++ b/tests/test_tool_contracts.py
@@ -1,7 +1,7 @@
-"""Contract tests for pfc-mcp tool response structures.
+"""Contract tests for itasca-mcp tool response structures.
 
 Verifies that each tool returns the expected field structure,
-ensuring the API contract between pfc-mcp and its consumers is stable.
+ensuring the API contract between itasca-mcp and its consumers is stable.
 """
 
 import http.server


### PR DESCRIPTION
Finishes the human-facing surface of the pfc-mcp → itasca-mcp rename. The package code (`src/itasca_mcp/`, `itasca_*` tool names) was already renamed; this sweeps the rest.

## Changed
- Docs (README en/zh, AGENTS/CLAUDE/GEMINI/WARP, docker/README, source-install) — `pfc-mcp` → `itasca-mcp`, tool names `pfc_*` → `itasca_*`
- Agentic bootstrap guides: renamed `docs/agentic/pfc-mcp-bootstrap-*.md` → `itasca-mcp-bootstrap-*.md` + internal cross-refs
- Repo URLs `yusong652/pfc-mcp` → `yusong652/itasca-mcp` (incl. the bootstrap URL in the `itasca_execute_task` tool description)
- Docker dev image tag `pfc-mcp:dev` → `itasca-mcp:dev` (Dockerfile / build.sh / run.sh / compose / .dockerignore kept consistent)
- CHANGELOG intro line

## Preserved (intentional)
- `pfc-mcp-bridge` (legacy frozen PyPI package, last release 0.3.3)
- `PFC` / `pfc` engine name (real Itasca product)
- `pfc_path` / `pfc_python` install-guide variables (PFC install dir / bundled interpreter)
- corpus-script internal vars; CHANGELOG historical entries

## Verify
- `tests/test_tool_contracts.py` + `tests/test_phase2_tools.py`: 11 passed
- Tree grep clean of stray `pfc-mcp` / `pfc_mcp` (excluding the preserved set above)

## Follow-up (not in this PR)
- Rename the demo GIF on the `assets` branch `pfc-mcp.gif` → `itasca-mcp.gif` (README now references the new name)
- Add `yusong652/itasca-mcp` trusted publisher to the **pfc-mcp** PyPI project (for the later deprecation shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)