### PR TITLE
docs: correct fixity DOF indices to 1-based for ball/clump/rblock

### DIFF
--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/fix.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/fix.json
@@ -8,7 +8,7 @@
   "description": "Fix the specified ball velocities. As a result, ball motion is constant in the specified directions (fixed velocities are not updated during cycling).",
   "python_sdk_alternative": {
     "available": true,
-    "workaround": "Ball.set_fix(component, True) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration"
+    "workaround": "Ball.set_fix(component, True) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration"
   },
   "versions": {
     "7.0": {

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/free.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/free.json
@@ -8,7 +8,7 @@
   "description": "Free the specified ball velocities. As a result, ball motion reflects the forces acting upon them (velocities are updated during cycling according to equations of motion).",
   "python_sdk_alternative": {
     "available": true,
-    "workaround": "Ball.set_fix(component, False) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration"
+    "workaround": "Ball.set_fix(component, False) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration"
   },
   "versions": {
     "7.0": {

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/clump/fix.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/clump/fix.json
@@ -13,7 +13,7 @@
   ],
   "python_sdk_alternative": {
     "available": true,
-    "workaround": "Clump.set_fix(component, True) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration: for c in itasca.clump.list(): c.set_fix(component, True)"
+    "workaround": "Clump.set_fix(component, True) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration: for c in itasca.clump.list(): c.set_fix(component, True)"
   },
   "versions": {
     "7.0": {

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/clump/free.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/clump/free.json
@@ -13,7 +13,7 @@
   ],
   "python_sdk_alternative": {
     "available": true,
-    "workaround": "Clump.set_fix(component, False) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration: for c in itasca.clump.list(): c.set_fix(component, False)"
+    "workaround": "Clump.set_fix(component, False) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration: for c in itasca.clump.list(): c.set_fix(component, False)"
   },
   "versions": {
     "7.0": {

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/index.json
@@ -92,7 +92,7 @@
           "short_description": "Fix the specified ball velocities",
           "syntax": "ball fix keyword ... [range]",
           "python_available": true,
-          "python_alternative": "Ball.set_fix(component, True) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration"
+          "python_alternative": "Ball.set_fix(component, True) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration"
         },
         {
           "name": "free",
@@ -100,7 +100,7 @@
           "short_description": "Free the specified ball velocities",
           "syntax": "ball free keyword ... [range]",
           "python_available": true,
-          "python_alternative": "Ball.set_fix(component, False) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration"
+          "python_alternative": "Ball.set_fix(component, False) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration"
         },
         {
           "name": "generate",
@@ -350,7 +350,7 @@
           "short_description": "Fix the specified clump velocities",
           "syntax": "clump fix keyword ... [range]",
           "python_available": true,
-          "python_alternative": "Clump.set_fix(component, True) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration: for c in itasca.clump.list(): c.set_fix(component, True)"
+          "python_alternative": "Clump.set_fix(component, True) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration: for c in itasca.clump.list(): c.set_fix(component, True)"
         },
         {
           "name": "free",
@@ -358,7 +358,7 @@
           "short_description": "Free the specified clump velocities",
           "syntax": "clump free keyword ... [range]",
           "python_available": true,
-          "python_alternative": "Clump.set_fix(component, False) where component: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ - requires iteration: for c in itasca.clump.list(): c.set_fix(component, False)"
+          "python_alternative": "Clump.set_fix(component, False) where component (1-based): 3D 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ; 2D 1=X, 2=Y, 3=spin - requires iteration: for c in itasca.clump.list(): c.set_fix(component, False)"
         },
         {
           "name": "generate",

--- a/src/itasca_mcp/knowledge/resources/pfc/python_sdk_docs/modules/ball/Ball.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/python_sdk_docs/modules/ball/Ball.json
@@ -1510,13 +1510,13 @@
     {
       "name": "fix",
       "signature": "ball.fix(component: int) -> bool",
-      "description": "Get ball fixity condition for a vector component.",
+      "description": "Get ball fixity condition for a DOF. Indices are 1-based, same as set_fix. 3D: 1-3=xyz velocity, 4-6=xyz angular velocity (range 1-6). 2D: 1-2=xy velocity, 3=spin (range 1-3). Verified live in PFC2D/PFC3D 7.0: index 0 is rejected ('Expected a value 1 <= x <= 6'); the official manual's 0-based description of this getter is wrong.",
       "parameters": [
         {
           "name": "component",
           "type": "int",
           "required": true,
-          "description": "Degree of freedom (0-5: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ)"
+          "description": "DOF index, 1-based. 3D: 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ. 2D: 1=X, 2=Y, 3=spin."
         }
       ],
       "returns": {
@@ -1527,13 +1527,13 @@
     {
       "name": "set_fix",
       "signature": "ball.set_fix(component: int, fix: bool) -> None",
-      "description": "Set ball fixity condition.",
+      "description": "Set ball fixity condition for a DOF. Indices are 1-based, same as fix. 3D: 1-3=xyz velocity, 4-6=xyz angular velocity (range 1-6). 2D: 1-2=xy velocity, 3=spin (range 1-3). Verified live in PFC2D/PFC3D 7.0 against the named command keywords (ball fix velocity-x/y/z, spin-x/y/z).",
       "parameters": [
         {
           "name": "component",
           "type": "int",
           "required": true,
-          "description": "Degree of freedom (0-5: 0=X, 1=Y, 2=Z, 3=RX, 4=RY, 5=RZ)"
+          "description": "DOF index, 1-based. 3D: 1=X, 2=Y, 3=Z, 4=RX, 5=RY, 6=RZ. 2D: 1=X, 2=Y, 3=spin."
         },
         {
           "name": "fix",

--- a/src/itasca_mcp/knowledge/resources/pfc/python_sdk_docs/modules/clump/Clump.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/python_sdk_docs/modules/clump/Clump.json
@@ -1871,13 +1871,13 @@
     {
       "name": "fix",
       "signature": "clump.fix(component: int) -> bool",
-      "description": "Get clump fixity condition for DOF. 3D: 0-2=xyz velocity, 3-5=xyz angular velocity. 2D: 0-1=xy velocity, 2=angular velocity.",
+      "description": "Get clump fixity condition for DOF. Indices are 1-based, same as set_fix. 3D: 1-3=xyz velocity, 4-6=xyz angular velocity (range 1-6). 2D: 1-2=xy velocity, 3=spin (range 1-3). Verified live in PFC2D/PFC3D 7.0: index 0 is rejected ('Expected a value 1 <= x <= 6'); the official manual's 0-based description of this getter is wrong.",
       "parameters": [
         {
           "name": "component",
           "type": "int",
           "required": true,
-          "description": "DOF index"
+          "description": "DOF index (1-based)"
         }
       ],
       "returns": {
@@ -1888,7 +1888,7 @@
     {
       "name": "set_fix",
       "signature": "clump.set_fix(component: int, fixity: bool) -> None",
-      "description": "Set clump fixity condition for DOF. 3D: 1-3=xyz velocity, 4-6=xyz angular velocity. 2D: 1-2=xy velocity, 3=angular velocity.",
+      "description": "Set clump fixity condition for DOF. 3D: 1-3=xyz velocity, 4-6=xyz angular velocity. 2D: 1-2=xy velocity, 3=angular velocity. Verified live in PFC2D/PFC3D 7.0 against the named command keywords (clump fix velocity-x/y/z, spin-x/y/z).",
       "parameters": [
         {
           "name": "component",

--- a/src/itasca_mcp/knowledge/resources/pfc/python_sdk_docs/modules/rblock/RBlock.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/python_sdk_docs/modules/rblock/RBlock.json
@@ -367,7 +367,7 @@
     {
       "name": "fix",
       "signature": "rblock.fix(component: int) -> bool",
-      "description": "Get the rblock fixity condition. The integer degree-of-freedom cooresponds to the following order: in 3D: 0) x-velocity, 1) y-velocity, 2) z-velocity, 3) x-angular velocity, 4) y-angular velocity, 5) z-angular velocity. in 2D: 0) x-velocity, 1) y-velocity, 2) angular velocity. The return value is false for free and true for fixed conditions.",
+      "description": "Get the rblock fixity condition. The integer degree-of-freedom is 1-based, same as set_fix: in 3D: 1) x-velocity, 2) y-velocity, 3) z-velocity, 4) x-angular velocity, 5) y-angular velocity, 6) z-angular velocity. in 2D: 1) x-velocity, 2) y-velocity, 3) angular velocity. The return value is false for free and true for fixed conditions. Verified live in PFC3D 7.0: index 0 is rejected ('Expected a value 1 <= x <= 6'); the official manual's 0-based description of this getter is wrong.",
       "returns": {
         "type": "bool",
         "description": "Boolean value"
@@ -970,7 +970,7 @@
     {
       "name": "set_fix",
       "signature": "rblock.set_fix(component: int, fixity: bool) -> None",
-      "description": "Get the rblock fixity condition. The integer degree-of-freedom cooresponds to the following order: in 3D: 1) x-velocity, 2) y-velocity, 3) z-velocity, 4) x-angular velocity, 5) y-angular velocity, 6) z-angular velocity. in 2D: 1) x-velocity, 2) y-velocity, 3) angular velocity. The fixity value is false for free and true for fixed conditions.",
+      "description": "Set the rblock fixity condition. The integer degree-of-freedom is 1-based, same as fix: in 3D: 1) x-velocity, 2) y-velocity, 3) z-velocity, 4) x-angular velocity, 5) y-angular velocity, 6) z-angular velocity. in 2D: 1) x-velocity, 2) y-velocity, 3) angular velocity. The fixity value is false for free and true for fixed conditions. Verified live in PFC3D 7.0.",
       "returns": {
         "type": "None",
         "description": ""


### PR DESCRIPTION
## Summary

- Verified live in PFC2D and PFC3D 7.0: `fix()` and `set_fix()` on Ball, Clump, and RBlock all use **1-based** DOF indices — 2D: 1–2 = xy velocity, 3 = spin (range 1–3); 3D: 1–3 = xyz velocity, 4–6 = xyz angular velocity (range 1–6). Index 0 is always rejected (`Expected a value 1 <= x <= 3/6`).
- Each index was mapped to its physical DOF via the named command keywords (`ball/clump fix velocity-x/y/z`, `spin-x/y/z`) with read-back through `fix()`.
- The official Itasca manual documents the **getter** as 0-based (while documenting the setter as 1-based); the corpus inherited that contradiction. Corrected:
  - `Ball.json` — `fix`/`set_fix` descriptions + `component` params (this was the "0=X, 1=Y, …" text)
  - `Clump.json` — 0-based `fix` line that contradicted the already-correct `set_fix`
  - `RBlock.json` — 0-based `fix` line; also fixed `set_fix` description starting with "Get"
  - `ball/clump` `fix`/`free` command docs + `index.json` — 8 `set_fix` workaround strings that would throw on index 0 if followed literally

## Test plan

- JSON round-trip validation on all touched files
- `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed
- Corpus-wide sweep: no `0=X` / `0) x-velocity` / `0-2=xyz` remnants

🤖 Generated with [Claude Code](https://claude.com/claude-code)