### PR TITLE
docs: recommend engine 9.0+ in prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ### Prerequisites
 
-- **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow (6.0, 7.0, or 9.0)
+- **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow. 9.0+ recommended; Python 3-compatible 6.0 / 7.0 builds also supported.
 - **[uv](https://docs.astral.sh/uv/getting-started/installation/)** installed (for `uvx`)
 
 ### Agentic Setup (Recommended)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@
 
 ### 前置条件
 
-- 已安装一个 **ITASCA 引擎** —— PFC、FLAC、3DEC、MPoint 或 MassFlow（6.0、7.0 或 9.0）
+- 已安装一个 **ITASCA 引擎** —— PFC、FLAC、3DEC、MPoint 或 MassFlow。推荐 9.0 及以上版本；兼容 Python 3 的 6.0 / 7.0 版本同样支持。
 - 已安装 **[uv](https://docs.astral.sh/uv/getting-started/installation/)**（用于 `uvx`）
 
 ### 智能体自动配置（推荐）


### PR DESCRIPTION
Clarify the engine version prerequisite: 9.0+ is recommended, while Python 3-compatible 6.0 / 7.0 builds remain supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)