### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,34 @@ section exists.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-04
+
+### Removed
+- **FLAC 6.0 documentation.** FLAC 6.x embeds Python 2.7, which cannot run
+  `itasca-mcp-bridge` (Python >= 3.6), so its command docs were removed from
+  the corpus and from the doc tools' version selectors. Requesting
+  `software="flac"` with `version="6.0"` now returns an `unsupported_version`
+  error stating the covered versions (FLAC: 7.0/9.0). PFC 6.0 is unaffected —
+  it ships Python 3.6 and remains fully supported (PFC: 6.0/7.0/9.0). Shared
+  `_common` docs no longer advertise versions outside the requesting engine's
+  coverage.
+
+### Fixed
+- **Bridge (`itasca-mcp-bridge` 0.4.1): client disconnects no longer dump
+  tracebacks into the engine GUI console.** A dropped MCP client socket on
+  Windows (`WinError 10053`, e.g. an SSE stream reconnecting) surfaced as a
+  noisy `ConnectionAbortedError` traceback; the connection now deregisters
+  quietly. Bridges pick this up automatically via self-upgrade on start.
+
+### Documentation
+- README prerequisites and the agentic bootstrap guide now state per-engine
+  minimum versions, with an engine-aware embedded-interpreter mapping; during
+  bootstrap the agent stops early with a clear report when the interpreter
+  resolves to `python27` (FLAC 6.x) instead of failing at the pip step.
+- README and bootstrap guide reframed as multi-engine (PFC → ITASCA), with
+  client-native `mcp add`-style commands for manual setup and an explicit
+  9.0+ engine recommendation.
+
 ## [0.6.0] - 2026-06-27
 
 First release under the `itasca-mcp` name (formerly `pfc-mcp`). The server is

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ### Prerequisites
 
-- **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow. 9.0+ recommended. Older builds are supported only if their embedded Python is 3.6+: PFC 6.0 / 7.0 qualify; FLAC requires 7.0+ (FLAC 6.x embeds Python 2.7 and cannot run the bridge).
+- **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow. 9.0+ recommended; PFC 6.0 / 7.0 and FLAC 7.0 are also supported.
 - **[uv](https://docs.astral.sh/uv/getting-started/installation/)** installed (for `uvx`)
 
 ### Agentic Setup (Recommended)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@
 
 ### 前置条件
 
-- 已安装一个 **ITASCA 引擎** —— PFC、FLAC、3DEC、MPoint 或 MassFlow。推荐 9.0 及以上版本。旧版本仅在其内嵌 Python 为 3.6+ 时可用：PFC 6.0 / 7.0 满足条件；FLAC 需 7.0 及以上（FLAC 6.x 内嵌 Python 2.7，无法运行 bridge）。
+- 已安装一个 **ITASCA 引擎** —— PFC、FLAC、3DEC、MPoint 或 MassFlow。推荐 9.0 及以上版本；也支持 PFC 6.0 / 7.0 与 FLAC 7.0。
 - 已安装 **[uv](https://docs.astral.sh/uv/getting-started/installation/)**（用于 `uvx`）
 
 ### 智能体自动配置（推荐）

--- a/src/itasca_mcp/__init__.py
+++ b/src/itasca_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Itasca MCP Server - ITASCA simulation tools (PFC, FLAC, 3DEC, MPoint, MassFlow) via MCP."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
Bump `__version__` to 0.6.1 and promote `## [Unreleased]` to `## [0.6.1] - 2026-07-04`. Also restates the README prerequisites positively (supported versions only).

Highlights: FLAC 6.0 docs removed from the corpus and version selectors, per-engine version gating in the doc tools, bridge 0.4.1 disconnect-noise fix restated, install-guide updates.

After merge: tag `v0.6.1` on main to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)