### PR TITLE
docs: fix bridge URL scheme in source-install guides (ws:// -> http://)

### DIFF
--- a/docs/development/source-install.md
+++ b/docs/development/source-install.md
@@ -67,13 +67,13 @@ If you want your MCP client to use local source instead of the published PyPI pa
   "mcpServers": {
     "itasca-mcp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/itasca-mcp", "itasca-mcp", "--bridge-url", "ws://localhost:9001"]
+      "args": ["run", "--directory", "/path/to/itasca-mcp", "itasca-mcp", "--bridge-url", "http://localhost:9001"]
     }
   }
 }
 ```
 
-The `--bridge-url` argument is optional (defaults to `ws://localhost:9001`). To
+The `--bridge-url` argument is optional (defaults to `http://localhost:9001`). To
 connect to a bridge on a non-default port, pass `--bridge-port` instead of
 spelling out the whole URL — e.g. `"args": [..., "itasca-mcp", "--bridge-port", "9002"]`
 when the bridge was started with `itasca_mcp_bridge.start(port=9002)`.

--- a/docs/development/source-install.zh-CN.md
+++ b/docs/development/source-install.zh-CN.md
@@ -67,13 +67,13 @@ uv run pytest tests
   "mcpServers": {
     "itasca-mcp": {
       "command": "uv",
-      "args": ["run", "--directory", "/path/to/itasca-mcp", "itasca-mcp", "--bridge-url", "ws://localhost:9001"]
+      "args": ["run", "--directory", "/path/to/itasca-mcp", "itasca-mcp", "--bridge-url", "http://localhost:9001"]
     }
   }
 }
 ```
 
-`--bridge-url` 参数是可选的（默认 `ws://localhost:9001`）。若 bridge 跑在非默认端口上，
+`--bridge-url` 参数是可选的（默认 `http://localhost:9001`）。若 bridge 跑在非默认端口上，
 直接用 `--bridge-port` 即可，无需写出整条 URL——例如 bridge 以
 `itasca_mcp_bridge.start(port=9002)` 启动时，配置写
 `"args": [..., "itasca-mcp", "--bridge-port", "9002"]`。


### PR DESCRIPTION
Follow-up to #59: the `--bridge-url` examples and stated default in both source-install guides still used the WebSocket-era `ws://localhost:9001`. The client default is `http://localhost:9001` (`src/itasca_mcp/config.py`, `server.py`). Missed last time because the sweep grepped for "websocket" but not `ws://`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)