### PR TITLE
fix: remove transport-level retry from bridge client

### DIFF
--- a/src/itasca_mcp/bridge/client.py
+++ b/src/itasca_mcp/bridge/client.py
@@ -27,15 +27,11 @@ class ItascaBridgeClient:
         self,
         url: str,
         reconnect_interval_s: float,
-        max_retries: int,
         request_timeout_s: float,
-        auto_reconnect: bool,
     ) -> None:
         self.url = url
         self.reconnect_interval_s = reconnect_interval_s
-        self.max_retries = max_retries
         self.request_timeout_s = request_timeout_s
-        self.auto_reconnect = auto_reconnect
 
         self._client: httpx.AsyncClient | None = None
         self._sse_task: asyncio.Task[Any] | None = None
@@ -141,27 +137,20 @@ class ItascaBridgeClient:
         payload: dict[str, Any] = response.json()
         return payload
 
-    async def _request_with_retry(
+    async def _request(
         self,
         message: dict[str, Any],
         operation_name: str,
         timeout_s: float | None = None,
     ) -> dict[str, Any]:
+        # Single attempt, no transport-level retry: execute requests are not
+        # idempotent (the bridge does not dedupe request_id), and the agent
+        # driving this client can see the error and decide for itself.
         timeout = timeout_s if timeout_s is not None else self.request_timeout_s
-        attempts = self.max_retries + 1
-        last_error: Exception | None = None
-
-        for attempt in range(1, attempts + 1):
-            try:
-                return await self._send_request(message, timeout)
-            except Exception as exc:
-                last_error = exc
-                if not self.auto_reconnect or attempt >= attempts:
-                    break
-                await asyncio.sleep(self.reconnect_interval_s)
-
-        assert last_error is not None
-        raise ConnectionError(f"{operation_name} failed: {last_error}") from last_error
+        try:
+            return await self._send_request(message, timeout)
+        except Exception as exc:
+            raise ConnectionError(f"{operation_name} failed: {exc}") from exc
 
     def listen_for_task(self, task_id: str) -> None:
         """Pre-register an event listener for task completion.
@@ -200,7 +189,7 @@ class ItascaBridgeClient:
         task_id: str,
         source: str = "agent",
     ) -> dict[str, Any]:
-        return await self._request_with_retry(
+        return await self._request(
             {
                 "type": "execute_task",
                 "task_id": task_id,
@@ -227,13 +216,13 @@ class ItascaBridgeClient:
         }
         if filter_text is not None:
             payload["filter_text"] = filter_text
-        return await self._request_with_retry(
+        return await self._request(
             payload,
             operation_name="check_task_status",
         )
 
     async def list_tasks(self, offset: int, limit: int | None) -> dict[str, Any]:
-        return await self._request_with_retry(
+        return await self._request(
             {
                 "type": "list_tasks",
                 "offset": offset,
@@ -243,7 +232,7 @@ class ItascaBridgeClient:
         )
 
     async def interrupt_task(self, task_id: str) -> dict[str, Any]:
-        return await self._request_with_retry(
+        return await self._request(
             {"type": "interrupt_task", "task_id": task_id},
             operation_name="interrupt_task",
             timeout_s=5.0,
@@ -251,7 +240,7 @@ class ItascaBridgeClient:
 
     async def execute_code(self, code: str, timeout_ms: int = 10000) -> dict[str, Any]:
         timeout_s = max(self.request_timeout_s, timeout_ms / 1000.0 + 5.0)
-        return await self._request_with_retry(
+        return await self._request(
             {
                 "type": "execute_code",
                 "code": code,
@@ -275,9 +264,7 @@ async def get_bridge_client() -> ItascaBridgeClient:
             _client = ItascaBridgeClient(
                 url=config.url,
                 reconnect_interval_s=config.reconnect_interval_s,
-                max_retries=config.max_retries,
                 request_timeout_s=config.request_timeout_s,
-                auto_reconnect=config.auto_reconnect,
             )
         await _client.connect()
         return _client

--- a/src/itasca_mcp/config.py
+++ b/src/itasca_mcp/config.py
@@ -4,23 +4,6 @@ import os
 from dataclasses import dataclass
 
 
-def _env_bool(name: str, default: bool) -> bool:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _env_int(name: str, default: int) -> int:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except ValueError:
-        return default
-
-
 def _env_float(name: str, default: float) -> float:
     value = os.getenv(name)
     if value is None:
@@ -35,9 +18,7 @@ def _env_float(name: str, default: float) -> float:
 class BridgeConfig:
     url: str
     reconnect_interval_s: float
-    max_retries: int
     request_timeout_s: float
-    auto_reconnect: bool
 
 
 def get_bridge_config() -> BridgeConfig:
@@ -45,7 +26,5 @@ def get_bridge_config() -> BridgeConfig:
     return BridgeConfig(
         url=os.getenv("ITASCA_MCP_BRIDGE_URL", "http://localhost:9001"),
         reconnect_interval_s=_env_float("ITASCA_MCP_RECONNECT_INTERVAL_S", 0.5),
-        max_retries=max(0, _env_int("ITASCA_MCP_MAX_RETRIES", 2)),
         request_timeout_s=max(1.0, _env_float("ITASCA_MCP_REQUEST_TIMEOUT_S", 10.0)),
-        auto_reconnect=_env_bool("ITASCA_MCP_AUTO_RECONNECT", True),
     )


### PR DESCRIPTION
## Summary

- Remove the request retry loop (`auto_reconnect` / `max_retries`) from `ItascaBridgeClient`; rename `_request_with_retry` to `_request` (single attempt).
- Drop the corresponding `BridgeConfig` fields and the `ITASCA_MCP_AUTO_RECONNECT` / `ITASCA_MCP_MAX_RETRIES` env vars (never documented), plus the now-unused `_env_bool` / `_env_int` helpers.

## Why

The retry loop dates from the WebSocket transport (where a failed request meant a dead socket and reconnect-then-resend was correct). Over HTTP it became a blind resend that also triggered on timeouts: execute requests are not idempotent and the bridge only uses `request_id` for logging/cancellation, not dedupe — a slow snippet that exceeded the timeout could be queued and executed twice.

Failing fast is also the right shape for an agent-facing client: the agent sees the error envelope immediately and decides whether to retry, instead of waiting through hidden resends to receive the same error.

Error classification is unchanged — `_request` still wraps failures as `ConnectionError(f"{operation} failed: ...")`, so `is_bridge_connectivity_error` routing and the tool error envelopes behave exactly as before, minus the retries. The SSE doorbell stream keeps its unconditional reconnect loop, the one place auto-recovery is load-bearing.

## Test plan

- `uv run pytest tests` — 183 passed
- `uv run ruff check` / `ruff format --check` / `mypy src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)