### PR TITLE
docs: list an AI agent as a setup prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 - **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow. 9.0+ recommended; PFC 6.0 / 7.0 and FLAC 7.0 are also supported.
 - **[uv](https://docs.astral.sh/uv/getting-started/installation/)** installed (for `uvx`)
+- **An AI agent** — Claude Code, Codex CLI, Gemini CLI, or any MCP-capable client
 
 ### Agentic Setup (Recommended)
 
@@ -83,7 +84,7 @@ Download [`addon.py`](addon.py), then use either of these two flows inside the e
 
 ### Verify
 
-Restart your AI agent (Claude Code, Codex CLI, Gemini CLI, etc.) and ask it to call `itasca_execute_code` to verify the connection.
+Restart your AI agent and ask it to call `itasca_execute_code` to verify the connection.
 
 ## Daily Startup
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,6 +32,7 @@
 
 - 已安装一个 **ITASCA 引擎** —— PFC、FLAC、3DEC、MPoint 或 MassFlow。推荐 9.0 及以上版本；也支持 PFC 6.0 / 7.0 与 FLAC 7.0。
 - 已安装 **[uv](https://docs.astral.sh/uv/getting-started/installation/)**（用于 `uvx`）
+- 一个 **AI 智能体** —— Claude Code、Codex CLI、Gemini CLI 或其他任意 MCP 客户端
 
 ### 智能体自动配置（推荐）
 
@@ -83,7 +84,7 @@ gemini mcp add itasca-mcp uvx itasca-mcp
 
 ### 验证
 
-重启你的 AI 智能体（Claude Code、Codex CLI、Gemini CLI 等），让它调用 `itasca_execute_code` 来验证连接是否正常。
+重启你的 AI 智能体，让它调用 `itasca_execute_code` 来验证连接是否正常。
 
 ## 日常启动
 


### PR DESCRIPTION
The First-time Setup flow assumed the reader already has an MCP-capable agent installed, but Prerequisites only listed the ITASCA engine and uv. This adds the third (previously implicit) prerequisite with concrete examples — Claude Code, Codex CLI, Gemini CLI — and removes the same example list from the Verify step, so the examples appear exactly once, at the earliest point where the reader needs them. Applied to both English and Chinese READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)