### PR TITLE
fix: port the pip isatty/interpreter-hint fixes to addon.py

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -59,10 +59,87 @@ def _build_install_args(index_url, trusted_hosts):
     ]
     for host in trusted_hosts:
         args += ["--trusted-host", host]
-    if sys.version_info >= (3, 10):
-        args += ["--no-warn-script-location", "--progress-bar", "off"]
     args.append(PACKAGE_NAME)
     return args
+
+
+def _embedded_python():
+    """Path to the engine's bundled Python interpreter, or "".
+
+    Inside the GUI `sys.executable` is the engine binary itself
+    (e.g. `pfc2d700_gui.exe`), which cannot run `-m pip`. The real
+    interpreter lives under `sys.exec_prefix` (`.../exe64/python36`).
+    """
+    prefixes = (sys.exec_prefix, getattr(sys, "base_prefix", ""))
+    candidates = ("python.exe", os.path.join("bin", "python3"), os.path.join("bin", "python"))
+    for prefix in prefixes:
+        if not prefix:
+            continue
+        for relative in candidates:
+            candidate = os.path.join(os.path.normpath(prefix), relative)
+            if os.path.isfile(candidate):
+                return candidate
+    return ""
+
+
+def _manual_install_hint():
+    python_path = _embedded_python()
+    if not python_path:
+        python_path = "<engine install dir>/python.exe"
+    return (
+        "You can also install manually and re-run this script -- in a "
+        "terminal, with the engine's own Python (a plain 'python' would "
+        "install into the system interpreter instead):\n"
+        '    "{}" -m pip install --user -U {}'.format(python_path, PACKAGE_NAME)
+    )
+
+
+class _StreamProxy(object):
+    """File-like proxy guaranteeing the attributes pip's progress bar probes.
+
+    Some engine GUI consoles install a stdout/stderr replacement (e.g.
+    Itasca's RedirectstdChannel) that has write/flush but no isatty. pip's
+    download progress bar calls ``file.isatty()`` unconditionally during
+    construction -- the AttributeError aborts the download and therefore
+    the whole install. Affects every pip that vendors ``progress`` (stock
+    pip 9 on PFC 6/7, reproduced up to pip 21). Delegates everything else
+    to the wrapped stream.
+    """
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
+
+    def isatty(self):
+        try:
+            return bool(self._stream.isatty())
+        except Exception:
+            return False
+
+    def flush(self):
+        try:
+            self._stream.flush()
+        except Exception:
+            pass
+
+
+def _progress_flags():
+    """Extra install args to silence pip's progress bar where supported.
+
+    Both flags exist since pip 10. On older pip the isatty=False reported
+    by _StreamProxy already keeps the vendored progress bar silent.
+    """
+    try:
+        import pip
+
+        major = int(str(pip.__version__).split(".")[0])
+    except Exception:
+        return []
+    if major >= 10:
+        return ["--no-warn-script-location", "--progress-bar", "off"]
+    return []
 
 
 def _resolve_pip_main():
@@ -97,22 +174,30 @@ def _resolve_pip_main():
 
 
 def _run_pip(args):
-    pip_main = _resolve_pip_main()
-    if pip_main is None:
-        raise RuntimeError(
-            "Could not locate pip's Python entry point in this engine interpreter. "
-            "Install the bridge manually, then re-run this script:\n"
-            "    python -m pip install --user itasca-mcp-bridge"
-        )
+    # Swap in the isatty-safe proxies BEFORE pip is first imported: pip
+    # binds ``file = sys.stdout`` on its progress-bar classes at import
+    # time, so a later swap would not reach them.
+    previous_streams = (sys.stdout, sys.stderr)
+    if sys.stdout is not None:
+        sys.stdout = _StreamProxy(sys.stdout)
+    if sys.stderr is not None:
+        sys.stderr = _StreamProxy(sys.stderr)
 
     # The engine runs pip inside an IPython host; temporarily suppress logging
     # handler tracebacks that don't reflect actual installation failures.
     previous_raise_exceptions = logging.raiseExceptions
     logging.raiseExceptions = False
     try:
-        return pip_main(list(args))
+        pip_main = _resolve_pip_main()
+        if pip_main is None:
+            raise RuntimeError(
+                "Could not locate pip's Python entry point in this engine "
+                "interpreter. " + _manual_install_hint()
+            )
+        return pip_main(list(args) + _progress_flags())
     finally:
         logging.raiseExceptions = previous_raise_exceptions
+        sys.stdout, sys.stderr = previous_streams
 
 
 def _install_bridge():
@@ -192,9 +277,8 @@ def main():
                 "Bridge installation failed (pip exit code {}). The real pip "
                 "error is in the output above this message -- read that, not "
                 "this line. Common causes: no network route to PyPI, or a "
-                "corporate proxy/firewall blocking the index. You can also "
-                "install manually and re-run this script:\n"
-                "    python -m pip install --user itasca-mcp-bridge".format(code)
+                "corporate proxy/firewall blocking the index. ".format(code)
+                + _manual_install_hint()
             )
 
     itasca_mcp_bridge = _import_bridge()

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -53,13 +53,39 @@ def test_build_install_args_no_trusted_host_when_empty():
     assert "--trusted-host" not in args
 
 
-def test_build_install_args_progress_flags_track_python_version():
-    # The quiet-output flags are gated on the *runner* interpreter; pin that
-    # documented behaviour rather than a fixed expectation.
+def test_build_install_args_carry_no_progress_flags():
+    # The quiet-output flags moved to _run_pip (_progress_flags), gated on
+    # the pip version that will actually parse them -- not on the Python
+    # version, and not baked into the static argument list.
     args = addon._build_install_args("https://example.test/simple/", ())
-    flags_present = "--no-warn-script-location" in args
 
-    assert flags_present is (sys.version_info >= (3, 10))
+    assert "--no-warn-script-location" not in args
+    assert "--progress-bar" not in args
+
+
+# --- _progress_flags -------------------------------------------------------
+
+
+def test_progress_flags_present_on_modern_pip(monkeypatch):
+    modern_pip = types.ModuleType("pip")
+    modern_pip.__version__ = "21.3.1"
+    monkeypatch.setitem(sys.modules, "pip", modern_pip)
+
+    assert addon._progress_flags() == ["--no-warn-script-location", "--progress-bar", "off"]
+
+
+def test_progress_flags_empty_when_pip_unimportable(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pip", None)
+
+    assert addon._progress_flags() == []
+
+
+def test_progress_flags_empty_on_old_pip(monkeypatch):
+    old_pip = types.ModuleType("pip")
+    old_pip.__version__ = "9.0.1"
+    monkeypatch.setitem(sys.modules, "pip", old_pip)
+
+    assert addon._progress_flags() == []
 
 
 # --- _resolve_pip_main ---------------------------------------------------
@@ -101,9 +127,118 @@ def test_run_pip_passes_args_and_returns_code(monkeypatch):
         return 0
 
     monkeypatch.setattr(addon, "_resolve_pip_main", lambda: fake_pip_main)
+    monkeypatch.setattr(addon, "_progress_flags", lambda: [])
 
     assert addon._run_pip(["install", "pkg"]) == 0
     assert received == [["install", "pkg"]]
+
+
+def test_run_pip_appends_progress_flags(monkeypatch):
+    received = []
+
+    def fake_pip_main(args):
+        received.append(args)
+        return 0
+
+    monkeypatch.setattr(addon, "_resolve_pip_main", lambda: fake_pip_main)
+    monkeypatch.setattr(addon, "_progress_flags", lambda: ["--progress-bar", "off"])
+
+    assert addon._run_pip(["install", "pkg"]) == 0
+    assert received == [["install", "pkg", "--progress-bar", "off"]]
+
+
+class _ChannelWithoutIsatty:
+    """Mimics Itasca's RedirectstdChannel: write/flush only, no isatty."""
+
+    def __init__(self):
+        self.written = []
+
+    def write(self, text):
+        self.written.append(text)
+
+    def flush(self):
+        pass
+
+
+def test_stream_proxy_reports_not_a_tty_when_isatty_missing():
+    # The field crash: pip's progress bar calls file.isatty() on a GUI
+    # console channel that doesn't have it.
+    assert addon._StreamProxy(_ChannelWithoutIsatty()).isatty() is False
+
+
+def test_stream_proxy_delegates_existing_isatty():
+    class Tty:
+        def isatty(self):
+            return True
+
+    assert addon._StreamProxy(Tty()).isatty() is True
+
+
+def test_stream_proxy_delegates_write():
+    channel = _ChannelWithoutIsatty()
+    addon._StreamProxy(channel).write("hello")
+    assert channel.written == ["hello"]
+
+
+def test_run_pip_proxies_streams_while_pip_runs_and_restores(monkeypatch):
+    channel = _ChannelWithoutIsatty()
+    monkeypatch.setattr(sys, "stdout", channel)
+    seen = {}
+
+    def fake_resolve():
+        # pip is first imported inside _resolve_pip_main and binds
+        # sys.stdout to its progress-bar classes at import time, so the
+        # proxy must already be installed here.
+        seen["stdout_type"] = type(sys.stdout)
+        seen["isatty"] = sys.stdout.isatty()
+        return lambda args: 0
+
+    monkeypatch.setattr(addon, "_resolve_pip_main", fake_resolve)
+    monkeypatch.setattr(addon, "_progress_flags", lambda: [])
+
+    assert addon._run_pip(["install", "pkg"]) == 0
+    assert seen["stdout_type"] is addon._StreamProxy
+    assert seen["isatty"] is False
+    assert sys.stdout is channel  # restored
+
+
+def test_run_pip_restores_streams_when_pip_raises(monkeypatch):
+    channel = _ChannelWithoutIsatty()
+    monkeypatch.setattr(sys, "stderr", channel)
+
+    def boom(_args):
+        raise RuntimeError("pip blew up")
+
+    monkeypatch.setattr(addon, "_resolve_pip_main", lambda: boom)
+    monkeypatch.setattr(addon, "_progress_flags", lambda: [])
+
+    with pytest.raises(RuntimeError, match="blew up"):
+        addon._run_pip(["install", "pkg"])
+
+    assert sys.stderr is channel
+
+
+# --- _manual_install_hint --------------------------------------------------
+
+
+def test_manual_hint_names_the_engine_interpreter(monkeypatch):
+    monkeypatch.setattr(
+        addon,
+        "_embedded_python",
+        lambda: r"C:\Program Files\Itasca\PFC700\exe64\python36\python.exe",
+    )
+
+    hint = addon._manual_install_hint()
+    assert (
+        '"C:\\Program Files\\Itasca\\PFC700\\exe64\\python36\\python.exe" -m pip install --user -U itasca-mcp-bridge'
+    ) in hint
+
+
+def test_manual_hint_degrades_when_interpreter_unknown(monkeypatch):
+    monkeypatch.setattr(addon, "_embedded_python", lambda: "")
+
+    hint = addon._manual_install_hint()
+    assert "<engine install dir>" in hint
 
 
 def test_run_pip_raises_helpful_error_when_no_pip(monkeypatch):


### PR DESCRIPTION
## Why

`addon.py` shares the bridge's in-process pip invocation, so both defects fixed in [itasca-mcp-bridge 0.4.3](https://github.com/yusong652/itasca-mcp-bridge/pull/30) existed here too. This matters doubly: **addon.py is the recovery channel** for installs whose self-upgrade the isatty crash already disabled (old bridges can't self-upgrade past the bug), so it must not crash the same way when a stuck user re-runs the bootstrap.

Uninstall-then-reinstall was considered and rejected: the install args already carry `-U`, so version-wise addon.py upgrades any old bridge in place — and an uninstall-first flow would strand the user with *no* bridge if the download then fails. The actual blocker was pip crashing, not pip refusing to upgrade.

## What

- `_run_pip` wraps `sys.stdout`/`sys.stderr` in an isatty-safe delegating `_StreamProxy` before pip is first imported (pip binds `sys.stdout` onto its progress-bar classes at import time), restored afterwards
- `--progress-bar off` / `--no-warn-script-location` now gate on pip ≥ 10 (where the flags exist) instead of Python ≥ 3.10
- both manual-install hints print the engine interpreter's full quoted path derived from `sys.exec_prefix` (`sys.executable` is the GUI binary itself, e.g. `pfc2d700_gui.exe`) and warn against bare `python`, which installs into the system interpreter

## Validation

- End-to-end with a no-isatty stdout (mimicking `RedirectstdChannel`): real PyPI download+install succeeds under stock pip 9.0.1 and pip 21.3.1; unfixed addon crashed under both
- `py_compile` clean under PFC 7.0's Python 3.6
- 194 tests pass; `tests/test_addon.py` updated for the moved progress flags and extended with proxy/restore/hint regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
