### PR TITLE
docs: recommend mcp add commands for manual setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,22 @@ https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-
 
 ### Manual Setup
 
-**1. Register the MCP server** in your client config:
+**1. Register the MCP server** with your agent.
+
+Most agents register it with a single command:
+
+```bash
+# Claude Code
+claude mcp add itasca-mcp -- uvx itasca-mcp
+
+# Codex / Codex-cli
+codex mcp add itasca-mcp -- uvx itasca-mcp
+
+# Gemini CLI
+gemini mcp add itasca-mcp uvx itasca-mcp
+```
+
+Or fill in the MCP config file manually:
 
 ```json
 {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,7 +44,22 @@ https://raw.githubusercontent.com/yusong652/itasca-mcp/main/docs/agentic/itasca-
 
 ### 手动配置
 
-**1. 在客户端配置中注册 MCP 服务：**
+**1. 向你的智能体注册 MCP 服务。**
+
+大多数智能体一条命令即可添加：
+
+```bash
+# Claude Code
+claude mcp add itasca-mcp -- uvx itasca-mcp
+
+# Codex / Codex-cli
+codex mcp add itasca-mcp -- uvx itasca-mcp
+
+# Gemini CLI
+gemini mcp add itasca-mcp uvx itasca-mcp
+```
+
+或者手动填写MCP配置文件：
 
 ```json
 {


### PR DESCRIPTION
## What

Rework the **Manual Setup → Register the MCP server** step in both READMEs to lead with one-line `mcp add` commands instead of a config-file-only flow.

```bash
claude mcp add itasca-mcp -- uvx itasca-mcp   # Claude Code
codex  mcp add itasca-mcp -- uvx itasca-mcp   # Codex / Codex-cli
gemini mcp add itasca-mcp uvx itasca-mcp      # Gemini CLI
```

The JSON snippet stays as the manual fallback.

## Why

Most users now drive these agents from the CLI, where a single command is friendlier than hand-editing a JSON config. Commands verified against each tool's `mcp add --help`. Note Codex's CLI and GUI share `~/.codex/config.toml`, so one command covers both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)