### PR TITLE
Release 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,48 @@ section exists.
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-08-05
+
+All behaviour fixes below ship in `itasca-mcp-bridge` 0.4.4 and reach end
+users through the bridge's self-upgrade on next `start()`; they are
+restated here per this changelog's convention because users perceive
+them as itasca-mcp behaviour.
+
+### Fixed
+- **Defining FISH inside an async task no longer wedges the bridge.** A
+  multi-line `itasca.command()` containing `fish define ... end` was
+  split line by line, so the lone `fish define` dropped the engine
+  console into interactive FISH mode with the whole bridge unreachable
+  until someone typed `end` in the GUI. Definition blocks (`fish
+  define` / `fish operator` / legacy bare `define`) now survive
+  splitting as one command.
+- **A `model new` / `model restore` inside a multi-line command batch no
+  longer makes the bridge unreachable and tasks uninterruptible for the
+  rest of the call.** Those commands clear the engine's cycle-callback
+  registry — the sole source of busy-time reachability (status polls,
+  `execute_code` interleaving, interrupt). Batches are now split on the
+  `execute_code` path too, and the re-registration hook detects resets
+  on any line of a command, not just the first. Verified equally
+  load-bearing on PFC 6 and PFC 7.
+- **Interrupting a task on PFC 6 now reports `interrupted` instead of
+  `failed`.** PFC 6 wraps the interrupt exception opaquely; the
+  classifier now falls back to the task's pending interrupt flag.
+- **A live `itasca_execute_code` during a cycling task no longer
+  silently stops the run on PFC 6.** The console-capture machinery
+  issued a `show-message` keyword PFC 6 rejects, and a command
+  complaint inside the cycle callback aborts the running `model cycle`;
+  capture commands executing in the callback now omit the keyword.
+- **Scripts that rebind `itasca` through an intermediate variable (`_it
+  = itasca`) now get an explicit warning in the task/snippet output**
+  instead of a silently unsplit batch that can stall the bridge — the
+  splitter cannot statically prove such receivers alias itasca.
+
+### Documentation
+- **`itasca_execute_task` / `itasca_execute_code` docstrings explain
+  multi-line command normalization**: batches are split to one engine
+  call per command when `itasca.command` is reached through its import
+  name, and which rebinding shapes bypass the mechanism.
+
 ## [0.6.2] - 2026-08-04
 
 ### Fixed

--- a/src/itasca_mcp/__init__.py
+++ b/src/itasca_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Itasca MCP Server - ITASCA simulation tools (PFC, FLAC, 3DEC, MPoint, MassFlow) via MCP."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/src/itasca_mcp/tools/execute_code.py
+++ b/src/itasca_mcp/tools/execute_code.py
@@ -56,6 +56,17 @@ def register(mcp: FastMCP) -> None:
         - Create and export plots: itasca.command('plot ...')
         - Development and REPL-style testing
 
+        Multi-line itasca.command(\"\"\"...\"\"\") batches are normalized to
+        one engine call per command, which keeps the bridge reachable
+        while the batch runs — including after a `model new`/
+        `model restore`, which reset the engine's cycle-callback
+        registry mid-batch. The normalization applies when
+        itasca.command is reached through its import name
+        (`import itasca` / `import itasca as x` / `from itasca import
+        command`); rebinding through intermediate variables
+        (`_it = itasca`) bypasses it, and the output then carries a
+        bridge warning.
+
         `program call '<file>.p3dat'` (or .p2dat / .dat) through this
         tool is engine-version-gated. On 6/7 the command-script
         interpreter blocks the bridge for the script's entire

--- a/src/itasca_mcp/tools/execute_task.py
+++ b/src/itasca_mcp/tools/execute_task.py
@@ -39,6 +39,17 @@ def register(mcp: FastMCP) -> None:
         and interleaved with Python prints in the task log, visible
         through itasca_check_task_status.
 
+        Multi-line itasca.command(\"\"\"...\"\"\") batches are normalized to
+        one engine call per command, which keeps the bridge reachable
+        and the task interruptible while the batch runs — including
+        after a `model new`/`model restore`, which reset the engine's
+        cycle-callback registry mid-batch. The normalization applies
+        when itasca.command is reached through its import name
+        (`import itasca` / `import itasca as x` / `from itasca import
+        command`); rebinding through intermediate variables
+        (`_it = itasca`) bypasses it, and the task log then carries a
+        bridge warning.
+
         Having the script invoke `program call '<file>.p3dat'` (or
         .p2dat / .dat) is engine-version-gated. On 6/7 the
         command-script interpreter blocks the bridge for the


### PR DESCRIPTION
Release 0.6.3: bridge pin bumped to itasca-mcp-bridge 0.4.4 (execution hardening from tonight''s live debugging session), execution-tool docstrings explaining multi-line command normalization, and the curated changelog restating the user-perceivable bridge fixes.

Includes commit 5736413 (docs: multi-line command normalization in the execution tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)