### PR TITLE
chore: add server.json for MCP registry publishing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.yusong652/itasca-mcp",
+  "title": "ITASCA MCP Server",
+  "description": "Give AI agents full access to ITASCA PFC, FLAC3D, 3DEC - documentation, simulation, plot capture.",
+  "repository": {
+    "url": "https://github.com/yusong652/itasca-mcp",
+    "source": "github"
+  },
+  "version": "0.6.3",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "itasca-mcp",
+      "version": "0.6.3",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Checks in the `server.json` used to publish this server to the official MCP registry, mirroring yade-mcp.

Registry state (already live):
- `io.github.yusong652/itasca-mcp` 0.6.3 — active (new entry)
- `io.github.yusong652/pfc` 0.2.5 — deprecated, statusMessage points to the new name

Note for future releases: bump `version` here alongside `__version__` and run `mcp-publisher publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)