### PR TITLE
docs: keep software parameter out of README pitch and tools overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 `itasca>model new ;now, with LLM.`
 
-**itasca-mcp** connects AI agents to [ITASCA](https://www.itascacg.com/)'s numerical modeling software — PFC, FLAC, 3DEC, MPoint, and MassFlow — through the [Model Context Protocol](https://modelcontextprotocol.io/). Browse documentation, run simulations, and execute code, all through natural conversation. Pick the engine with the `software` parameter.
+**itasca-mcp** connects AI agents to [ITASCA](https://www.itascacg.com/)'s numerical modeling software — PFC, FLAC, 3DEC, MPoint, and MassFlow — through the [Model Context Protocol](https://modelcontextprotocol.io/). Browse documentation, run simulations, and execute code, all through natural conversation.
 
 `itasca>model solve ;LLM solves.`
 
@@ -22,7 +22,7 @@
 
 ## Tools (10)
 
-**5 documentation tools** — browse and search the selected engine's commands, Python API, and reference docs (`software` parameter). No bridge required.
+**5 documentation tools** — browse and search the selected engine's commands, Python API, and reference docs. No bridge required.
 
 **5 execution tools** — interactive REPL, task submission, progress monitoring, interruption, and history. Requires bridge.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 `itasca>model new ;now, with LLM.`
 
-**itasca-mcp** 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 将 AI 智能体连接到 [ITASCA](https://www.itascacg.com/) 的数值模拟软件 —— PFC、FLAC、3DEC、MPoint、MassFlow。通过自然语言对话即可浏览文档、运行仿真和执行代码，用 `software` 参数选择引擎。
+**itasca-mcp** 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 将 AI 智能体连接到 [ITASCA](https://www.itascacg.com/) 的数值模拟软件 —— PFC、FLAC、3DEC、MPoint、MassFlow。通过自然语言对话即可浏览文档、运行仿真和执行代码。
 
 `itasca>model solve ;LLM solves.`
 
@@ -22,7 +22,7 @@
 
 ## 工具（10）
 
-**5 个文档工具** — 浏览和搜索所选引擎的命令、Python API 及参考文档（`software` 参数）。无需 bridge。
+**5 个文档工具** — 浏览和搜索所选引擎的命令、Python API 及参考文档。无需 bridge。
 
 **5 个执行工具** — 交互式 REPL、任务提交、进度监控、中断和历史浏览。需要 bridge。
 


### PR DESCRIPTION
Removes the `software` parameter mentions from the README first paragraph and the Tools section note, in both English and Chinese READMEs.

The first paragraph is the product pitch and the Tools section is a capability summary — a tool-contract detail is at the wrong altitude in both places. Agents discover the required `software` parameter from the tool schema at runtime, and the Features section already documents it for human readers, so nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)