### PR TITLE
docs: four-engine montage header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 .pfc-mcp-bridge/
 .tmp/
 .pytest_tmp/
+temp/
 
 # Docker dev container's user workspace (mounted into container at /workspace).
 # Keep the dir itself via .gitkeep, ignore everything dropped inside.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/header.gif" alt="itasca-mcp" width="70%">
+  <img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/header.webp" alt="itasca-mcp" width="70%">
 </p>
 
 # itasca-mcp

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/header.gif" alt="itasca-mcp" width="70%">
+  <img src="https://raw.githubusercontent.com/yusong652/itasca-mcp/assets/header.webp" alt="itasca-mcp" width="70%">
 </p>
 
 # itasca-mcp


### PR DESCRIPTION
Replaces the single-engine `header.gif` with a new four-engine montage banner (PFC · FLAC · 3DEC · MPoint), each panel a real simulation driven through itasca-mcp.

- **Image**: shipped on the `assets` branch as `header.webp` (WebP q92, ~184 KB — visually lossless, ~5× smaller than the 864 KB PNG source).
- **Sources & pipeline** also on `assets` under `header/`: `render_all.py` (transparent panels, shared steel↔terracotta palette) → `montage.py` (equal diagonal-seam strips over a light-blue diagonal wash) → `add_title.py` (monospace wordmark).
- Updates both `README.md` and `README.zh-CN.md`.
- Gitignores the local `temp/` scratch dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)