### PR TITLE
docs: require FISH definition blocks to reach the engine in one command string

### DIFF
--- a/src/itasca_mcp/tools/execute_code.py
+++ b/src/itasca_mcp/tools/execute_code.py
@@ -67,6 +67,21 @@ def register(mcp: FastMCP) -> None:
         (`_it = itasca`) bypasses it, and the output then carries a
         bridge warning.
 
+        FISH definition blocks (`fish define` / `fish operator` /
+        legacy bare `define` ... `end`) must arrive at the engine
+        whole: pass the complete block, header through its
+        terminating standalone `end`, in ONE itasca.command() string —
+        on its own or inside a multi-line batch (normalization keeps
+        definition blocks intact as a single engine call). Never feed
+        a definition line-by-line (e.g. looping with one
+        itasca.command(line) per line): the `fish define` header alone
+        drops the console into interactive FISH mode and that engine
+        call blocks waiting for body input that can never arrive over
+        the bridge, leaving the engine stuck until someone completes
+        the definition manually in the GUI console. Per-line loops
+        are fine for ordinary commands; only definition blocks must
+        stay in one string.
+
         `program call '<file>.p3dat'` (or .p2dat / .dat) through this
         tool is engine-version-gated. On 6/7 the command-script
         interpreter blocks the bridge for the script's entire

--- a/src/itasca_mcp/tools/execute_task.py
+++ b/src/itasca_mcp/tools/execute_task.py
@@ -50,6 +50,21 @@ def register(mcp: FastMCP) -> None:
         (`_it = itasca`) bypasses it, and the task log then carries a
         bridge warning.
 
+        FISH definition blocks (`fish define` / `fish operator` /
+        legacy bare `define` ... `end`) must arrive at the engine
+        whole: pass the complete block, header through its
+        terminating standalone `end`, in ONE itasca.command() string —
+        on its own or inside a multi-line batch (normalization keeps
+        definition blocks intact as a single engine call). Never feed
+        a definition line-by-line (e.g. looping with one
+        itasca.command(line) per line): the `fish define` header alone
+        drops the console into interactive FISH mode and that engine
+        call blocks waiting for body input that can never arrive over
+        the bridge, leaving the engine stuck until someone completes
+        the definition manually in the GUI console. Per-line loops
+        are fine for ordinary commands; only definition blocks must
+        stay in one string.
+
         Having the script invoke `program call '<file>.p3dat'` (or
         .p2dat / .dat) is engine-version-gated. On 6/7 the
         command-script interpreter blocks the bridge for the


### PR DESCRIPTION
## Why

A live incident (SHPB project, PFC2D 7.0, bridge 0.4.4 — current) showed the remaining fish-define wedge path is **agent-authored line-by-line sending**: the agent placed FISH lines in a Python list and looped `itasca.command(line)` one line at a time. The bridge's command splitter only rewrites multi-line string literals, so it never sees a block to keep whole; the `fish define` header alone drops the console into interactive FISH mode and the engine call blocks waiting for body input that cannot arrive over the bridge.

A runtime guard (rejecting bodiless define headers in the bridge's command wrapper) was considered and rejected: a lone define line is legitimate console behaviour.

## What

Adds a paragraph to the `itasca_execute_code` / `itasca_execute_task` docstrings, next to the existing batch-normalization paragraph: FISH definition blocks (`fish define` / `fish operator` / legacy bare `define` … `end`) must arrive at the engine whole, in ONE `itasca.command()` string — on their own or inside a multi-line batch — and per-line loops remain fine for ordinary commands.

Doc-only change; `ruff format --check`, `ruff check`, and both contract test suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)