### PR TITLE
docs: PFC 7 plot item corpus + linearpbond bond_break event fixes (live-verified)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/3dec/references/index.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/references/index.json
@@ -90,7 +90,7 @@
   },
   "notes": [
     "References are syntax elements used within commands, not standalone commands",
-    "Use pfc_browse_commands (software='3dec') for command syntax",
-    "Use pfc_browse_reference (software='3dec') for reference documentation"
+    "Use itasca_browse_commands (software='3dec') for command syntax",
+    "Use itasca_browse_reference (software='3dec') for reference documentation"
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/fracture/group.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/fracture/group.json
@@ -4,7 +4,10 @@
     "group"
   ],
   "description": "Specify fracture group names. Use of the group logic is described in Groups . By default, s is assigned to the default slot Default . Use the remove keyword to remove s from all slots.",
-  "notes": [],
+  "notes": [
+    "To scope the assignment to the fractures of ONE DFN, use 'range fish <fn>' with a FISH function filtering on the fracture (official pattern), or assign the group right when each fracture is created. 'range dfn <name>' does NOT work here - that range element selects by distance from a DFN, not by membership, and fracture-scoped commands reject it.",
+    "Groups are the route to per-family fracture visualization: the fracture plot item has no per-DFN color attribute, but supports 'color-by text-attribute' with value 'group' followed by a slot name or the keyword Any, and 'range group <name>'."
+  ],
   "python_sdk_alternative": {
     "available": false,
     "workaround": ""
@@ -25,7 +28,16 @@
           "description": "Assign group s to the slot named slot . By default, slot Default is used."
         }
       ],
-      "examples": []
+      "examples": [
+        {
+          "command": "fracture group 'large' slot 'size' range fish mylarge",
+          "description": "Official pattern: assign group via a FISH filter function (mylarge returns 1 for fractures with area > 4); \"fracture group 'small' slot 'size' range fish mylarge not\" assigns the complement"
+        },
+        {
+          "command": "fracture group 'shear_cracks'",
+          "description": "No range: assigns the group to ALL fractures (slot Default)"
+        }
+      ]
     },
     "7.0": {
       "command": "fracture group",
@@ -42,7 +54,16 @@
           "description": "Assign group s to the slot named slot . By default, slot Default is used."
         }
       ],
-      "examples": []
+      "examples": [
+        {
+          "command": "fracture group 'large' slot 'size' range fish mylarge",
+          "description": "Official pattern: assign group via a FISH filter function (mylarge returns 1 for fractures with area > 4); \"fracture group 'small' slot 'size' range fish mylarge not\" assigns the complement"
+        },
+        {
+          "command": "fracture group 'shear_cracks'",
+          "description": "No range: assigns the group to ALL fractures (slot Default)"
+        }
+      ]
     },
     "9.0": {
       "command": "fracture group",
@@ -59,7 +80,16 @@
           "description": "Assign group s to the slot named slot . By default, slot Default is used."
         }
       ],
-      "examples": []
+      "examples": [
+        {
+          "command": "fracture group 'large' slot 'size' range fish mylarge",
+          "description": "Official pattern: assign group via a FISH filter function (mylarge returns 1 for fractures with area > 4); \"fracture group 'small' slot 'size' range fish mylarge not\" assigns the complement"
+        },
+        {
+          "command": "fracture group 'shear_cracks'",
+          "description": "No range: assigns the group to ALL fractures (slot Default)"
+        }
+      ]
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/active.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/active.json
@@ -109,6 +109,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/background.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/background.json
@@ -106,6 +106,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/clear.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/clear.json
@@ -80,6 +80,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/copy.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/copy.json
@@ -132,6 +132,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/create.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/create.json
@@ -79,6 +79,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/current.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/current.json
@@ -65,6 +65,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/delete.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/delete.json
@@ -79,6 +79,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/export.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/export.json
@@ -243,6 +243,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/item.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/item.json
@@ -17,7 +17,7 @@
     "tensor",
     "zone"
   ],
-  "description": "Create, destroy, or modify plot items associated with a plot. If no plot name is specified, the current view is assumed. Plot items control what is visualized in the plot. Note: Plot item configuration keywords are extensive and not fully documented; use 'plot export datafile' to inspect syntax.",
+  "description": "Create, destroy, or modify plot items associated with a plot. If no plot name is specified, the current view is assumed. Plot items control what is visualized in the plot. Note: Plot item configuration keywords are extensive and not fully documented; to discover them, issue a deliberately incomplete command and read the expected-token list in the engine error (e.g. 'plot item create zzz' lists every item type). Do NOT use 'plot export datafile' for this from a script or the MCP bridge - it opens a GUI file dialog and blocks the process.",
   "plot_items": [
     {
       "keyword": "axes",
@@ -196,8 +196,8 @@
     }
   ],
   "notes": [
-    "Plot item configuration keywords (color-by, cut, transparency, legend) are documented in references: use pfc_browse_reference('plot-items') to list available item types, then pfc_browse_reference('plot-items ball') for full keyword documentation",
-    "chart-history and chart-table need an explicit data source. For chart-history, bind a trace with 'history <name>' where <name> is the Name column from 'history list' (NOT the numeric ID); passing an ID, an unknown name, or omitting the keyword draws an empty chart with no error. Repeat 'history <name>' for multiple traces; add 'vs <name>' to cross-plot against another history. See pfc_browse_reference('plot-items chart-history').",
+    "Plot item configuration keywords (color-by, cut, transparency, legend) are documented in references: use itasca_browse_reference('plot-items') to list available item types, then itasca_browse_reference('plot-items ball') for full keyword documentation",
+    "chart-history and chart-table need an explicit data source. For chart-history, bind a trace with 'history <name>' where <name> is the Name column from 'history list' (NOT the numeric ID); passing an ID, an unknown name, or omitting the keyword draws an empty chart with no error. Repeat 'history <name>' for multiple traces; add 'vs <name>' to cross-plot against another history. See itasca_browse_reference('plot-items chart-history').",
     "Additional plot items can be added by plug-ins"
   ],
   "python_sdk_alternative": {

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/rename.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/rename.json
@@ -94,6 +94,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/title.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/title.json
@@ -95,6 +95,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/update.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/update.json
@@ -106,6 +106,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/view.json
+++ b/src/itasca_mcp/knowledge/resources/_common/command_docs/commands/plot/view.json
@@ -336,6 +336,6 @@
     }
   },
   "notes": [
-    "For detailed plot item keywords (color-by, cut, transparency, legend), use pfc_browse_reference(\"plot-items\") to list item types and pfc_browse_reference(\"plot-items ball\") for full syntax."
+    "For detailed plot item keywords (color-by, cut, transparency, legend), use itasca_browse_reference(\"plot-items\") to list item types and itasca_browse_reference(\"plot-items ball\") for full syntax."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/mpoint/references/index.json
+++ b/src/itasca_mcp/knowledge/resources/mpoint/references/index.json
@@ -58,7 +58,7 @@
   },
   "notes": [
     "References are syntax elements used within commands, not standalone commands",
-    "Use pfc_browse_commands (software='mpoint') for command syntax",
-    "Use pfc_browse_reference (software='mpoint') for reference documentation"
+    "Use itasca_browse_commands (software='mpoint') for command syntax",
+    "Use itasca_browse_reference (software='mpoint') for reference documentation"
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/plot/item.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/plot/item.json
@@ -1,0 +1,348 @@
+{
+  "category": "plot",
+  "search_keywords": [
+    "item",
+    "create",
+    "delete",
+    "modify",
+    "axes",
+    "ball",
+    "wall",
+    "clump",
+    "contact",
+    "fracture",
+    "dfn",
+    "geometry",
+    "chart",
+    "history",
+    "legend",
+    "measure",
+    "domain",
+    "force chain"
+  ],
+  "description": "Create, destroy, or modify plot items associated with a plot. If no plot name is specified, the current view is assumed. Plot items control what is visualized in the plot. Item type list below verified against PFC2D 7.00; PFC3D adds CFD items (ball-cfd, clump-cfd, element-cfd) and plug-ins can add more.",
+  "plot_items": [
+    {
+      "keyword": "axes",
+      "label": "Axes",
+      "description": "Cartesian axes representation for view orientation and location reference"
+    },
+    {
+      "keyword": "ball",
+      "label": "Ball",
+      "description": "Balls colored by attributes or properties. See itasca_browse_reference('plot-items ball') for configuration keywords"
+    },
+    {
+      "keyword": "ballthermal",
+      "label": "Ball Thermal",
+      "description": "Thermal balls colored by attributes or properties"
+    },
+    {
+      "keyword": "chart-history",
+      "label": "History Chart",
+      "description": "Line chart of one or more history traces. Requires a data source: append 'history <name>' to bind a history by its Name (the Name column from 'history list', NOT its numeric ID). Repeat 'history <name>' for multiple traces; add 'vs <name>' to cross-plot against another history instead of vs step. A chart-history created without a valid 'history <name>' draws an empty chart with no error."
+    },
+    {
+      "keyword": "chart-table",
+      "label": "Table Chart",
+      "description": "Chart of a table"
+    },
+    {
+      "keyword": "clump",
+      "label": "Clump",
+      "description": "Clumps colored by attributes or properties. See itasca_browse_reference('plot-items clump')"
+    },
+    {
+      "keyword": "clumpthermal",
+      "label": "Clump Thermal",
+      "description": "Thermal clumps colored by attributes or properties"
+    },
+    {
+      "keyword": "contact",
+      "label": "Contact",
+      "description": "Contacts colored by attributes or properties. This is the force-chain item: combine 'color-by vector-attribute \"force\"' with 'scale-by-force on'. See itasca_browse_reference('plot-items contact')"
+    },
+    {
+      "keyword": "contactthermal",
+      "label": "Contact Thermal",
+      "description": "Thermal contacts colored by attributes or properties"
+    },
+    {
+      "keyword": "data-label",
+      "label": "Labels",
+      "description": "User defined labels"
+    },
+    {
+      "keyword": "data-scalar",
+      "label": "Scalars",
+      "description": "User defined scalar data"
+    },
+    {
+      "keyword": "data-tensor",
+      "label": "Tensors",
+      "description": "User defined tensor data"
+    },
+    {
+      "keyword": "data-vector",
+      "label": "Vectors",
+      "description": "User defined vector data"
+    },
+    {
+      "keyword": "dfn",
+      "label": "DFN Fracture Contour",
+      "description": "Contour mechanical contact data on DFN fractures. Creation REQUIRES the contour keyword: 'plot item create dfn contour' (bare 'plot item create dfn' is an error). Not the item for drawing fractures themselves - use 'fracture' for that"
+    },
+    {
+      "keyword": "domain",
+      "label": "Domain",
+      "description": "Domain geometry (model domain extent)"
+    },
+    {
+      "keyword": "fos",
+      "label": "Factor of Safety",
+      "description": "Last calculated factor of safety, displayed in legend"
+    },
+    {
+      "keyword": "fracture",
+      "label": "Fracture",
+      "description": "Fractures from the Discrete Fracture Network system. Cannot color by parent DFN directly ('dfn' is not a valid color-by attribute); assign 'fracture group' per DFN and color by group instead. See itasca_browse_reference('plot-items fracture')"
+    },
+    {
+      "keyword": "geometry",
+      "label": "Geometry",
+      "description": "Geometry data created or imported"
+    },
+    {
+      "keyword": "gridpoint-fix",
+      "label": "Gp Fixity",
+      "description": "Lines showing gridpoint fixity conditions and direction (coupled zone models)"
+    },
+    {
+      "keyword": "history-locations",
+      "label": "History Locations",
+      "description": "Location of history traces"
+    },
+    {
+      "keyword": "inlet",
+      "label": "Inlet",
+      "description": "Ball/clump inlet geometry"
+    },
+    {
+      "keyword": "measure",
+      "label": "Measure",
+      "description": "Measurement regions (circles in 2D, spheres in 3D) colored by attributes"
+    },
+    {
+      "keyword": "particle-trace",
+      "label": "Particle Trace",
+      "description": "Path taken by particle trace records"
+    },
+    {
+      "keyword": "rblock",
+      "label": "Rigid Block",
+      "description": "Rigid blocks colored by attributes or properties. See itasca_browse_reference('plot-items rblock')"
+    },
+    {
+      "keyword": "rblockthermal",
+      "label": "Rigid Block Thermal",
+      "description": "Thermal rigid blocks colored by attributes or properties"
+    },
+    {
+      "keyword": "thermal-analytical-source",
+      "label": "Thermal Analytical Source",
+      "description": "Analytical thermal sources"
+    },
+    {
+      "keyword": "wall",
+      "label": "Wall",
+      "description": "Walls colored by attributes or properties. See itasca_browse_reference('plot-items wall')"
+    },
+    {
+      "keyword": "wallthermal",
+      "label": "Wall Thermal",
+      "description": "Arrows corresponding to thermal walls' vector attributes or properties"
+    },
+    {
+      "keyword": "zone",
+      "label": "Zone",
+      "description": "Surfaces of zones in the range (coupled zone models)"
+    },
+    {
+      "keyword": "zone-attach",
+      "label": "Attach Conditions",
+      "description": "Attach conditions connecting gridpoints (coupled zone models)"
+    },
+    {
+      "keyword": "zone-face",
+      "label": "Face",
+      "description": "Zone faces within the range (coupled zone models)"
+    },
+    {
+      "keyword": "zone-profile",
+      "label": "Profile",
+      "description": "Profile of zone field values along a line (coupled zone models)"
+    },
+    {
+      "keyword": "zone-tensor",
+      "label": "Tensors",
+      "description": "Tensor values of zones (coupled zone models)"
+    },
+    {
+      "keyword": "zone-vector",
+      "label": "Vectors",
+      "description": "Vector-based zone values (coupled zone models)"
+    },
+    {
+      "keyword": "zone-water",
+      "label": "Water Table",
+      "description": "Water table used for pore pressures (coupled zone models)"
+    }
+  ],
+  "notes": [
+    "Plot item configuration keywords (color-by, cut, transparency, legend) are documented in references: use itasca_browse_reference('plot-items') to list available item types, then itasca_browse_reference('plot-items ball') for full keyword documentation",
+    "chart-history and chart-table need an explicit data source. For chart-history, bind a trace with 'history <name>' where <name> is the Name column from 'history list' (NOT the numeric ID); passing an ID, an unknown name, or omitting the keyword draws an empty chart with no error. Repeat 'history <name>' for multiple traces; add 'vs <name>' to cross-plot against another history. See itasca_browse_reference('plot-items chart-history').",
+    "Item indices in 'modify <i>'/'delete <i>' are 1-based creation-order positions within one plot, and delete renumbers the items that follow. When scripting, keep one plot per purpose and rebuild it ('plot clear' then create items in a fixed order) rather than modifying by remembered index.",
+    "Force chains: use the contact item with 'scale-by-force on'. 'radius-factor' and a bare 'automatic'/'automatic off' are NOT contact-item keywords (verified PFC2D 7.00, they fail with 'Unused extra parameter'); the word 'automatic' is only valid inside 'color-options ... minimum automatic maximum automatic'.",
+    "To discover configuration keywords empirically, issue a deliberately incomplete command: the engine error lists the expected tokens (e.g. 'plot item create zzz' lists every item type). Do NOT use 'plot export datafile' for this from a script or the MCP bridge - in PFC 7 it takes no filename and opens a GUI file dialog, which blocks the process.",
+    "Additional plot items can be added by plug-ins; PFC3D adds CFD items (ball-cfd, clump-cfd, element-cfd)"
+  ],
+  "python_sdk_alternative": {
+    "available": false,
+    "workaround": "itasca.command('plot item create <type>') - no direct Python SDK method"
+  },
+  "versions": {
+    "7.0": {
+      "command": "plot item",
+      "syntax": "plot [<s>] item keyword",
+      "keywords": [
+        {
+          "name": "create",
+          "syntax": "create keyword ...",
+          "description": "adds a new plot item to the list associated with the plot. An alphabetical list of keywords, matched to the items available from the Build Plot dialog , is shown below. Note that additional plot items can be added by plug-ins to the system at any time."
+        },
+        {
+          "name": "delete",
+          "syntax": "delete <i>",
+          "description": "destroys the i th plot item in the list associated with the current plot. Note that this will renumber the plots following that in the list."
+        },
+        {
+          "name": "modify",
+          "syntax": "modify <i>keyword ...",
+          "description": "allows modification of the existing plot item at the i th position in the list associated with the current plot."
+        }
+      ],
+      "examples": [
+        {
+          "command": "plot item create ball",
+          "description": "Add balls to the current plot"
+        },
+        {
+          "command": "plot item create contact active on color-by vector-attribute 'force' color-options scaled ramp rainbow minimum automatic maximum automatic scale-by-force on legend active on",
+          "description": "Force-chain item: contacts colored and thickness-scaled by force magnitude (verified PFC2D 7.00)"
+        },
+        {
+          "command": "plot item create fracture color-by text-attribute 'group' Any",
+          "description": "Draw DFN fractures colored by their group (assign per-DFN groups first with 'fracture group <name> range fish <fn>' or at crack creation time); the slot argument after 'group' is required - a slot name string or Any"
+        },
+        {
+          "command": "plot item create fracture range group 'tension_cracks'",
+          "description": "A fracture item restricted to one crack family via group range ('range dfn <name>' does NOT select by DFN membership - the dfn range element is distance-based)"
+        },
+        {
+          "command": "plot 'myplot' item create chart-history history 'ratio'",
+          "description": "Chart the history named 'ratio' (the Name column from 'history list', NOT its numeric ID). A chart-history with no 'history <name>', or a name/ID no history has, draws an empty chart with no error"
+        },
+        {
+          "command": "plot 'myplot' item create chart-history history 'stress' vs 'strain'",
+          "description": "Cross-plot one history against another (x-y) instead of the default 'vs step'"
+        },
+        {
+          "command": "plot item delete 1",
+          "description": "Delete the first plot item (following items are renumbered)"
+        },
+        {
+          "command": "plot item modify 2 legend active off",
+          "description": "Modify the second plot item"
+        }
+      ]
+    },
+    "6.0": {
+      "command": "plot item",
+      "syntax": "plot [<s>] item keyword",
+      "keywords": [
+        {
+          "name": "create",
+          "syntax": "create keyword ...",
+          "description": "adds a new plot item to the list associated with the plot. An alphabetical list of keywords, matched to the items available from the Build Plot dialog , is shown below. Note that additional plot items can be added by plug-ins to the system at any time."
+        },
+        {
+          "name": "delete",
+          "syntax": "delete <i>",
+          "description": "destroys the i th plot item in the list associated with the current plot. Note that this will renumber the plots following that in the list."
+        },
+        {
+          "name": "modify",
+          "syntax": "modify <i>keyword ...",
+          "description": "allows modification of the existing plot item at the i th position in the list associated with the current plot."
+        }
+      ],
+      "examples": [
+        {
+          "command": "plot item create ball",
+          "description": "Add balls to the current plot"
+        },
+        {
+          "command": "plot item create contact active on color-by vector-attribute 'force' color-options scaled ramp rainbow minimum automatic maximum automatic scale-by-force on legend active on",
+          "description": "Force-chain item: contacts colored and thickness-scaled by force magnitude"
+        },
+        {
+          "command": "plot 'myplot' item create chart-history history 'ratio'",
+          "description": "Chart the history named 'ratio' (the Name column from 'history list', NOT its numeric ID). A chart-history with no 'history <name>', or a name/ID no history has, draws an empty chart with no error"
+        },
+        {
+          "command": "plot item delete 1",
+          "description": "Delete the first plot item (following items are renumbered)"
+        }
+      ]
+    },
+    "9.0": {
+      "command": "plot item",
+      "syntax": "plot [<s>] item keyword",
+      "keywords": [
+        {
+          "name": "create",
+          "syntax": "create keyword ...",
+          "description": "adds a new plot item to the list associated with the plot. An alphabetical list of keywords, matched to the items available from the Build Plot dialog , is shown below. Note that additional plot items can be added by plug-ins to the system at any time."
+        },
+        {
+          "name": "delete",
+          "syntax": "delete <i>",
+          "description": "destroys the i th plot item in the list associated with the current plot. Note that this will renumber the plots following that in the list."
+        },
+        {
+          "name": "modify",
+          "syntax": "modify <i>keyword ...",
+          "description": "allows modification of the existing plot item at the i th position in the list associated with the current plot."
+        }
+      ],
+      "examples": [
+        {
+          "command": "plot item create ball",
+          "description": "Add balls to the current plot"
+        },
+        {
+          "command": "plot item create contact active on color-by vector-attribute 'force' color-options scaled ramp rainbow minimum automatic maximum automatic scale-by-force on legend active on",
+          "description": "Force-chain item: contacts colored and thickness-scaled by force magnitude"
+        },
+        {
+          "command": "plot 'myplot' item create chart-history history 'ratio'",
+          "description": "Chart the history named 'ratio' (the Name column from 'history list', NOT its numeric ID). A chart-history with no 'history <name>', or a name/ID no history has, draws an empty chart with no error"
+        },
+        {
+          "command": "plot item delete 1",
+          "description": "Delete the first plot item (following items are renumbered)"
+        }
+      ]
+    }
+  }
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/index.json
@@ -2315,7 +2315,7 @@
         },
         {
           "name": "item",
-          "file": "_common/command_docs/commands/plot/item.json",
+          "file": "pfc/command_docs/commands/plot/item.json",
           "short_description": "Create, destroy, or modify plot items associated with a plot",
           "syntax": "plot [<s>] item keyword",
           "python_available": false,

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/linearpbond.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/linearpbond.json
@@ -6,7 +6,11 @@
     "parallel",
     "bond",
     "contact",
-    "model"
+    "model",
+    "bond_break",
+    "callback",
+    "crack",
+    "failure mode"
   ],
   "description": "Linear parallel bond model simulates a finite-sized piece of cement-like material deposited between two contacting pieces. It combines a linear elastic interface with a parallel bond that transmits both force and moment, allowing the bonded interface to resist relative rotation. This is the most commonly used model for simulating cemented particulate materials.",
   "typical_applications": [
@@ -627,5 +631,41 @@
     "6.0": true,
     "7.0": true,
     "9.0": true
+  },
+  "callback_events": {
+    "description": "FISH callback events fired by this model (register with 'fish callback add <fn> event <name>'). The FISH function receives ONE argument: an entries array.",
+    "events": [
+      {
+        "name": "bond_break",
+        "when": "The parallel bond breaks (tension or shear)",
+        "entries": [
+          {
+            "index": 1,
+            "type": "C_PNT",
+            "meaning": "Contact pointer"
+          },
+          {
+            "index": 2,
+            "type": "INT",
+            "meaning": "Failure mode: 1 = failed in TENSION, 2 = failed in SHEAR"
+          },
+          {
+            "index": 3,
+            "type": "FLT",
+            "meaning": "Failure strength [stress]: sigma_c (pb_ten) or tau_c, according to the failure mode"
+          },
+          {
+            "index": 4,
+            "type": "FLT",
+            "meaning": "Bond strain energy at onset of failure"
+          }
+        ],
+        "warning": "The official PFC 7 'rocktest' example reads the failure mode from entries(3) - that is a BUG in the example. entries(3) is the failure strength (a float), so 'mode == 1' never matches and every crack classifies as shear (or whatever the else-branch is). The failure mode is entries(2). Verified empirically on PFC2D 7.00.161 with single-bond tension and shear calibration tests: tension break -> entries(2)=1, entries(3)=pb_ten value; shear break -> entries(2)=2, entries(3)=cohesion-derived tau_c.",
+        "usage_pattern": {
+          "description": "Crack tracking with tension/shear classification (Brazilian/UCS tests). Tag each crack's group at creation so the fracture plot item can color by family (see itasca_browse_reference('plot-items fracture')).",
+          "fish": "fish define add_crack(entries)\n    local cp   = entries(1)\n    local mode = entries(2)   ; 1=tension, 2=shear  (NOT entries(3)!)\n    local dfn_label = 'crack_shear'\n    if mode = 1 then\n        dfn_label = 'crack_tension'\n    endif\n    ; ... create fracture in dfn.find(dfn_label), then:\n    ; fracture.group(frac) = dfn_label   ; enables per-family plot coloring\nend\nfish callback add add_crack event bond_break"
+        }
+      }
+    ]
   }
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/index.json
@@ -34,7 +34,7 @@
   },
   "notes": [
     "References are syntax elements used within commands, not standalone commands",
-    "Use pfc_browse_commands for command syntax",
-    "Use pfc_browse_reference for reference documentation"
+    "Use itasca_browse_commands for command syntax",
+    "Use itasca_browse_reference for reference documentation"
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/color-by.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/color-by.json
@@ -28,7 +28,7 @@
         "emod", "kratio",
         "rr_fric", "rr_kr", "rr_slip"
       ],
-      "notes": "Property must exist in the assigned contact model. See pfc_browse_reference('contact-models') for properties per model."
+      "notes": "Property must exist in the assigned contact model. See itasca_browse_reference('contact-models') for properties per model."
     },
     {
       "keyword": "color-by text-attribute",

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/index.json
@@ -47,6 +47,11 @@
     }
   ],
 
+  "notes": [
+    "'radius-factor' and a bare 'automatic'/'automatic off' are NOT contact-item keywords - they fail with 'Unused extra parameter' (verified PFC2D 7.00). Force-chain thickness comes from 'scale-by-force'; the word 'automatic' is only valid inside 'color-options ... minimum automatic maximum automatic'.",
+    "The force-chain pattern below is verified working on PFC2D 7.00."
+  ],
+
   "common_usage_patterns": [
     {
       "use_case": "Contact force network",

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/dfn.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/dfn.json
@@ -1,0 +1,34 @@
+{
+  "name": "dfn",
+  "item_type": "dfn",
+  "search_keywords": ["dfn", "fracture contour", "discrete fracture network", "contour"],
+  "description": "Configuration keywords for 'plot item create dfn' - the 'DFN Fracture Contour' item, which contours mechanical contact data on DFN fractures. NOT the item for drawing the fractures themselves; use the 'fracture' item for that. Verified against PFC2D 7.00.",
+  "base_syntax": "plot item create dfn contour <keywords...>",
+
+  "basic_keywords": [
+    {
+      "keyword": "contour",
+      "description": "REQUIRED at creation: 'plot item create dfn' without it is an error ('Expected tokens: contour'). Bare 'contour' completes the creation",
+      "syntax": "plot item create dfn contour"
+    },
+    {
+      "keyword": "active on|off",
+      "description": "Show or hide the item without removing it",
+      "syntax": "active on"
+    }
+  ],
+
+  "common_usage_patterns": [
+    {
+      "use_case": "Contour contact data on DFN fractures",
+      "command": "plot item create dfn contour",
+      "description": "Creates the DFN Fracture Contour item with default contour settings"
+    }
+  ],
+
+  "notes": [
+    "Official label: 'DFN Fracture Contour - Contour mechanical contact data on DFN fractures' (PFC 7.0 Program Guide, Plot Items in PFC).",
+    "For visualizing cracks/fractures as line segments or disks (the common bonded-material use case), use the 'fracture' plot item instead - see itasca_browse_reference('plot-items fracture').",
+    "Further contour configuration keywords are sparsely documented; discover them by issuing an incomplete 'plot item modify <i> ...' command and reading the expected-token list in the engine error."
+  ]
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/fracture.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/fracture.json
@@ -1,0 +1,66 @@
+{
+  "name": "fracture",
+  "item_type": "fracture",
+  "search_keywords": ["fracture", "dfn", "crack", "discrete fracture network", "color", "group", "bond break"],
+  "description": "Configuration keywords for 'plot item create fracture'. Draws the fractures of the Discrete Fracture Network (DFN) system - including cracks recorded during bond breakage - with coloring and range filtering. Verified against PFC2D 7.00.",
+  "base_syntax": "plot item create fracture <keywords...>",
+
+  "basic_keywords": [
+    {
+      "keyword": "active on|off",
+      "description": "Show or hide the item without removing it",
+      "syntax": "active on"
+    },
+    {
+      "keyword": "color-by text-attribute 'group' <slot>",
+      "description": "Color fractures by group. The slot argument after 'group' is REQUIRED: a slot name string (e.g. 'Default') or the keyword Any",
+      "syntax": "color-by text-attribute 'group' Any",
+      "notes": "This is the way to distinguish crack families (e.g. tension vs shear) - see the per-DFN recipe in notes"
+    },
+    {
+      "keyword": "color-by text-attribute 'id'",
+      "description": "Color each fracture individually by ID",
+      "syntax": "color-by text-attribute 'id'"
+    },
+    {
+      "keyword": "color-by numeric-attribute",
+      "description": "Contour fractures by a numeric attribute. Valid attributes (verified 2D): 'aperture', 'length', 'cluster'; 3D uses 'area' instead of 'length'",
+      "syntax": "color-by numeric-attribute 'aperture'"
+    },
+    {
+      "keyword": "range group",
+      "description": "Restrict the item to fractures in a group - the supported way to build one plot item per crack family",
+      "syntax": "range group 'tension_cracks'"
+    },
+    {
+      "keyword": "legend active on|off",
+      "description": "Show or hide this item's legend entry",
+      "syntax": "legend active on"
+    }
+  ],
+
+  "common_usage_patterns": [
+    {
+      "use_case": "Cracks colored by family (tension vs shear)",
+      "command": "plot item create fracture color-by text-attribute 'group' Any",
+      "description": "Requires groups assigned first (see notes). Legend then lists each group with its own color"
+    },
+    {
+      "use_case": "One item per crack family",
+      "command": "plot item create fracture range group 'tension_cracks'",
+      "description": "Separate items allow per-family styling; repeat with the other group name"
+    },
+    {
+      "use_case": "Fracture size contour",
+      "command": "plot item create fracture color-by numeric-attribute 'length' color-options scaled ramp rainbow minimum automatic maximum automatic legend active on",
+      "description": "Contour fractures by trace length (2D; use 'area' in 3D)"
+    }
+  ],
+
+  "notes": [
+    "There is NO color-by attribute for the parent DFN: text-attribute 'dfn', 'dfn-group', 'name' etc. are rejected as invalid attributes (verified PFC2D 7.00). Coloring or filtering by DFN membership must go through groups.",
+    "Per-DFN recipe: assign a group to each DFN's fractures, then color by group. Scope the assignment with 'fracture group <name> range fish <fn>' (official pattern, filter on dfn.fracture.dfn(frac)), or simplest: tag each crack's group right when it is created in the bond-break callback.",
+    "'range dfn <name>' does NOT select by DFN membership - the dfn range element selects by DISTANCE from a named DFN (geometric proximity) and is not accepted by fracture-scoped commands in PFC 7.",
+    "Plot legend groups fractures under 'Fracture group <slot>' when coloring by group; a plain fracture item shows a single 'fractures' entry regardless of how many DFNs exist."
+  ]
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/index.json
@@ -36,6 +36,18 @@
       "common_use": "Visualize rigid blocks colored by velocity, displacement, volume, group, etc."
     },
     {
+      "name": "fracture",
+      "file": "fracture.json",
+      "description": "DFN fracture visualization: color by group/id/numeric attribute, range filtering; no direct per-DFN coloring (use groups)",
+      "common_use": "Visualize cracks from bond breakage colored by crack family (tension vs shear) via groups"
+    },
+    {
+      "name": "dfn",
+      "file": "dfn.json",
+      "description": "DFN Fracture Contour item: contours mechanical contact data on DFN fractures; creation requires the 'contour' keyword",
+      "common_use": "Contour contact data over a fracture network (not for drawing the fractures themselves - use 'fracture')"
+    },
+    {
       "name": "chart-history",
       "file": "_common/references/plot-items/chart-history.json",
       "description": "History time-series line chart: bind traces with 'history <name>', plot vs step or cross-plot vs another history",

--- a/src/itasca_mcp/knowledge/resources/pfc/references/range-elements/dfn.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/range-elements/dfn.json
@@ -1,0 +1,21 @@
+{
+  "name": "dfn",
+  "element_type": "pfc_specific",
+  "search_keywords": ["dfn", "discrete fracture network", "distance", "proximity"],
+  "description": "Select objects based on their DISTANCE from the discrete fracture network with name s - a geometric proximity element, NOT a DFN-membership filter. Additional fracture networks can be added to the same element using the name keyword. The extent keyword can be used with this element.",
+  "syntax": "range dfn <s> [keyword ...]",
+
+  "common_pitfall": "This element does NOT mean 'objects belonging to DFN s'. To operate on the fractures of one DFN (e.g. assign a group per crack family), use 'range fish <fn>' filtering on dfn.fracture.dfn(frac), or tag groups at fracture creation time. Fracture-scoped commands in PFC 7 reject 'range dfn' outright ('Bad conversion').",
+
+  "examples": [
+    {
+      "command": "ball group 'near_joints' range dfn 'joints'",
+      "description": "Group balls near the fractures of DFN 'joints' (distance-based selection)"
+    }
+  ],
+
+  "notes": [
+    "Verified PFC2D 7.00: 'fracture group <name> range dfn <dfn_name>' fails - the element is not available in fracture-scoped range phrases.",
+    "Official reference: range phrase reference, 'dfn' element - 'Select objects based on their distance from the discrete fracture network with name s.'"
+  ]
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/range-elements/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/range-elements/index.json
@@ -46,7 +46,8 @@
       "name": "PFC-Specific Elements",
       "description": "Elements specific to PFC (balls, walls, contacts)",
       "elements": [
-        "contact"
+        "contact",
+        "dfn"
       ]
     },
     "user_defined": {
@@ -170,6 +171,12 @@
       "name": "contact",
       "file": "contact.json",
       "short_description": "Filter contacts by activity state, gap distance, c...",
+      "category": "pfc_specific"
+    },
+    {
+      "name": "dfn",
+      "file": "dfn.json",
+      "short_description": "Select objects by DISTANCE from a named DFN (geometric proximity, NOT DFN membership).",
       "category": "pfc_specific"
     },
     {


### PR DESCRIPTION
## Summary

Documentation-corpus fixes driven by a real agent-driven PFC2D 7.00 Brazilian-test session, where the corpus gaps sent the agent down wrong syntax paths. Every claim added here was verified against the live engine (error-token enumeration + single-bond calibration runs).

### 1. PFC-specific `plot item` doc (was FLAC-contaminated)
- The shared `_common` plot item list carries FLAC-only items (structure-*, zone extras) and misses every PFC-native type. PFC now has its own `plot/item.json` with the 35 item types enumerated from the engine (`plot item create <bad-token>` expected-token list). Other engines keep the `_common` copy.
- Replaced the `plot export datafile` syntax-inspection advice everywhere it appeared: in PFC 7 the command takes no filename and opens a GUI file dialog, which wedges a bridge-driven session. The replacement documents the safe error-token probing technique.

### 2. New `plot-items` references: `fracture` and `dfn`
- `fracture`: there is **no per-DFN color attribute** (`'dfn'`, `'dfn-group'`… are invalid); crack-family coloring/filtering must go through groups (`color-by text-attribute 'group' <slot|Any>`, `range group`). Verified recipes included.
- `dfn`: the "DFN Fracture Contour" item; creation requires the `contour` keyword.
- `contact`: anti-confabulation note — `radius-factor` / bare `automatic` are not contact-item keywords; force-chain thickness is `scale-by-force`.
- `range-elements dfn`: documents that the element selects by **distance** from a DFN, not membership.

### 3. `linearpbond` `bond_break` callback event args
- Failure mode is `entries(2)` {1 tension, 2 shear}; `entries(3)` is the failure strength. **The official PFC 7 rocktest example reads the mode from `entries(3)` — a bug** any copied crack-tracking FISH inherits, classifying every break as shear.
- Adjudicated with single-bond tension/shear calibration runs on PFC2D 7.00.161: tension → `entries(2)=1`, `entries(3)=pb_ten`; shear → `entries(2)=2`, `entries(3)=τc`.
- Rerunning the Brazilian loading with the corrected index inverted the statistics from 0/751 to **413 tension / 0 shear** (peak load within 2.4%), matching the tensile splitting band.
- Documented the verified argument table, the example-bug warning, and a corrected FISH pattern that group-tags cracks for per-family plot coloring.

### 4. Stale tool names
- `pfc_browse_reference` / `pfc_browse_commands` → `itasca_browse_reference` / `itasca_browse_commands` across 16 corpus files (pre-rename names no longer exist on the unified server).

## Test plan
- `uv run pytest` — 321 passed
- All documented plot patterns re-executed against live PFC2D 7.00 (5/5 OK)
- FLAC/3DEC/MPoint/MassFlow still resolve the `_common` plot item doc unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)