### PR TITLE
docs: clean dimension prose and spacing in FLAC syntax strings (Batch 4)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-create.json
@@ -29,17 +29,17 @@
         },
         {
           "name": "hexahedron",
-          "syntax": "hexahedron [by-points <v1><v2><v3><v4><v5><v6><v7><v8>] [group <s>[slot <s>]]",
+          "syntax": "hexahedron [by-points <v1> <v2> <v3> <v4> <v5> <v6> <v7> <v8>] [group <s> [slot <s>]]",
           "description": "Create a hexahedral block. by-points , if present, must be followed by points that define the block (a hexahedron requires eight points). The optional keywords group and slot assign the created block to the specified group and slot."
         },
         {
           "name": "tetrahedron",
-          "syntax": "tetrahedron [by-points <v1><v2><v3><v4>] [group <s>[slot <s>]]",
+          "syntax": "tetrahedron [by-points <v1> <v2> <v3> <v4>] [group <s> [slot <s>]]",
           "description": "Create a tetrahedral block. by-points , if present, must be followed by points that define the block (a tetrahedron requires four points). The optional keywords group and slot assign the created block to the specified group and slot."
         },
         {
           "name": "wedge",
-          "syntax": "wedge [by-points <v1><v2><v3><v4><v5><v6>] [group <s>[slot <s>]]",
+          "syntax": "wedge [by-points <v1> <v2> <v3> <v4> <v5> <v6>] [group <s> [slot <s>]]",
           "description": "Create a wedge block. by-points , if present, must be followed by points that define the block (a wedge requires six points). The optional keywords group and slot assign the created block to the specified group and slot."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-export.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-export.json
@@ -24,7 +24,7 @@
         },
         {
           "name": "to-set",
-          "syntax": "to-set <s>[offset <v>]",
+          "syntax": "to-set <s> [offset <v>]",
           "description": "Export the blocks to a building block set named s . If the optional <offset v > is supplied, all coordinates will be shifted by that vector in the destination set."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-group.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks block group",
-      "syntax": "building-blocks block group <s>[keyword] [range]",
+      "syntax": "building-blocks block group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-hide.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-hide.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks block hide",
-      "syntax": "building-blocks block hide <b>[range]",
+      "syntax": "building-blocks block hide <b> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-id.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "split",
-          "syntax": "split face-id <i2><v1><v2>",
+          "syntax": "split face-id <i2> <v1> <v2>",
           "description": "Split a block. The splitting is defined by the splitting line on a block face with id i2 . The splitting line is defined by the points v1 and v2 . When the points are on opposite edges of a face this is called an edge-to-edge split. When the points are on opposite corners of a face this is called a diagonal split. When the points are on a corner and opposite edge of a face this is called a corner split. When the points are inside a face this is a central split, in which case v1 must be equal to v2 within the tolerance (see building-blocks set tolerance ). In the case of a triangular face, it will be treated as the central point of the triangle. The split will start with two cross-split lines with a central point. The splitting of the block will propagate to the next face-attached block until blocks with already-split faces are reached."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-multiplier.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-multiplier.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks block multiplier",
-      "syntax": "building-blocks block multiplier <i>[range]",
+      "syntax": "building-blocks block multiplier <i> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-snapon.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "edge",
-          "syntax": "edge id <i>[<f>]",
+          "syntax": "edge id <i> [<f>]",
           "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
         },
         {
@@ -29,7 +29,7 @@
         },
         {
           "name": "polygon",
-          "syntax": "polygon id <i>[(<f1,><f2>)]",
+          "syntax": "polygon id <i> [(<f1,> <f2>)]",
           "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-transform.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "reflect-plane",
-          "syntax": "plane <v_1><v_2><v_3>",
+          "syntax": "plane <v_1> <v_2> <v_3>",
           "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-factor.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-factor.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks edge factor",
-      "syntax": "building-blocks edge factor <f>[range]",
+      "syntax": "building-blocks edge factor <f> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-group.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks edge group",
-      "syntax": "building-blocks edge group <s>[slot <s>] [remove] [range]",
+      "syntax": "building-blocks edge group <s> [slot <s>] [remove] [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio-isolate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio-isolate.json
@@ -17,7 +17,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks edge ratio-isolate",
-      "syntax": "building-blocks edge ratio-isolate <b>[range]",
+      "syntax": "building-blocks edge ratio-isolate <b> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks edge ratio",
-      "syntax": "building-blocks edge ratio <f>[range]",
+      "syntax": "building-blocks edge ratio <f> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-size.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks edge size",
-      "syntax": "building-blocks edge size <i>[range]",
+      "syntax": "building-blocks edge size <i> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-snapon.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "edge",
-          "syntax": "edge id <i>[<f>]",
+          "syntax": "edge id <i> [<f>]",
           "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
         },
         {
@@ -29,7 +29,7 @@
         },
         {
           "name": "polygon",
-          "syntax": "polygon id <i>[(<f1,><f2>)]",
+          "syntax": "polygon id <i> [(<f1,> <f2>)]",
           "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-transform.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "reflect-plane",
-          "syntax": "plane <v_1><v_2><v_3>",
+          "syntax": "plane <v_1> <v_2> <v_3>",
           "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-group.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks face group",
-      "syntax": "building-blocks face group <s>[slot <s>] [remove] [range]",
+      "syntax": "building-blocks face group <s> [slot <s>] [remove] [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-snapon.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "edge",
-          "syntax": "edge id <i>[<f>]",
+          "syntax": "edge id <i> [<f>]",
           "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
         },
         {
@@ -29,7 +29,7 @@
         },
         {
           "name": "polygon",
-          "syntax": "polygon id <i>[(<f1,><f2>)]",
+          "syntax": "polygon id <i> [(<f1,> <f2>)]",
           "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-transform.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "reflect-plane",
-          "syntax": "plane <v_1><v_2><v_3>",
+          "syntax": "plane <v_1> <v_2> <v_3>",
           "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-group.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks point group",
-      "syntax": "building-blocks point group <s>[slot <s>] [remove] [range]",
+      "syntax": "building-blocks point group <s> [slot <s>] [remove] [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-merge.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-merge.json
@@ -15,7 +15,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks point merge",
-      "syntax": "building-blocks point merge <i1><i2>",
+      "syntax": "building-blocks point merge <i1> <i2>",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-move-to.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-move-to.json
@@ -17,7 +17,7 @@
   "versions": {
     "9.0": {
       "command": "building-blocks point move-to",
-      "syntax": "building-blocks point move-to keyword <f>[control-point <b>] [range]",
+      "syntax": "building-blocks point move-to keyword <f> [control-point <b>] [range]",
       "keywords": [
         {
           "name": "x",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-snapon.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "edge",
-          "syntax": "edge id <i>[<f>]",
+          "syntax": "edge id <i> [<f>]",
           "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
         },
         {
@@ -29,7 +29,7 @@
         },
         {
           "name": "polygon",
-          "syntax": "polygon id <i>[(<f1,><f2>)]",
+          "syntax": "polygon id <i> [(<f1,> <f2>)]",
           "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-transform.json
@@ -19,7 +19,7 @@
       "keywords": [
         {
           "name": "reflect-plane",
-          "syntax": "plane <v_1><v_2><v_3>",
+          "syntax": "plane <v_1> <v_2> <v_3>",
           "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-import.json
@@ -16,7 +16,7 @@
       "keywords": [
         {
           "name": "adummy",
-          "syntax": "<s1>[set <s2>] [<v>]",
+          "syntax": "<s1> [set <s2>] [<v>]",
           "description": "Import blocks from the file s1 . The file must have one of the extensions “.f3bset”, “.f3grid” or “.flac3d” (and be a valid file of that type). The destination building blocks set is s2 . If s2 is not supplied a new set is created and given a set name that derives from the file name s1 . When < v > is supplied the coordinates of all the points of imported blocks will be shifted by that vector."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/domain/condition.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/domain/condition.json
@@ -10,11 +10,55 @@
   "versions": {
     "7.0": {
       "command": "model domain condition",
-      "syntax": "model domain condition <sx>[<sy><sz>] <sz>"
+      "syntax": "model domain condition <sx> [<sy> <sz>] <sz>",
+      "keywords": [
+        {
+          "name": "destroy",
+          "syntax": "destroy",
+          "description": "Objects reaching the domain boundary are destroyed. Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        },
+        {
+          "name": "periodic",
+          "syntax": "periodic",
+          "description": "Periodic domain boundary condition. Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        },
+        {
+          "name": "reflect",
+          "syntax": "reflect",
+          "description": "Reflecting domain boundary condition ('model domain condition reflect' accepted live). Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        },
+        {
+          "name": "stop",
+          "syntax": "stop",
+          "description": "Objects stop at the domain boundary (default per 'model list information'). Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        }
+      ]
     },
     "9.0": {
       "command": "model domain condition",
-      "syntax": "model domain condition <sx>[<sy><sz>] <sz>is 3D only"
+      "syntax": "model domain condition <sx> [<sy> <sz>] <sz> (3D only)",
+      "keywords": [
+        {
+          "name": "destroy",
+          "syntax": "destroy",
+          "description": "Objects reaching the domain boundary are destroyed. Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        },
+        {
+          "name": "periodic",
+          "syntax": "periodic",
+          "description": "Periodic domain boundary condition. Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        },
+        {
+          "name": "reflect",
+          "syntax": "reflect",
+          "description": "Reflecting domain boundary condition ('model domain condition reflect' accepted live). Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        },
+        {
+          "name": "stop",
+          "syntax": "stop",
+          "description": "Objects stop at the domain boundary (default per 'model list information'). Verified against FLAC3D 9.7 (error enumeration + acceptance, 2026-08-13)."
+        }
+      ]
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/domain/extent.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/domain/extent.json
@@ -10,11 +10,11 @@
   "versions": {
     "7.0": {
       "command": "model domain extent",
-      "syntax": "model domain extent <fxl><fxu>[<fyl><fyu><fzl><fzu>]"
+      "syntax": "model domain extent <fxl> <fxu> [<fyl> <fyu> <fzl> <fzu>]"
     },
     "9.0": {
       "command": "model domain extent",
-      "syntax": "model domain extent <fxl><fxu>[<fyl><fyu><fzl><fzu>]"
+      "syntax": "model domain extent <fxl> <fxu> [<fyl> <fyu> <fzl> <fzu>]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-create.json
@@ -16,22 +16,22 @@
       "keywords": [
         {
           "name": "at-group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Create a block from the edges surrounding the point with the 2D coordinates f1 , f2 . Assign the created block the group name s1 (in slot s2 if provided, in slot Default if not)."
         },
         {
           "name": "automatic-group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Create regular and/or irregular blocks from pre-existing edges within the range. Only edges which form closed polygons are used. If no range is provided, blocks will be created from all closed polygons present in the set. Assign the created block the group name s1 (in slot s2 if provided, in slot Default if not)."
         },
         {
           "name": "by-edges-group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Create a block from the edges with specified IDs i1 i2 i3 … The order of edges is irrelevant. For polygons with internal boundaries, only the edges forming the external boundary need to be specified. Assign the created block the group name s1 (in slot s2 if provided, in slot Default if not)."
         },
         {
           "name": "by-points-group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Create a block from the points specified IDs i1 i2 i3 … Order of points is irrelevant. Points must be connected by edges. For polygons with internal boundaries, only the points on the external boundary need be specified. Assign the created block the group name s1 (in slot s2 if provided, in slot Default if not)."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-group.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch block group",
-      "syntax": "sketch block group <s>[keyword] [range]",
+      "syntax": "sketch block group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-multiplier.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-multiplier.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch block multiplier",
-      "syntax": "sketch block multiplier <i>[range]",
+      "syntax": "sketch block multiplier <i> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-position.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-position.json
@@ -21,7 +21,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>] [remove]",
+          "syntax": "group <s1> [slot <s2>] [remove]",
           "description": "Assign the group name s1 in slot s2 (if supplied) to the block. If the slot keyword is omitted, the group is assigned to the slot named Default . The block is removed from the group/slot if remove is present."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-combine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-combine.json
@@ -16,7 +16,7 @@
       "keywords": [
         {
           "name": "id",
-          "syntax": "id <i1><i2><i3>...",
+          "syntax": "id <i1> <i2> <i3>...",
           "description": "Combine edges with the specified IDs i1 i2 i3 … into a single spline-type edge. A number of control points are inserted automatically to best approximate the original polyline (consisting of the specified edges). Only the edges connected to no more than one other edge from each end can be combined."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-group.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch edge group",
-      "syntax": "sketch edge group <s>[keyword] [range]",
+      "syntax": "sketch edge group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio-isolate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio-isolate.json
@@ -14,7 +14,7 @@
   "versions": {
     "9.0": {
       "command": "sketch edge ratio-isolate",
-      "syntax": "sketch edge ratio-isolate <b>[range]",
+      "syntax": "sketch edge ratio-isolate <b> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-size.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch edge size",
-      "syntax": "sketch edge size <i>[range]",
+      "syntax": "sketch edge size <i> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-zone-length.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-zone-length.json
@@ -14,7 +14,7 @@
   "versions": {
     "9.0": {
       "command": "sketch edge zone-length",
-      "syntax": "sketch edge zone-length <f>[range]",
+      "syntax": "sketch edge zone-length <f> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-create.json
@@ -21,7 +21,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created point the group name s1 (in slot s2 if provided, in slot Default if not). Use of the group logic is described in the Groups topic."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-group.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch point group",
-      "syntax": "sketch point group <s>[keyword] [range]",
+      "syntax": "sketch point group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-transform.json
@@ -16,7 +16,7 @@
       "keywords": [
         {
           "name": "merge-tolerance",
-          "syntax": "merge-tolerance <f>[range]",
+          "syntax": "merge-tolerance <f> [range]",
           "description": "Set the merge tolerance. When supplied, this will be used as a tolerance for merging points."
         },
         {
@@ -31,7 +31,7 @@
         },
         {
           "name": "scale",
-          "syntax": "scale <f1>[<f2>]",
+          "syntax": "scale <f1> [<f2>]",
           "description": "Scale the points; f1 = scale factor along the \\(x\\) coordinate, f2 = scale factor along \\(y\\) coordinate."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-polygon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-polygon.json
@@ -16,12 +16,12 @@
       "keywords": [
         {
           "name": "point",
-          "syntax": "point <v1><v2>...",
+          "syntax": "point <v1> <v2>...",
           "description": "List of point positions that belong to the polygon. Points and edges are created if none are found, and the polygon is automatically closed."
         },
         {
           "name": "control-point",
-          "syntax": "control-point <v1><v2>...",
+          "syntax": "control-point <v1> <v2>...",
           "description": "List of control-point positions on the polygon."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-group.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch segment group",
-      "syntax": "sketch segment group <s>[keyword] [range]",
+      "syntax": "sketch segment group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-create.json
@@ -23,7 +23,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created node the group name s1 (in slot s2 if provided, in slot Default if not). Use of the group logic is described in the Groups topic."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-group.json
@@ -14,7 +14,7 @@
   "versions": {
     "9.0": {
       "command": "sketch segment-node group",
-      "syntax": "sketch segment-node group <s>[keyword] [range]",
+      "syntax": "sketch segment-node group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-transform.json
@@ -28,7 +28,7 @@
         },
         {
           "name": "scale",
-          "syntax": "scale <f1>[<f2>]",
+          "syntax": "scale <f1> [<f2>]",
           "description": "Scale the nodes; f1 = scale factor along the the horizontal coordinate, f2 = scale factor along the vertical coordinate."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-ratio.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-ratio.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch segment ratio",
-      "syntax": "sketch segment ratio <f>[range]",
+      "syntax": "sketch segment ratio <f> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-size.json
@@ -12,7 +12,7 @@
   "versions": {
     "9.0": {
       "command": "sketch segment size",
-      "syntax": "sketch segment size <i>[range]",
+      "syntax": "sketch segment size <i> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-zone-length.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-zone-length.json
@@ -14,7 +14,7 @@
   "versions": {
     "9.0": {
       "command": "sketch segment zone-length",
-      "syntax": "sketch segment zone-length <f>[range]",
+      "syntax": "sketch segment zone-length <f> [range]",
       "keywords": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-automatic-validate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-automatic-validate.json
@@ -14,7 +14,7 @@
   "versions": {
     "9.0": {
       "command": "sketch set automatic-validate",
-      "syntax": "sketch set automatic-validate <b>[keyword]",
+      "syntax": "sketch set automatic-validate <b> [keyword]",
       "keywords": [
         {
           "name": "tolerance",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-metadata.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-metadata.json
@@ -21,7 +21,7 @@
         },
         {
           "name": "set",
-          "syntax": "set <s1><s2>",
+          "syntax": "set <s1> <s2>",
           "description": "Set the string value s2 to the string key s1 in the sketch set metadata. If a value was already assigned to the key, it is overwritten. Otherwise, a new key/value pair is created."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/group/rename.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/group/rename.json
@@ -10,11 +10,11 @@
   "versions": {
     "7.0": {
       "command": "group rename",
-      "syntax": "group rename <sold><snew>"
+      "syntax": "group rename <sold> <snew>"
     },
     "9.0": {
       "command": "group rename",
-      "syntax": "group rename <sold><snew>"
+      "syntax": "group rename <sold> <snew>"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/group/slot.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/group/slot.json
@@ -19,7 +19,7 @@
         },
         {
           "name": "rename",
-          "syntax": "rename <sold><snew>",
+          "syntax": "rename <sold> <snew>",
           "description": "Find the slot named sold and rename it to snew . All objects and groups referring to that slot are unchanged, except they now belong to snew ."
         }
       ]
@@ -35,7 +35,7 @@
         },
         {
           "name": "rename",
-          "syntax": "rename <sold><snew>",
+          "syntax": "rename <sold> <snew>",
           "description": "Find the slot named sold and rename it to snew . All objects and groups referring to that slot are unchanged, except they now belong to snew ."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-apply.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure beam apply",
-      "syntax": "structure beam apply <f1><f2>[range] only 1 component in 2D"
+      "syntax": "structure beam apply <f1> <f2> [range] (only 1 component in 2D)"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-create.json
@@ -87,22 +87,22 @@
       "keywords": [
         {
           "name": "by-line",
-          "syntax": "by-line <v1><v2>[beamcreateblock]",
+          "syntax": "by-line <v1> <v2> [beamcreateblock]",
           "description": "Create a collection of elements that lie along a straight line between the locations v1 and v2 . New nodes associated with the elements will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 to v2 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC , and particles in PFC3D ) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2>[beamcreateblock]",
+          "syntax": "by-nodeids <i1> <i2> [beamcreateblock]",
           "description": "Specify the ID numbers ( i1 , i2 ) of two nodes that will define the element. These nodes must already exist\u2014nodes can be created with the structure node create command. Ordering of the nodes defines the beam element coordinate system as follows. The positive \\(x\\) -direction lies along the line from i1 to i2 , and the \\(y\\) -direction is found by projecting the global \\(y\\) - or \\(x\\) -directions onto the element cross-section. The \\(y\\) -direction can also be modified with the property direction-y . The new element will not be attached to any objects (zones in FLAC3D and 3DEC , and particles in PFC3D ); if you wish to attach it to objects, then after creating it, position its nodes with the structure node initialize position command (which will create links and set appropriate attachment conditions for all nodes that are moved into an object."
         },
         {
           "name": "by-ray",
-          "syntax": "by-ray <v1><v2><f>[beamcreateblock]",
+          "syntax": "by-ray <v1> <v2> <f> [beamcreateblock]",
           "description": "Create a collection of elements that lie along a straight line starting at v1 , proceeding in the direction specified by v2 , for a distance given by f . New nodes associated with the element will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC , and particles in PFC3D ) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-zone-face",
-          "syntax": "by-zone-face 2D ONLY [beamcreateblock] [range]",
+          "syntax": "by-zone-face (2D ONLY) [beamcreateblock] [range]",
           "description": "Create new elements that are attached to the set of 2-noded edges (faces) in the range. By default, only surface faces will be considered, and the internal keyword can be used to select internal faces. New nodes associated with each element will also be created. The nodes of each element will be ordered counter-clockwise with respect to the outside of the zone faces, thereby making each element \\(y\\) axis point outward from the zone face. The orientation of the \\(y\\) axis can be reversed with the reverse keyword. Note that after creating the elements with this command, the zones may be deleted and the elements may be positioned by moving their nodes with the structure node initialize position command."
         },
         {
@@ -117,17 +117,17 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign all newly created elements to the group s . The optional keyword slot can be used to specify the group slot; if not specified, the group is assigned to the slot Default . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Beam N where N is the ID number assigned to the beam."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "Set the group name that will be assigned to the first node of the elements created along a line or ray. The default name assigned will be Beam Begin ."
         },
         {
           "name": "group-end",
-          "syntax": "group-end <s>[slot <s>]",
+          "syntax": "group-end <s> [slot <s>]",
           "description": "Set the group name that will be assigned to the last node of the elements created along a line or ray. The default name assigned will be Beam End ."
         },
         {
@@ -142,7 +142,7 @@
         },
         {
           "name": "reverse",
-          "syntax": "reverse 2D ONLY",
+          "syntax": "reverse (2D ONLY)",
           "description": "Specifies that the orientation of the element will be reversed from the default, so that only the element \\(y\\) axis points in the other direction."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure beam group",
-      "syntax": "structure beam group <s>[keyword] [range]",
+      "syntax": "structure beam group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-history.json
@@ -102,12 +102,12 @@
         },
         {
           "name": "force-z",
-          "syntax": "force-z 3D ONLY [beamhistoryblock]",
+          "syntax": "force-z (3D ONLY) [beamhistoryblock]",
           "description": "force ( \\(z\\) -component, force-moment sign convention)"
         },
         {
           "name": "ipstress",
-          "syntax": "ipstress 3D ONLY [beamhistoryblock]",
+          "syntax": "ipstress (3D ONLY) [beamhistoryblock]",
           "description": "axial stress ( \\(\\sigma_{xx}\\) ) for an element with a plastic material model. Uses the integration-point keyword."
         },
         {
@@ -117,17 +117,17 @@
         },
         {
           "name": "moment-x",
-          "syntax": "moment-x 3D ONLY [beamhistoryblock]",
+          "syntax": "moment-x (3D ONLY) [beamhistoryblock]",
           "description": "moment ( \\(x\\) -component, force-moment sign convention)"
         },
         {
           "name": "moment-y",
-          "syntax": "moment-y 3D ONLY [beamhistoryblock]",
+          "syntax": "moment-y (3D ONLY) [beamhistoryblock]",
           "description": "moment ( \\(y\\) -component, force-moment sign convention)"
         },
         {
           "name": "moment-z",
-          "syntax": "moment-z 3D ONLY [beamhistoryblock]",
+          "syntax": "moment-z (3D ONLY) [beamhistoryblock]",
           "description": "moment ( \\(z\\) -component, force-moment sign convention)"
         },
         {
@@ -147,7 +147,7 @@
         },
         {
           "name": "integration-point",
-          "syntax": "integration-point <ind>3D ONLY",
+          "syntax": "integration-point <ind> (3D ONLY)",
           "description": "the integration point at which the axial stress is sampled. The integration point locations are shown here and here . If this keyword is not specified, then the integration point index is set to 1 . Only available if noted."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-import.json
@@ -112,7 +112,7 @@
         },
         {
           "name": "from-file",
-          "syntax": "from-file <s>[beamimportblock]",
+          "syntax": "from-file <s> [beamimportblock]",
           "description": "Create elements from the geometry file s . The optional format keyword can be used to specify the format of the file. The options are dxf , geom , or stl . [CS: work out what needs to happen here later; formats should have links] If not specified, the format is assumed from the file extension."
         },
         {
@@ -132,12 +132,12 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign the elements created to group s . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Beam N where N is the ID number assinged to the elements."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line. The default name assigned will be Beam Begin ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-list.json
@@ -167,22 +167,22 @@
         },
         {
           "name": "plastic-state",
-          "syntax": "plastic-state [integration-point <ind>] 3D ONLY",
+          "syntax": "plastic-state [integration-point <ind>] (3D ONLY)",
           "description": "List plasticity state indicators. Each beam element with a plastic material model has a number of integration points distributed throughout its volume, and each of them tracks its plasticity state. The plasticity states at all integration points are listed, unless integration-point is specified. The integration point locations are shown here and here . The plasticity states of the plastic constitutive models can be listed by the structure beam cmodel list states command."
         },
         {
           "name": "plastic-stress",
-          "syntax": "plastic-stress [integration-point <ind>] 3D ONLY",
+          "syntax": "plastic-stress [integration-point <ind>] (3D ONLY)",
           "description": "List stress for elements with a plastic material model. The plasticity is induced by axial and bending deformations; twisting deformation induces an elastic response. Each beam element with a plastic material model has a number of integration points distributed throughout its volume, and each of them tracks its axial stress. The axial stress is the only non-zero stress component arising from axial and bending deformation. The axial stress ( \\(\\sigma_{xx}\\) ) is expressed in the beam element coordinate system. The axial stress at all integration points is listed, unless integration-point is specified. The integration point locations are shown here and here ."
         },
         {
           "name": "plastic-stress-bounds",
-          "syntax": "plastic-stress-bounds 3D ONLY",
+          "syntax": "plastic-stress-bounds (3D ONLY)",
           "description": "List minimum and maximum axial stress for elements with a plastic material model by checking over all integration points."
         },
         {
           "name": "property-torsion-constant",
-          "syntax": "torsion-constant 3D ONLY",
+          "syntax": "torsion-constant (3D ONLY)",
           "description": "The properties consist of constitutive model properties, and additional properties of beam-type elements. The constitutive model properties are listed by specifying the constitutive model property name; these names are not listed here. Elastic-plastic constitutive model properties are stored at each integration point. Such properties are the same at all integration points, except for the softening properties of the strain-softening/hardening Mohr Coulomb constitutive model. The value at a particular integration point is listed by specifying the integration-point keyword \u2014 the integration point locations are shown here and here . Scaled properties are returned if the scaled keyword ( FLAC2D ONLY ) is set to true (the default is false). If the property cannot be scaled, an error is emitted. cross-sectional area. mass density. \\(y\\) -direction vector whose projection onto the element cross-section defines the \\(y\\) -axis of the element coordinate system. moment of inertia with respect to element \\(y\\) -axis. moment of inertia with respect to element \\(z\\) -axis. plastic moment capacity in Y and Z. plastic moment capacity in Y. plastic moment capacity in Z. plastic shear capacity in Y and Z. plastic shear capacity in Y. plastic shear capacity in Z. shear coefficient for transverse shear deformation in the \\(y\\) -direction (Timoshenko beam element only). shear coefficient for transverse shear deformation in the \\(z\\) -direction (Timoshenko beam element only). thermal-expansion coefficient. torsion constant."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-property.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-property.json
@@ -97,17 +97,17 @@
         },
         {
           "name": "moi",
-          "syntax": "moi <f>2D ONLY",
+          "syntax": "moi <f> (2D ONLY)",
           "description": "second moment"
         },
         {
           "name": "moi-y",
-          "syntax": "moi-y <f>3D ONLY",
+          "syntax": "moi-y <f> (3D ONLY)",
           "description": "moment of inertia with respect to element \\(y\\) -axis"
         },
         {
           "name": "moi-z",
-          "syntax": "moi-z <f>3D ONLY",
+          "syntax": "moi-z <f> (3D ONLY)",
           "description": "moment of inertia with respect to element \\(z\\) -axis"
         },
         {
@@ -117,12 +117,12 @@
         },
         {
           "name": "plastic-moment-y",
-          "syntax": "plastic-moment-y <f>3D ONLY",
+          "syntax": "plastic-moment-y <f> (3D ONLY)",
           "description": "plastic moment capacity in Y"
         },
         {
           "name": "plastic-moment-z",
-          "syntax": "plastic-moment-z <f>3D ONLY",
+          "syntax": "plastic-moment-z <f> (3D ONLY)",
           "description": "plastic moment capacity in Z"
         },
         {
@@ -132,12 +132,12 @@
         },
         {
           "name": "plastic-shear-y",
-          "syntax": "plastic-shear-y <f>3D ONLY",
+          "syntax": "plastic-shear-y <f> (3D ONLY)",
           "description": "plastic shear capacity in Y"
         },
         {
           "name": "plastic-shear-z",
-          "syntax": "plastic-shear-z <f>3D ONLY",
+          "syntax": "plastic-shear-z <f> (3D ONLY)",
           "description": "plastic shear capacity in Z"
         },
         {
@@ -147,22 +147,22 @@
         },
         {
           "name": "shear-coefficient",
-          "syntax": "shear-coefficient <f>2D ONLY",
+          "syntax": "shear-coefficient <f> (2D ONLY)",
           "description": "shear coefficient for transverse shear deformation in the \\(y\\) -direction (Timoshenko beam element only)"
         },
         {
           "name": "shear-coefficient-y",
-          "syntax": "shear-coefficient-y <f>3D ONLY",
+          "syntax": "shear-coefficient-y <f> (3D ONLY)",
           "description": "shear coefficient for transverse shear deformation in the \\(y\\) -direction (Timoshenko beam element only)"
         },
         {
           "name": "shear-coefficient-z",
-          "syntax": "shear-coefficient-z <f>3D ONLY",
+          "syntax": "shear-coefficient-z <f> (3D ONLY)",
           "description": "shear coefficient for transverse shear deformation in the \\(z\\) -direction (Timoshenko beam element only)"
         },
         {
           "name": "spacing",
-          "syntax": "spacing <f>2D ONLY",
+          "syntax": "spacing <f> (2D ONLY)",
           "description": "out-of-plane distance between beam-type elements"
         },
         {
@@ -172,7 +172,7 @@
         },
         {
           "name": "torsion-constant",
-          "syntax": "torsion-constant <f>3D ONLY",
+          "syntax": "torsion-constant <f> (3D ONLY)",
           "description": "torsion constant"
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-refine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-refine.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure beam refine",
-      "syntax": "structure beam refine <i>[range]"
+      "syntax": "structure beam refine <i> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-create.json
@@ -87,22 +87,22 @@
       "keywords": [
         {
           "name": "by-line",
-          "syntax": "by-line <v1><v2>[cablecreateblock]",
+          "syntax": "by-line <v1> <v2> [cablecreateblock]",
           "description": "create a collection of elements that lie along a straight line between the locations v1 and v2 . New nodes associated with the elements will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 to v2 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC, and particles in PFC3D) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2>[cablecreateblock]",
+          "syntax": "by-nodeids <i1> <i2> [cablecreateblock]",
           "description": "specify the ID numbers ( i1 , i2 ) of two nodes that will define the element. These nodes must already exist\u2014nodes can be created with the structure node create command. Ordering of the nodes defines the beam element coordinate system as follows. The positive \\(x\\) -direction lies along the line from i1 to i2 , and the \\(y\\) -direction is found by projecting the global \\(y\\) - or \\(x\\) -directions onto the element cross-section. The \\(y\\) -direction can also be modified with the property direction-y . The new element will not be attached to any objects (zones in FLAC3D and 3DEC, and particles in PFC3D); if you wish to attach it to objects, then after creating it, position its nodes with the structure node initialize position command (which will create links and set appropriate attachment conditions for all nodes that are moved into an object."
         },
         {
           "name": "by-ray",
-          "syntax": "by-ray <v1><v2><f>[cablecreateblock]",
+          "syntax": "by-ray <v1> <v2> <f> [cablecreateblock]",
           "description": "creates a collection of elements that lie along a straight line starting at v1 , proceeding in the direction specified by v2 for a distance given by f . New nodes associated with the element will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC, and particles in PFC3D) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-zone-face",
-          "syntax": "by-zone-face 2D ONLY [pilecreateblock] [range]",
+          "syntax": "by-zone-face (2D ONLY) [pilecreateblock] [range]",
           "description": "create new elements that are attached to the set of 2-noded edges (faces) in the range. By default, only surface faces will be considered, and the internal keyword can be used to select internal faces. New nodes associated with each element will also be created. The nodes of each element will be ordered counter-clockwise with respect to the outside of the zone faces, thereby making each element \\(y\\) axis point outward from the zone face. The orientation of the \\(y\\) axis can be reversed with the reverse keyword. Note that after creating the elements with this command, the zones may be deleted and the elements may be positioned by moving their nodes with the structure node initialize position command."
         },
         {
@@ -112,17 +112,17 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign all newly created elements to the group s . If the optional keyword slot can be used to specify the group slot, if not specified the group is assigned to the slot Default . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Cable N where N is the ID number assinged to the cable."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line or ray. The default name assigned will be Cable Begin ."
         },
         {
           "name": "group-end",
-          "syntax": "group-end <s>[slot <s>]",
+          "syntax": "group-end <s> [slot <s>]",
           "description": "A group name that will be assigned to the last node of the elements created along a line or ray. The default name assigned will be Cable End ."
         },
         {
@@ -137,7 +137,7 @@
         },
         {
           "name": "reverse",
-          "syntax": "reverse 2D ONLY",
+          "syntax": "reverse (2D ONLY)",
           "description": "Specifies that the orientation of the element will be reversed from the default, so that only the element \\(y\\) axis points in the other direction."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure cable group",
-      "syntax": "structure cable group <s>[keyword] [range]",
+      "syntax": "structure cable group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-import.json
@@ -117,7 +117,7 @@
         },
         {
           "name": "from-file",
-          "syntax": "from-file <s>[cableimportblock]",
+          "syntax": "from-file <s> [cableimportblock]",
           "description": "Create elements from the geometry file s ."
         },
         {
@@ -137,12 +137,12 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign the elements created to group s . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Cable N where N is the ID number assinged to the elements."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line. The default name assigned will be Cable Begin ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-refine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-refine.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure cable refine",
-      "syntax": "structure cable refine <i>[range]"
+      "syntax": "structure cable refine <i> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/dynamic-damping.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/dynamic-damping.json
@@ -34,7 +34,7 @@
         },
         {
           "name": "maxwell",
-          "syntax": "maxwell <fd1><f1><fd2><f2><fd3><f3>[off-when-yield <b>]",
+          "syntax": "maxwell <fd1> <f1> <fd2> <f2> <fd3> <f3> [off-when-yield <b>]",
           "description": "Maxwell damping (see Maxwell Damping ) for all structural elements in the range. f1 is the center frequency of the first Maxwell component and fd1 is the maximum damping ratio of the first Maxwell component; f2 is the center frequency of the second Maxwell component and fd2 is the maximum damping ratio of the second Maxwell component; f3 is the center frequency of the third Maxwell component and fd3 is the maximum damping ratio of the third Maxwell component. This command must be issued when the dynamic option is configured and turned on. If off-when-yield = on/yes/true (default), the Maxwell damping will be inactivated when the constitutive model is yielding; If off-when-yield = off/no/false , the Maxwell damping will still be active when the constitutive model is yielding. This damping automatically transfers to the conformable link whose source node belong to the structure element in the range. To separately assign or modify the dynamic damping for deformable links, see the command structure link dynamic-damping ."
         },
         {
@@ -44,7 +44,7 @@
         },
         {
           "name": "rayleigh",
-          "syntax": "rayleigh <f1><f2>",
+          "syntax": "rayleigh <f1> <f2>",
           "description": "Rayleigh damping (see Rayleigh Damping ) for all nodes in the range. The stiffness-proportional constant is f1 = beta , and the mass-proportional constant is f2 = alpha . This command must be issued when the dynamic option is configured and turned on."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-apply.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure geogrid apply",
-      "syntax": "structure geogrid apply <f>[range]"
+      "syntax": "structure geogrid apply <f> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-create.json
@@ -124,17 +124,17 @@
       "keywords": [
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2><i3>[geogridcreateblock]",
+          "syntax": "by-nodeids <i1> <i2> <i3> [geogridcreateblock]",
           "description": "Create a single element from three existing nodes."
         },
         {
           "name": "by-quadrilateral",
-          "syntax": "by-quadrilateral <v1><v2><v3><v4>[geogridcreateblock]",
+          "syntax": "by-quadrilateral <v1> <v2> <v3> <v4> [geogridcreateblock]",
           "description": "Create elements based on four points forming a quadrilateral, in order. The element \\(z\\) -axis will point in the direction determined by applying the right-hand rule to the quadrilateral."
         },
         {
           "name": "by-triangle",
-          "syntax": "by-triangle <v1><v2><v3>[geogridcreateblock]",
+          "syntax": "by-triangle <v1> <v2> <v3> [geogridcreateblock]",
           "description": "Create elements based on three points forming a triangle. The element \\(z\\) -axis will point in the direction determined by applying the right-hand rule to the triangle."
         },
         {
@@ -159,7 +159,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created elements to group s1 . The group is assigned to the slot named s2 if supplied; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {
@@ -189,7 +189,7 @@
         },
         {
           "name": "size",
-          "syntax": "size <i1><i2>",
+          "syntax": "size <i1> <i2>",
           "description": "This keyword only applies if the by-quadrilateral option was used. Increases the number of elements created by subdividing the quadrilateral into i1 segments along the first edge and i2 segments along the second. By default, only one quad is created."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure geogrid group",
-      "syntax": "structure geogrid group <s1>[keyword] [range]",
+      "syntax": "structure geogrid group <s1> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-import.json
@@ -131,7 +131,7 @@
       "keywords": [
         {
           "name": "from-file",
-          "syntax": "from-file <s>[geogridimportblock]",
+          "syntax": "from-file <s> [geogridimportblock]",
           "description": "Create elements from the geometry file s ."
         },
         {
@@ -161,7 +161,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created elements to group s1 . The group is assigned to the slot named s2 if supplied; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-refine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-refine.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure geogrid refine",
-      "syntax": "structure geogrid refine <i>[range]"
+      "syntax": "structure geogrid refine <i> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-create.json
@@ -87,17 +87,17 @@
       "keywords": [
         {
           "name": "by-line",
-          "syntax": "by-line <v1><v2>[hybridcreateblock]",
+          "syntax": "by-line <v1> <v2> [hybridcreateblock]",
           "description": "create a collection of elements that lie along a straight line between the locations v1 and v2 . New nodes associated with the elements will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 to v2 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC, and particles in PFC3D) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2>[hybridcreateblock]",
+          "syntax": "by-nodeids <i1> <i2> [hybridcreateblock]",
           "description": "specify the ID numbers ( i1 , i2 ) of two nodes that will define the element. These nodes must already exist\u2014nodes can be created with the structure node create command. Ordering of the nodes defines the beam element coordinate system as follows. The positive \\(x\\) -direction lies along the line from i1 to i2 , and the \\(y\\) -direction is found by projecting the global \\(y\\) - or \\(x\\) -directions onto the element cross-section. The \\(y\\) -direction can also be modified with the property direction-y . The new element will not be attached to any objects (zones in FLAC3D and 3DEC, and particles in PFC3D); if you wish to attach it to objects, then after creating it, position its nodes with the structure node initialize position command (which will create links and set appropriate attachment conditions for all nodes that are moved into an object."
         },
         {
           "name": "by-ray",
-          "syntax": "by-ray <v1><v2><f>[hybridcreateblock]",
+          "syntax": "by-ray <v1> <v2> <f> [hybridcreateblock]",
           "description": "creates a collection of elements that lie along a straight line starting at v1 , proceeding in the direction specified by v2 for a distance given by f . New nodes associated with the element will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC, and particles in PFC3D) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
@@ -107,17 +107,17 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign all newly created elements to the group s . If the optional keyword slot can be used to specify the group slot, if not specified the group is assigned to the slot Default . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Cable N where N is the ID number assinged to the cable."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line or ray. The default name assigned will be Hybrid Begin ."
         },
         {
           "name": "group-end",
-          "syntax": "group-end <s>[slot <s>]",
+          "syntax": "group-end <s> [slot <s>]",
           "description": "A group name that will be assigned to the last node of the elements created along a line or ray. The default name assigned will be Hybrid End ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure hybrid group",
-      "syntax": "structure hybrid group <s>[keyword] [range]",
+      "syntax": "structure hybrid group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-import.json
@@ -117,7 +117,7 @@
         },
         {
           "name": "from-file",
-          "syntax": "from-file <s>[hybridimportblock]",
+          "syntax": "from-file <s> [hybridimportblock]",
           "description": "Create elements from the geometry file s ."
         },
         {
@@ -137,12 +137,12 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign the elements created to group s . Use of the group logic is described in Groups . If not specified, the default group name assigned will be the same as the name of the imported geometry set."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line. The default name assigned will be Hybrid Begin ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-apply.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure liner apply",
-      "syntax": "structure liner apply <f>[range]"
+      "syntax": "structure liner apply <f> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-create.json
@@ -154,17 +154,17 @@
         },
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2><i3>[linercreateblock]",
+          "syntax": "by-nodeids <i1> <i2> <i3> [linercreateblock]",
           "description": "Create a single element from three existing nodes."
         },
         {
           "name": "by-quadrilateral",
-          "syntax": "by-quadrilateral <v1><v2><v3><v4>[linercreateblock]",
+          "syntax": "by-quadrilateral <v1> <v2> <v3> <v4> [linercreateblock]",
           "description": "Create elements based on four points forming a quadrilateral, in order. The element \\(z\\) -axis will point in the direction determined by applying the right-hand rule to the quadrilateral."
         },
         {
           "name": "by-triangle",
-          "syntax": "by-triangle <v1><v2><v3>[linercreateblock]",
+          "syntax": "by-triangle <v1> <v2> <v3> [linercreateblock]",
           "description": "Create elements based on three points forming a triangle. The element \\(z\\) -axis will point in the direction determined by applying the right-hand rule to the triangle."
         },
         {
@@ -194,7 +194,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created elements to group s1 . The group is assigned to the slot named s2 if supplied; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {
@@ -229,7 +229,7 @@
         },
         {
           "name": "size",
-          "syntax": "size <i1><i2>",
+          "syntax": "size <i1> <i2>",
           "description": "This keyword only applies if the by-quadrilateral option was used. Increases the number of elements created by subdividing the quadrilateral into i1 segments along the first edge and i2 segments along the second. By default, only one quad is created."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure liner group",
-      "syntax": "structure liner group <s1>[keyword] [range]",
+      "syntax": "structure liner group <s1> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-import.json
@@ -151,7 +151,7 @@
       "keywords": [
         {
           "name": "from-file",
-          "syntax": "from-file <s>[linerimportblock]",
+          "syntax": "from-file <s> [linerimportblock]",
           "description": "Create elements from the geometry file s"
         },
         {
@@ -186,7 +186,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created elements to group s1 . The group is assigned to the slot named s2 if supplied; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-refine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-refine.json
@@ -25,7 +25,7 @@
     },
     "9.0": {
       "command": "structure liner refine",
-      "syntax": "structure liner refine <i>[range]"
+      "syntax": "structure liner refine <i> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-attach.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-attach.json
@@ -102,27 +102,27 @@
         },
         {
           "name": "z",
-          "syntax": "z 3D ONLY [linkattachblock]",
+          "syntax": "z (3D ONLY) [linkattachblock]",
           "description": "Set the translational \\(z\\) -direction, also degree-of-freedom 3."
         },
         {
           "name": "rotation",
-          "syntax": "rotation 2D ONLY [linkattachblock]",
+          "syntax": "rotation (2D ONLY) [linkattachblock]",
           "description": "Set rotation."
         },
         {
           "name": "rotation-x",
-          "syntax": "rotation-x 3D ONLY [linkattachblock]",
+          "syntax": "rotation-x (3D ONLY) [linkattachblock]",
           "description": "Set the rotational \\(x\\) -direction, also degree-of-freedom 4."
         },
         {
           "name": "rotation-y",
-          "syntax": "rotation-y 3D ONLY [linkattachblock]",
+          "syntax": "rotation-y (3D ONLY) [linkattachblock]",
           "description": "Set the rotational \\(y\\) -direction, also degree-of-freedom 5."
         },
         {
           "name": "rotation-z",
-          "syntax": "rotation-z 3D ONLY [linkattachblock]",
+          "syntax": "rotation-z (3D ONLY) [linkattachblock]",
           "description": "Set the rotational \\(z\\) -direction, also degree-of-freedom 6."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-create.json
@@ -107,7 +107,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created link to the group named s1 . If the optional slot s2 is supplied, the group is assigned to the slot named s2 ; if omitted, the group is assigned to the slot named Default . Use of the group logic is described in Groups ."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-dynamic-damping.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-dynamic-damping.json
@@ -31,7 +31,7 @@
         },
         {
           "name": "maxwell",
-          "syntax": "maxwell <fd1><f1><fd2><f2><fd3><f3>[off-when-yield <b>]",
+          "syntax": "maxwell <fd1> <f1> <fd2> <f2> <fd3> <f3> [off-when-yield <b>]",
           "description": "Maxwell damping (see Maxwell Damping ) for all conformable structural links in the range. f1 is the center frequency of the first Maxwell component and fd1 is the maximum damping ratio of the first Maxwell component; f2 is the center frequency of the second Maxwell component and fd2 is the maximum damping ratio of the second Maxwell component; f3 is the center frequency of the third Maxwell component and fd3 is the maximum damping ratio of the third Maxwell component. This command must be issued when the dynamic option is configured and turned on. If off-when-yield = on/yes/true (default), the Maxwell damping will be inactivated when the constitutive model is yielding; If off-when-yield = off/no/false , the Maxwell damping will still be active when the link constitutive model is yielding."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure link group",
-      "syntax": "structure link group <s1>[keyword] [range]",
+      "syntax": "structure link group <s1> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-history.json
@@ -117,27 +117,27 @@
         },
         {
           "name": "displacement-z",
-          "syntax": "displacement-z 3D ONLY [linkhistoryblock]",
+          "syntax": "displacement-z (3D ONLY) [linkhistoryblock]",
           "description": "Set the relative displacement in the local \\(z\\) degree-of-freedom."
         },
         {
           "name": "displacement-rotational",
-          "syntax": "displacement-rotational 2D ONLY [linkhistoryblock]",
+          "syntax": "displacement-rotational (2D ONLY) [linkhistoryblock]",
           "description": "Set the relative angular displacement."
         },
         {
           "name": "displacement-rotational-x",
-          "syntax": "displacement-rotational-x 3D ONLY [linkhistoryblock]",
+          "syntax": "displacement-rotational-x (3D ONLY) [linkhistoryblock]",
           "description": "Set the relative angular displacement in the local \\(x\\) degree-of-freedom."
         },
         {
           "name": "displacement-rotational-y",
-          "syntax": "displacement-rotational-y 3D ONLY [linkhistoryblock]",
+          "syntax": "displacement-rotational-y (3D ONLY) [linkhistoryblock]",
           "description": "Set the relative angular displacement in the local \\(y\\) degree-of-freedom."
         },
         {
           "name": "displacement-rotational-z",
-          "syntax": "displacement-rotational-z 3D ONLY [linkhistoryblock]",
+          "syntax": "displacement-rotational-z (3D ONLY) [linkhistoryblock]",
           "description": "Set the relative angular displacement in the local \\(z\\) degree-of-freedom."
         },
         {
@@ -152,27 +152,27 @@
         },
         {
           "name": "force-z",
-          "syntax": "force-z 3D ONLY [linkhistoryblock]",
+          "syntax": "force-z (3D ONLY) [linkhistoryblock]",
           "description": "Set the force in the local \\(z\\) degree-of-freedom."
         },
         {
           "name": "moment",
-          "syntax": "moment 2D ONLY [linkhistoryblock]",
+          "syntax": "moment (2D ONLY) [linkhistoryblock]",
           "description": "Set the moment."
         },
         {
           "name": "moment-x",
-          "syntax": "moment-x 3D ONLY [linkhistoryblock]",
+          "syntax": "moment-x (3D ONLY) [linkhistoryblock]",
           "description": "Set the moment in the local \\(x\\) degree-of-freedom."
         },
         {
           "name": "moment-y",
-          "syntax": "moment-y 3D ONLY [linkhistoryblock]",
+          "syntax": "moment-y (3D ONLY) [linkhistoryblock]",
           "description": "Set the moment in the local \\(y\\) degree-of-freedom."
         },
         {
           "name": "moment-z",
-          "syntax": "moment-z 3D ONLY [linkhistoryblock]",
+          "syntax": "moment-z (3D ONLY) [linkhistoryblock]",
           "description": "Set the moment in the local \\(z\\) degree-of-freedom."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-property.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-property.json
@@ -137,27 +137,27 @@
         },
         {
           "name": "z",
-          "syntax": "z [[linkpropertyblock]]3D ONLY",
+          "syntax": "z [[linkpropertyblock]] (3D ONLY)",
           "description": "Set the translational \\(z\\) -direction, also degree-of-freedom 3."
         },
         {
           "name": "rotation",
-          "syntax": "rotation [[linkpropertyblock]]2D ONLY",
+          "syntax": "rotation [[linkpropertyblock]] (2D ONLY)",
           "description": "Set the rotational also degree-of-freedom 3"
         },
         {
           "name": "rotation-x",
-          "syntax": "rotation-x [[linkpropertyblock]]3D ONLY",
+          "syntax": "rotation-x [[linkpropertyblock]] (3D ONLY)",
           "description": "Set the rotational \\(x\\) -direction, also degree-of-freedom 4."
         },
         {
           "name": "rotation-y",
-          "syntax": "rotation-y [[linkpropertyblock]]3D ONLY",
+          "syntax": "rotation-y [[linkpropertyblock]] (3D ONLY)",
           "description": "Set the rotational \\(y\\) -direction, also degree-of-freedom 5."
         },
         {
           "name": "rotation-z",
-          "syntax": "rotation-z [[linkpropertyblock]]3D ONLY",
+          "syntax": "rotation-z [[linkpropertyblock]] (3D ONLY)",
           "description": "Set the rotational \\(z\\) -direction, also degree-of-freedom 6."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-slide.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-slide.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure link slide",
-      "syntax": "structure link slide <b>[range]"
+      "syntax": "structure link slide <b> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-tolerance-slide.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-tolerance-slide.json
@@ -28,7 +28,7 @@
     },
     "9.0": {
       "command": "structure link tolerance-slide",
-      "syntax": "structure link tolerance-slide <f>[range]"
+      "syntax": "structure link tolerance-slide <f> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-create.json
@@ -39,7 +39,7 @@
     },
     "9.0": {
       "command": "structure node create",
-      "syntax": "structure node create <v>[group <s1>[slot <s2>]]",
+      "syntax": "structure node create <v> [group <s1> [slot <s2>]]",
       "figure_reference": {
         "figures": [
           {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-damping-local.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-damping-local.json
@@ -28,7 +28,7 @@
     },
     "9.0": {
       "command": "structure node damping-local",
-      "syntax": "structure node damping-local <f>[range]"
+      "syntax": "structure node damping-local <f> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-fix.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-fix.json
@@ -82,17 +82,17 @@
         },
         {
           "name": "rotation-x",
-          "syntax": "rotation-x 3D ONLY",
+          "syntax": "rotation-x (3D ONLY)",
           "description": "rotational velocity about \\(x\\) -axis (node-local system)"
         },
         {
           "name": "rotation-y",
-          "syntax": "rotation-y 3D ONLY",
+          "syntax": "rotation-y (3D ONLY)",
           "description": "rotational velocity about \\(y\\) -axis (node-local system)"
         },
         {
           "name": "rotation-z",
-          "syntax": "rotation-z 3D ONLY",
+          "syntax": "rotation-z (3D ONLY)",
           "description": "rotational velocity about \\(z\\) -axis (node-local system)"
         },
         {
@@ -117,7 +117,7 @@
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z 3D ONLY",
+          "syntax": "velocity-z (3D ONLY)",
           "description": "translational velocity in \\(z\\) -direction (node-local system)"
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-free.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-free.json
@@ -87,17 +87,17 @@
         },
         {
           "name": "rotation-x",
-          "syntax": "rotation-x 3D ONLY",
+          "syntax": "rotation-x (3D ONLY)",
           "description": "rotational velocity about \\(x\\) -axis (node-local system)"
         },
         {
           "name": "rotation-y",
-          "syntax": "rotation-y 3D ONLY",
+          "syntax": "rotation-y (3D ONLY)",
           "description": "rotational velocity about \\(y\\) -axis (node-local system)"
         },
         {
           "name": "rotation-z",
-          "syntax": "rotation-z 3D ONLY",
+          "syntax": "rotation-z (3D ONLY)",
           "description": "rotational velocity about \\(z\\) -axis (node-local system)"
         },
         {
@@ -117,12 +117,12 @@
         },
         {
           "name": "velocity-y",
-          "syntax": "velocity-y 3D ONLY",
+          "syntax": "velocity-y (3D ONLY)",
           "description": "translational velocity in \\(y\\) -direction (node-local system)"
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z 3D ONLY",
+          "syntax": "velocity-z (3D ONLY)",
           "description": "translational velocity in \\(z\\) -direction (node-local system)"
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure node group",
-      "syntax": "structure node group <s1>[keyword] [range]",
+      "syntax": "structure node group <s1> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-history.json
@@ -162,22 +162,22 @@
         },
         {
           "name": "acceleration-z",
-          "syntax": "acceleration-z 3D ONLY [nodehistoryblock]",
+          "syntax": "acceleration-z (3D ONLY) [nodehistoryblock]",
           "description": "translational acceleration ( \\(z\\) -component, global or node-local system)"
         },
         {
           "name": "acceleration-rotational-x",
-          "syntax": "acceleration-rotational-x 3D ONLY [nodehistoryblock]",
+          "syntax": "acceleration-rotational-x (3D ONLY) [nodehistoryblock]",
           "description": "rotational acceleration ( \\(x\\) -component, global or node-local system)"
         },
         {
           "name": "acceleration-rotational-y",
-          "syntax": "acceleration-rotational-y 3D ONLY [nodehistoryblock]",
+          "syntax": "acceleration-rotational-y (3D ONLY) [nodehistoryblock]",
           "description": "rotational acceleration ( \\(y\\) -component, global or node-local system)"
         },
         {
           "name": "acceleration-rotational-z",
-          "syntax": "acceleration-rotational-z 3D ONLY [nodehistoryblock]",
+          "syntax": "acceleration-rotational-z (3D ONLY) [nodehistoryblock]",
           "description": "rotational acceleration ( \\(z\\) -component, global or node-local system)"
         },
         {
@@ -192,27 +192,27 @@
         },
         {
           "name": "displacement-z",
-          "syntax": "displacement-z 3D ONLY [nodehistoryblock]",
+          "syntax": "displacement-z (3D ONLY) [nodehistoryblock]",
           "description": "translational displacement ( \\(z\\) -component, global or node-local system)"
         },
         {
           "name": "displacement-rotational",
-          "syntax": "displacement-rotational 2D ONLY [nodehistoryblock]",
+          "syntax": "displacement-rotational (2D ONLY) [nodehistoryblock]",
           "description": "rotational displacement (global or node-local system)"
         },
         {
           "name": "displacement-rotational-x",
-          "syntax": "displacement-rotational-x 3D ONLY [nodehistoryblock]",
+          "syntax": "displacement-rotational-x (3D ONLY) [nodehistoryblock]",
           "description": "rotational displacement ( \\(x\\) -component, global or node-local system)"
         },
         {
           "name": "displacement-rotational-y",
-          "syntax": "displacement-rotational-y 3D ONLY [nodehistoryblock]",
+          "syntax": "displacement-rotational-y (3D ONLY) [nodehistoryblock]",
           "description": "rotational displacement ( \\(y\\) -component, global or node-local system)"
         },
         {
           "name": "displacement-rotational-z",
-          "syntax": "displacement-rotational-z 3D ONLY [nodehistoryblock]",
+          "syntax": "displacement-rotational-z (3D ONLY) [nodehistoryblock]",
           "description": "rotational displacement ( \\(z\\) -component, global or node-local system)"
         },
         {
@@ -227,27 +227,27 @@
         },
         {
           "name": "force-z",
-          "syntax": "force-z 3D ONLY [nodehistoryblock]",
+          "syntax": "force-z (3D ONLY) [nodehistoryblock]",
           "description": "translational out-of-balance force ( \\(z\\) -component, global or node-local system)"
         },
         {
           "name": "moment",
-          "syntax": "moment 2D ONLY [nodehistoryblock]",
+          "syntax": "moment (2D ONLY) [nodehistoryblock]",
           "description": "out-of-balance moment (global or node-local system)"
         },
         {
           "name": "moment-x",
-          "syntax": "moment-x 3D ONLY [nodehistoryblock]",
+          "syntax": "moment-x (3D ONLY) [nodehistoryblock]",
           "description": "out-of-balance moment ( \\(x\\) -component, global or node-local system)"
         },
         {
           "name": "moment-y",
-          "syntax": "moment-y 3D ONLY [nodehistoryblock]",
+          "syntax": "moment-y (3D ONLY) [nodehistoryblock]",
           "description": "out-of-balance moment ( \\(y\\) -component, global or node-local system)"
         },
         {
           "name": "moment-z",
-          "syntax": "moment-z 3D ONLY [nodehistoryblock]",
+          "syntax": "moment-z (3D ONLY) [nodehistoryblock]",
           "description": "out-of-balance moment ( \\(z\\) -component, global or node-local system)"
         },
         {
@@ -262,7 +262,7 @@
         },
         {
           "name": "position-z",
-          "syntax": "position-z 3D ONLY [nodehistoryblock]",
+          "syntax": "position-z (3D ONLY) [nodehistoryblock]",
           "description": "current position ( \\(z\\) -component, global system)"
         },
         {
@@ -277,27 +277,27 @@
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z 3D ONLY [nodehistoryblock]",
+          "syntax": "velocity-z (3D ONLY) [nodehistoryblock]",
           "description": "translational velocity ( \\(z\\) -component, global or node-local system)"
         },
         {
           "name": "velocity-rotational",
-          "syntax": "velocity-rotational 2D ONLY [nodehistoryblock]",
+          "syntax": "velocity-rotational (2D ONLY) [nodehistoryblock]",
           "description": "rotational velocity ( \\(x\\) -component, global or node-local system"
         },
         {
           "name": "velocity-rotational-x",
-          "syntax": "velocity-rotational-x 3D ONLY [nodehistoryblock]",
+          "syntax": "velocity-rotational-x (3D ONLY) [nodehistoryblock]",
           "description": "rotational velocity ( \\(x\\) -component, global or node-local system)"
         },
         {
           "name": "velocity-rotational-y",
-          "syntax": "velocity-rotational-y 3D ONLY [nodehistoryblock]",
+          "syntax": "velocity-rotational-y (3D ONLY) [nodehistoryblock]",
           "description": "rotational velocity ( \\(y\\) -component, global or node-local system)"
         },
         {
           "name": "velocity-rotational-z",
-          "syntax": "velocity-rotational-z 3D ONLY [nodehistoryblock]",
+          "syntax": "velocity-rotational-z (3D ONLY) [nodehistoryblock]",
           "description": "rotational velocity ( \\(z\\) -component, global or node-local system)"
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-initialize.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-initialize.json
@@ -156,107 +156,107 @@
       "keywords": [
         {
           "name": "displacement",
-          "syntax": "displacement <v>[[nodeinitializeblock]]",
+          "syntax": "displacement <v> [[nodeinitializeblock]]",
           "description": "translational displacement"
         },
         {
           "name": "displacement-x",
-          "syntax": "displacement-x <f>[[nodeinitializeblock]]",
+          "syntax": "displacement-x <f> [[nodeinitializeblock]]",
           "description": "translational displacement ( \\(x\\) -component)"
         },
         {
           "name": "displacement-y",
-          "syntax": "displacement-y <f>[[nodeinitializeblock]]",
+          "syntax": "displacement-y <f> [[nodeinitializeblock]]",
           "description": "translational displacement ( \\(y\\) -component)"
         },
         {
           "name": "displacement-z",
-          "syntax": "displacement-z <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "displacement-z <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "translational displacement ( \\(z\\) -component)"
         },
         {
           "name": "displacement-rotational",
-          "syntax": "displacement-rotational <v>[[nodeinitializeblock]]",
+          "syntax": "displacement-rotational <v> [[nodeinitializeblock]]",
           "description": "rotational displacement"
         },
         {
           "name": "displacement-rotational-x",
-          "syntax": "displacement-rotational-x <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "displacement-rotational-x <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "rotational displacement ( \\(x\\) -component)"
         },
         {
           "name": "displacement-rotational-y",
-          "syntax": "displacement-rotational-y <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "displacement-rotational-y <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "rotational displacement ( \\(y\\) -component)"
         },
         {
           "name": "displacement-rotational-z",
-          "syntax": "displacement-rotational-z <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "displacement-rotational-z <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "rotational displacement ( \\(z\\) -component)"
         },
         {
           "name": "position",
-          "syntax": "position <v>[[nodeinitializeblock]]",
+          "syntax": "position <v> [[nodeinitializeblock]]",
           "description": "position of node (global system). This is used for positioning of structural elements, and must be used after creating the node, but before executing any cycles. A node that is moved into a zone will have its link deleted (if one is present) and will have a new link created with attachment conditions corresponding to the type of structural element using the node (see this table ). If more than one element type is using the node, then the attachment condition will correspond with the first element type in the following list: liner, geogrid, pile, cable, shell, and beam. Thus, if a node is being used by both a geogrid and a cable, then the attachment condition after moving this node will correspond with that of a geogrid."
         },
         {
           "name": "position-x",
-          "syntax": "position-x <f>[[nodeinitializeblock]]",
+          "syntax": "position-x <f> [[nodeinitializeblock]]",
           "description": "\\(x\\) -coordinate of node (global system). See position above."
         },
         {
           "name": "position-y",
-          "syntax": "position-y <f>[[nodeinitializeblock]]",
+          "syntax": "position-y <f> [[nodeinitializeblock]]",
           "description": "\\(y\\) -coordinate of node (global system). See position above."
         },
         {
           "name": "position-z",
-          "syntax": "position-z <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "position-z <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "\\(z\\) -coordinate of node (global system). See position above."
         },
         {
           "name": "ratio-target",
-          "syntax": "ratio-target <f>[[nodeinitializeblock]]",
+          "syntax": "ratio-target <f> [[nodeinitializeblock]]",
           "description": "Sets the target local force ratio that is considered to be converged for mechanical calculations. The default value is 1e-4. A local force ratio of this value will result in a convergence value of 1.0 for the node. See the convergence keyword in the model solve command."
         },
         {
           "name": "velocity",
-          "syntax": "velocity <v>[[nodeinitializeblock]]",
+          "syntax": "velocity <v> [[nodeinitializeblock]]",
           "description": "translational velocity"
         },
         {
           "name": "velocity-x",
-          "syntax": "velocity-x <f>[[nodeinitializeblock]]",
+          "syntax": "velocity-x <f> [[nodeinitializeblock]]",
           "description": "translational velocity ( \\(x\\) -component)"
         },
         {
           "name": "velocity-y",
-          "syntax": "velocity-y <f>[[nodeinitializeblock]]",
+          "syntax": "velocity-y <f> [[nodeinitializeblock]]",
           "description": "translational velocity ( \\(y\\) -component)"
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "velocity-z <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "translational velocity ( \\(z\\) -component)"
         },
         {
           "name": "velocity-rotational",
-          "syntax": "velocity-rotational <v>[[nodeinitializeblock]]",
+          "syntax": "velocity-rotational <v> [[nodeinitializeblock]]",
           "description": "rotational velocity"
         },
         {
           "name": "velocity-rotational-x",
-          "syntax": "velocity-rotational-x <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "velocity-rotational-x <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "rotational velocity ( \\(x\\) -component)"
         },
         {
           "name": "velocity-rotational-y",
-          "syntax": "velocity-rotational-y <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "velocity-rotational-y <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "rotational velocity ( \\(y\\) -component)"
         },
         {
           "name": "velocity-rotational-z",
-          "syntax": "velocity-rotational-z <f>[[nodeinitializeblock]]3D ONLY",
+          "syntax": "velocity-rotational-z <f> [[nodeinitializeblock]] (3D ONLY)",
           "description": "rotational velocity ( \\(z\\) -component)"
         },
         {
@@ -266,7 +266,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-join.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-join.json
@@ -47,7 +47,7 @@
       "keywords": [
         {
           "name": "group",
-          "syntax": "group <s>[slot <slot>]",
+          "syntax": "group <s> [slot <slot>]",
           "description": "Specify a group assignment that will be made to all links created with this command. The slot keyword can be used to specify the slot used, otherwise the slot will be Default . Use of the group logic is described in Groups ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-system-local.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-system-local.json
@@ -59,17 +59,17 @@
         },
         {
           "name": "z",
-          "syntax": "z <v>3D ONLY",
+          "syntax": "z <v> (3D ONLY)",
           "description": "specifies the local \\(z\\) -direction"
         },
         {
           "name": "reverse-x",
-          "syntax": "reverse-x 2D ONLY",
+          "syntax": "reverse-x (2D ONLY)",
           "description": "reverses the current \\(x\\) -direction (cannot be used with the \\(x\\) or \\(y\\) keywords)"
         },
         {
           "name": "reverse-y",
-          "syntax": "reverse-y 2D ONLY",
+          "syntax": "reverse-y (2D ONLY)",
           "description": "reverses the current \\(y\\) -direction (cannot be used with the \\(x\\) or \\(y\\) keywords)"
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-create.json
@@ -87,22 +87,22 @@
       "keywords": [
         {
           "name": "by-line",
-          "syntax": "by-line <v1><v2>[pilecreateblock]",
+          "syntax": "by-line <v1> <v2> [pilecreateblock]",
           "description": "create a collection of elements that lie along a straight line between the locations v1 and v2 . New nodes associated with the elements will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 to v2 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC, and particles in PFC3D) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2>[pilecreateblock]",
+          "syntax": "by-nodeids <i1> <i2> [pilecreateblock]",
           "description": "specify the ID numbers ( i1 , i2 ) of two nodes that will define the element. These nodes must already exist\u2014nodes can be created with the structure node create command. Ordering of the nodes defines the beam element coordinate system as follows. The positive \\(x\\) -direction lies along the line from i1 to i2 , and the \\(y\\) -direction is found by projecting the global \\(y\\) - or \\(x\\) -directions onto the element cross-section. The \\(y\\) -direction can also be modified with the property direction-y . The new element will not be attached to any objects (zones in FLAC3D and 3DEC, and particles in PFC3D); if you wish to attach it to objects, then after creating it, position its nodes with the structure node initialize position command (which will create links and set appropriate attachment conditions for all nodes that are moved into an object."
         },
         {
           "name": "by-ray",
-          "syntax": "by-ray <v1><v2><f>[pilecreateblock]",
+          "syntax": "by-ray <v1> <v2> <f> [pilecreateblock]",
           "description": "creates a collection of elements that lie along a straight line starting at v1 , proceeding in the direction specified by v2 for a distance given by f . New nodes associated with the element will also be created (see the id keyword). The nodal connectivity of each new element will be ordered such that the direction from v1 corresponds with the direction from the begin point to the end point. If there are objects (zones in FLAC3D and 3DEC, and particles in PFC3D) in these locations, the element will be attached to the objects at its nodes such that the translational degrees-of-freedom are rigidly connected to the objects and the rotational degrees-of-freedom are free. If no attachment to objects is desired, then the links may be deleted with the command structure link delete after creating and positioning the element."
         },
         {
           "name": "by-zone-face",
-          "syntax": "by-zone-face 2D ONLY [pilecreateblock] [range]",
+          "syntax": "by-zone-face (2D ONLY) [pilecreateblock] [range]",
           "description": "create new elements that are attached to the set of 2-noded edges (faces) in the range. By default, only surface faces will be considered, and the internal keyword can be used to select internal faces. New nodes associated with each element will also be created. The nodes of each element will be ordered counter-clockwise with respect to the outside of the zone faces, thereby making each element \\(y\\) axis point outward from the zone face. The orientation of the \\(y\\) axis can be reversed with the reverse keyword. Note that after creating the elements with this command, the zones may be deleted and the elements may be positioned by moving their nodes with the structure node initialize position command."
         },
         {
@@ -117,12 +117,12 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign all newly created elements to the group s . The optional keyword slot can be used to specify the group slot; if not specified, the group is assigned to the slot Default . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Pile N where N is the ID number assigned to the pile."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line or ray. The default name assigned will be Pile Begin ."
         },
         {
@@ -142,7 +142,7 @@
         },
         {
           "name": "reverse",
-          "syntax": "reverse 2D ONLY",
+          "syntax": "reverse (2D ONLY)",
           "description": "Specifies that the orientation of the element will be reversed from the default, so that only the element \\(y\\) axis points in the other direction."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure pile group",
-      "syntax": "structure pile group <s>[keyword] [range]",
+      "syntax": "structure pile group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-import.json
@@ -117,7 +117,7 @@
         },
         {
           "name": "from-file",
-          "syntax": "from-file <s>[pileimportblock]",
+          "syntax": "from-file <s> [pileimportblock]",
           "description": "Create elements from the geometry file s ."
         },
         {
@@ -137,12 +137,12 @@
         },
         {
           "name": "group",
-          "syntax": "group <s>[slot <s>]",
+          "syntax": "group <s> [slot <s>]",
           "description": "Assign the elements created to group s . Use of the group logic is described in Groups . If not specified, the default group name assigned will be Pile N where N is the ID number assinged to the elements."
         },
         {
           "name": "group-begin",
-          "syntax": "group-begin <s>[slot <s>]",
+          "syntax": "group-begin <s> [slot <s>]",
           "description": "A group name that will be assigned to the first node of the elements created along a line. The default name assigned will be Pile Begin ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-refine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-refine.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure pile refine",
-      "syntax": "structure pile refine <i>[range]"
+      "syntax": "structure pile refine <i> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-apply.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure shell apply",
-      "syntax": "structure shell apply <f>[range]"
+      "syntax": "structure shell apply <f> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-create.json
@@ -134,17 +134,17 @@
         },
         {
           "name": "by-nodeids",
-          "syntax": "by-nodeids <i1><i2><i3>[shellcreateblock]",
+          "syntax": "by-nodeids <i1> <i2> <i3> [shellcreateblock]",
           "description": "Create a single element from three existing nodes."
         },
         {
           "name": "by-quadrilateral",
-          "syntax": "by-quadrilateral <v1><v2><v3><v4>[shellcreateblock]",
+          "syntax": "by-quadrilateral <v1> <v2> <v3> <v4> [shellcreateblock]",
           "description": "Create elements based on four points forming a quadrilateral, in order. The element \\(z\\) -axis will point in the direction determined by applying the right-hand rule to the quadrilateral."
         },
         {
           "name": "by-triangle",
-          "syntax": "by-triangle <v1><v2><v3>[shellcreateblock]",
+          "syntax": "by-triangle <v1> <v2> <v3> [shellcreateblock]",
           "description": "Create elements based on three points forming a triangle. The element \\(z\\) -axis will point in the direction determined by applying the right-hand rule to the triangle."
         },
         {
@@ -169,7 +169,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created elements to group s1 . The group is assigned to the slot named s2 if supplied; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {
@@ -199,7 +199,7 @@
         },
         {
           "name": "size",
-          "syntax": "size <i1><i2>",
+          "syntax": "size <i1> <i2>",
           "description": "This keyword only applies if the by-quadrilateral option was used. Increases the number of elements created by subdividing the quadrilateral into i1 segments along the first edge and i2 segments along the second. By default, only one quad is created."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "structure shell group",
-      "syntax": "structure shell group <s1>[keyword] [range]",
+      "syntax": "structure shell group <s1> [keyword] [range]",
       "keywords": [
         {
           "name": "slot",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-import.json
@@ -136,7 +136,7 @@
       "keywords": [
         {
           "name": "from-file",
-          "syntax": "from-file <s>[shellimportblock]",
+          "syntax": "from-file <s> [shellimportblock]",
           "description": "Create elements from the geometry file s ."
         },
         {
@@ -166,7 +166,7 @@
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign the created elements to group s1 . The group is assigned to the slot named s2 if supplied; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-property-{elastic}.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-property-{elastic}.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "ortho-bend-constants",
-          "syntax": "ortho-bend-constants <f1><f2><f3><f4>",
+          "syntax": "ortho-bend-constants <f1> <f2> <f3> <f4>",
           "description": "orthotropic bending elastic constants \\(\\{ {c_{11}^b}', {c_{12}^b}', {c_{22}^b}', {c_{33}^b}' \\}\\) [F/L 2 ] which define the bending material-stiffness matrix \\(\\big[ {\\mathbf{E}_b}' \\big]\\) in the material directions \\(x'y'z'\\) . The material directions should also be specified with the material-x property."
         },
         {
@@ -42,7 +42,7 @@
         },
         {
           "name": "ortho-memb-constants",
-          "syntax": "ortho-memb-constants <f1><f2><f3><f4>",
+          "syntax": "ortho-memb-constants <f1> <f2> <f3> <f4>",
           "description": "orthotropic membrane elastic constants \\(\\{ {c_{11}^m}', {c_{12}^m}', {c_{22}^m}', {c_{33}^m}' \\}\\) [F/L 2 ] which define the membrane material-stiffness matrix \\(\\big[ {\\mathbf{E}_m}' \\big]\\) in the material directions \\(x'y'z'\\) . The material directions should also be specified with the material-x property."
         },
         {
@@ -52,7 +52,7 @@
         },
         {
           "name": "aniso-bend-constants",
-          "syntax": "aniso-bend-constants <f1><f2><f3><f4><f5><f6>",
+          "syntax": "aniso-bend-constants <f1> <f2> <f3> <f4> <f5> <f6>",
           "description": "anisotropic bending elastic constants \\(\\{ {c_{11}^b}', {c_{12}^b}', {c_{13}^b}', {c_{22}^b}', {c_{23}^b}', {c_{33}^b}' \\}\\) [F/L 2 ] which define the bending material-stiffness matrix \\(\\big[ {\\mathbf{E}_b}' \\big]\\) in the material directions \\(x'y'z'\\) . The material directions should also be specified with the material-x property."
         },
         {
@@ -62,7 +62,7 @@
         },
         {
           "name": "aniso-memb-constants",
-          "syntax": "aniso-memb-constants <f1><f2><f3><f4><f5><f6>",
+          "syntax": "aniso-memb-constants <f1> <f2> <f3> <f4> <f5> <f6>",
           "description": "anisotropic membrane elastic constants \\(\\{ {c_{11}^m}', {c_{12}^m}', {c_{13}^m}', {c_{22}^m}', {c_{23}^m}', {c_{33}^m}' \\}\\) [F/L 2 ] which define the membrane material-stiffness matrix \\(\\big[ {\\mathbf{E}_m}' \\big]\\) in the material directions \\(x'y'z'\\) . The material directions should also be specified with the material-x property."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-refine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-refine.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "structure shell refine",
-      "syntax": "structure shell refine <i>[range]"
+      "syntax": "structure shell refine <i> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/apply-remove.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/apply-remove.json
@@ -72,7 +72,7 @@
         },
         {
           "name": "force-z",
-          "syntax": "force-z 3D ONLY",
+          "syntax": "force-z (3D ONLY)",
           "description": "Remove a zone apply force-z condition applied to a zone."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/apply.json
@@ -185,32 +185,32 @@
       "keywords": [
         {
           "name": "force",
-          "syntax": "force <v>[applyblock]",
+          "syntax": "force <v> [applyblock]",
           "description": "Apply all components of the body force, per unit volume, to all zones in the range."
         },
         {
           "name": "force-x",
-          "syntax": "force-x <f>[applyblock]",
+          "syntax": "force-x <f> [applyblock]",
           "description": "Apply the \\(x\\) -component of the body force, per unit volume, to all zones in the range."
         },
         {
           "name": "force-y",
-          "syntax": "force-y <f>[applyblock]",
+          "syntax": "force-y <f> [applyblock]",
           "description": "Apply the \\(y\\) -component of the body force, per unit volume, to all zones in the range."
         },
         {
           "name": "force-z",
-          "syntax": "force-z <f>3D ONLY [applyblock]",
+          "syntax": "force-z <f> (3D ONLY) [applyblock]",
           "description": "Apply the \\(z\\) -component of the body force, per unit volume, to all zones in the range."
         },
         {
           "name": "source",
-          "syntax": "source <f>[applyblock]",
+          "syntax": "source <f> [applyblock]",
           "description": "Apply a heat-generating source, f , as a volume source of the specified strength (e.g., in W/m 3 ) in each zone in the specified range. When a new source is applied to a zone with an existing source, the new source strength replaces the existing source strength. Decay of the heat source over time can be represented by applying one of the available modifiers. Note: This keyword is only available for the thermal model option."
         },
         {
           "name": "well",
-          "syntax": "well <f>[applyblock]",
+          "syntax": "well <f> [applyblock]",
           "description": "Apply a volume rate of flow, f (i.e., fluid volume per zone volume per unit time), for each zone in the specified range ( f > 0 for inflow). Note: A fluid flow model must exist for this command to work."
         },
         {
@@ -225,7 +225,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient in space to the scalar-value provided. The position used in this calculation is the zone centroid. Another way of assigning a linear gradient is with the vary modifier."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/copy.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/copy.json
@@ -25,7 +25,7 @@
     },
     "9.0": {
       "command": "zone copy",
-      "syntax": "zone copy <v>[merge <b>] [range]"
+      "syntax": "zone copy <v> [merge <b>] [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create.json
@@ -293,12 +293,12 @@
         },
         {
           "name": "fill",
-          "syntax": "fill <b>[group <s1>[slot <s2>]]",
+          "syntax": "fill <b> [group <s1> [slot <s2>]]",
           "description": "If specified, the interior region for some shapes (see Summary of 3D Mesh Shape Properties above) will be filled with zones. If not specified, the interior region will not contain zones. If the optional group keyword is given with a valid name, the name s1 is assigned to the filled zones. This keyword can only be used with the following keywords of the zone create command: cylindrical-intersection , radial-brick , radial-cylinder , radial-tunnel , and tunnel-intersection ."
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign a group name s1 to this primitive at creation. By default (when the slot keyword is not supplied), the group is assigned to slot Default . Use of the group logic is described in Groups ."
         },
         {
@@ -313,12 +313,12 @@
         },
         {
           "name": "ratio",
-          "syntax": "ratio <f1>[<f2...>]",
+          "syntax": "ratio <f1> [<f2...>]",
           "description": "This specifies a ratio that is used to space zones with an increasing or decreasing geometric ratio. This ratio is defined as creating a zone size distribution such that each zone along the edge is f times the previous. Up to five ratio entries ( f5 ) may be needed for some shapes. For each shape, the entries and their associated zone directions are shown in the reference images (click any thumbnail above). If ratio is not given, all entries default to 1.0."
         },
         {
           "name": "size",
-          "syntax": "size <i1>[<i2>... ]",
+          "syntax": "size <i1> [<i2>... ]",
           "description": "This specifies the number of zones for each shape. Up to five ( i5 ) may be needed for some shapes. The number required is listed in Summary of 3D Mesh Shape Properties above. The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above). If not specified, size values default to 10."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create2d.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/create2d.json
@@ -68,12 +68,12 @@
         },
         {
           "name": "fill",
-          "syntax": "fill <b>[group <s1>[slot <s2>]]",
+          "syntax": "fill <b> [group <s1> [slot <s2>]]",
           "description": "If specified, the interior region for some shapes (see Summary of 2D Mesh Shape Properties above) will be filled with zones. If not specified, the interior region will not contain zones. If the optional group keyword is given with a valid name, the name s1 is assigned to the filled zones."
         },
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "Assign a group name s1 to this primitive at creation. By default (when the slot keyword is not supplied), the group is assigned to slot Default . Use of the group logic is described in Groups ."
         },
         {
@@ -88,12 +88,12 @@
         },
         {
           "name": "ratio",
-          "syntax": "ratio <f1>[<f2...>]",
+          "syntax": "ratio <f1> [<f2...>]",
           "description": "This specifies a ratio that is used to space zones with an increasing or decreasing geometric ratio. This ratio is defined as creating a zone size distribution such that each zone along the edge is f times the previous. Up to three ratio entries ( f3 ) may be needed for some shapes. For each shape, the entries and their associated zone directions are shown in the reference images (click any thumbnail above). If ratio is not given, all entries default to 1.0."
         },
         {
           "name": "size",
-          "syntax": "size <i1>[<i2>... ]",
+          "syntax": "size <i1> [<i2>... ]",
           "description": "This specifies the number of zones for each shape. Up to three ( i3 ) may be needed for some shapes. The number required is listed in Summary of 2D Mesh Shape Properties above. The entries and their corresponding directions for each shape are shown in the reference images (click any thumbnail above). If not specified, size values default to 10."
         }
       ],

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/densify.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/densify.json
@@ -96,12 +96,12 @@
         },
         {
           "name": "maximum-length",
-          "syntax": "maximum-length <f1>[<f2>[<f3>]]",
+          "syntax": "maximum-length <f1> [<f2> [<f3>]]",
           "description": "This specifies the maximum edge lengths to be densified, in order of local or global \\(x\\) -, \\(y\\) -, or \\(z\\) - direction. If f2 and f3 are not specified, they will be set to the same number as f1 . The value f3 is used in 3D only. The number of divisions (used instead of what can specified with the segments keyword) is calculated for each zone in order to bring the resulting edge length below the maximum. The divisions resulting are constrained to fall in powers of 2 (1,2,4,8,\u2026). Note that this differs from the behavior of the edge-limit keyword, which will use the divisions specified in the segments keyword. When the repeat keyword is used the difference is only that the maximum-length keyword allows different length limits in different directions."
         },
         {
           "name": "segments",
-          "syntax": "segments <i1>[<i2>[<i3>]]",
+          "syntax": "segments <i1> [<i2> [<i3>]]",
           "description": "This specifies the subdivision number of zones to be densified, in order. If i2 and i3 are not specified, they will be set to the same number as i1 . The value i3 is used in 3D only. Note that using non-uniform segment values is not recommended on very irregular starting meshes\u2014in particular the kind resulting from mesh generation tools like Griddle . Adjacent zones may have very different local orientations. Use of the global keyword may mitigate these effects but it will not eliminate them. If using non-uniform segment values, choose choose numbers that are multiples of each other. For example 1,2,4 will tend to produce better meshes than 2,3,5."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/export.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/export.json
@@ -32,7 +32,7 @@
     },
     "9.0": {
       "command": "zone export",
-      "syntax": "zone export <s>[keyword] [range]",
+      "syntax": "zone export <s> [keyword] [range]",
       "keywords": [
         {
           "name": "binary",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply-remove.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply-remove.json
@@ -198,7 +198,7 @@
         },
         {
           "name": "acceleration-dip",
-          "syntax": "acceleration-dip 3D ONLY"
+          "syntax": "acceleration-dip (3D ONLY)"
         },
         {
           "name": "acceleration-local",
@@ -210,11 +210,11 @@
         },
         {
           "name": "acceleration-strike",
-          "syntax": "acceleration-strike 3D ONLY"
+          "syntax": "acceleration-strike (3D ONLY)"
         },
         {
           "name": "acceleration-tangential",
-          "syntax": "acceleration-tangential 2D ONLY"
+          "syntax": "acceleration-tangential (2D ONLY)"
         },
         {
           "name": "acceleration-x",
@@ -226,7 +226,7 @@
         },
         {
           "name": "acceleration-z",
-          "syntax": "acceleration-z 3D ONLY"
+          "syntax": "acceleration-z (3D ONLY)"
         },
         {
           "name": "convection",
@@ -273,7 +273,7 @@
         },
         {
           "name": "quiet-dip",
-          "syntax": "quiet-dip 3D ONLY"
+          "syntax": "quiet-dip (3D ONLY)"
         },
         {
           "name": "quiet-normal",
@@ -281,11 +281,11 @@
         },
         {
           "name": "quiet-strike",
-          "syntax": "quiet-strike 3D ONLY"
+          "syntax": "quiet-strike (3D ONLY)"
         },
         {
           "name": "quiet-tangential",
-          "syntax": "quiet-tangential 2D ONLY"
+          "syntax": "quiet-tangential (2D ONLY)"
         },
         {
           "name": "reaction",
@@ -293,7 +293,7 @@
         },
         {
           "name": "reaction-dip",
-          "syntax": "reaction-dip 3D ONLY"
+          "syntax": "reaction-dip (3D ONLY)"
         },
         {
           "name": "reaction-local",
@@ -305,11 +305,11 @@
         },
         {
           "name": "reaction-strike",
-          "syntax": "reaction-strike 3D ONLY"
+          "syntax": "reaction-strike (3D ONLY)"
         },
         {
           "name": "reaction-tangential",
-          "syntax": "reaction-tangential 2D ONLY"
+          "syntax": "reaction-tangential (2D ONLY)"
         },
         {
           "name": "reaction-x",
@@ -321,11 +321,11 @@
         },
         {
           "name": "reaction-z",
-          "syntax": "reaction-z 3D ONLY"
+          "syntax": "reaction-z (3D ONLY)"
         },
         {
           "name": "stress-dip",
-          "syntax": "stress-dip 3D ONLY"
+          "syntax": "stress-dip (3D ONLY)"
         },
         {
           "name": "stress-normal",
@@ -333,7 +333,7 @@
         },
         {
           "name": "stress-strike",
-          "syntax": "stress-strike 3D ONLY"
+          "syntax": "stress-strike (3D ONLY)"
         },
         {
           "name": "stress-tensor",
@@ -342,7 +342,7 @@
         },
         {
           "name": "stress-tangential",
-          "syntax": "stress-tangential 2D ONLY"
+          "syntax": "stress-tangential (2D ONLY)"
         },
         {
           "name": "stress-xx",
@@ -354,7 +354,7 @@
         },
         {
           "name": "stress-xz",
-          "syntax": "stress-xz 3D ONLY"
+          "syntax": "stress-xz (3D ONLY)"
         },
         {
           "name": "stress-yy",
@@ -367,7 +367,7 @@
         },
         {
           "name": "stress-zz",
-          "syntax": "stress-zz 3D ONLY"
+          "syntax": "stress-zz (3D ONLY)"
         },
         {
           "name": "temperature",
@@ -379,7 +379,7 @@
         },
         {
           "name": "velocity-dip",
-          "syntax": "velocity-dip 3D ONLY"
+          "syntax": "velocity-dip (3D ONLY)"
         },
         {
           "name": "velocity-local",
@@ -391,11 +391,11 @@
         },
         {
           "name": "velocity-strike",
-          "syntax": "velocity-strike 3D ONLY"
+          "syntax": "velocity-strike (3D ONLY)"
         },
         {
           "name": "velocity-tangential",
-          "syntax": "velocity-tangential 2D ONLY"
+          "syntax": "velocity-tangential (2D ONLY)"
         },
         {
           "name": "velocity-x",
@@ -407,7 +407,7 @@
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z 3D ONLY"
+          "syntax": "velocity-z (3D ONLY)"
         }
       ]
     }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-hide.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-hide.json
@@ -142,7 +142,7 @@
         },
         {
           "name": "only-grouped",
-          "syntax": "only-grouped <s>[slot <s>]",
+          "syntax": "only-grouped <s> [slot <s>]",
           "description": "Specifies that only the set of faces that have had group names assigned should be considered. Other filter options are allowed. If an option slot is specified, then only the set of faces with group assignments in that particular slot will be considered."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-select.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-select.json
@@ -142,7 +142,7 @@
         },
         {
           "name": "only-grouped",
-          "syntax": "only-grouped <s>[slot <s>]",
+          "syntax": "only-grouped <s> [slot <s>]",
           "description": "Specifies that only the set of faces that have had group names assigned should be considered. Other filter options are allowed. If an option slot is specified, then only the set of faces with group assignments in that particular slot will be considered."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-skin.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-skin.json
@@ -12,7 +12,7 @@
   "versions": {
     "7.0": {
       "command": "zone face skin",
-      "syntax": "zone face skin <keyword... ><range>",
+      "syntax": "zone face skin <keyword... > <range>",
       "description": "Skin the model to automatically generate face groups. \u201cSkinning\u201d refers to automatic face group generation, which occurs as follows: the program looks for contiguous faces and puts them into automatically named groups within the slot named skin. Two faces are not considered contiguous if: the angle between two faces exceeds the break-angle, or if the two faces belong to different groups according to the command\u2019s slot specification. Unless internal is specified, the operation of the command is restricted to external faces. For this command, only zone faces that have no zone on the other side, a hidden zone on the other side, or a mechanically null zone on the other side, are considered surface faces. When use-hidden-zones is used, zone faces within the specified range will be included for consideration, even if they are a part of zones that are currently hidden.",
       "keywords": [
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-create.json
@@ -38,11 +38,11 @@
     },
     "9.0": {
       "command": "zone gridpoint create",
-      "syntax": "zone gridpoint create <v>[keyword]",
+      "syntax": "zone gridpoint create <v> [keyword]",
       "keywords": [
         {
           "name": "group",
-          "syntax": "group <s1>[slot <s2>]",
+          "syntax": "group <s1> [slot <s2>]",
           "description": "The gridpoint is assigned to group s1 if the optional group keyword is used. The group is assigned to slot s2 if the optional slot keyword follows; it is assigned to the slot named Default if not. Use of the group logic is described in Groups ."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-fix.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-fix.json
@@ -141,7 +141,7 @@
         },
         {
           "name": "acceleration-z",
-          "syntax": "acceleration-z [<f>] [[gridpointfixblock]]3D ONLY",
+          "syntax": "acceleration-z [<f>] [[gridpointfixblock]] (3D ONLY)",
           "description": "Fix \\(z\\) -acceleration. If f is given, \\(z\\) -acceleration is fixed at that value. This is only available if model configure dynamic has been specified. The value is always in terms of the gridpoint local coordinate system, if any."
         },
         {
@@ -161,7 +161,7 @@
         },
         {
           "name": "force-applied-z",
-          "syntax": "force-applied-z [<f>] [[gridpointfixblock]]3D ONLY",
+          "syntax": "force-applied-z [<f>] [[gridpointfixblock]] (3D ONLY)",
           "description": "Fix applied force in the z -direction. If f is given, applied force in the z -direction is fixed at that value. Note that this value is independent of either force-based apply conditions, or forces applied via FISH . The value is always in terms of the gridpoint local coordinate system, if any."
         },
         {
@@ -206,7 +206,7 @@
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z [<f>] [[gridpointfixblock]]3D ONLY",
+          "syntax": "velocity-z [<f>] [[gridpointfixblock]] (3D ONLY)",
           "description": "Fixes \\(z\\) -velocity. If f is given, the \\(z\\) -velocity is fixed at that value. The value is always in terms of the gridpoint local coordinate system, if any."
         },
         {
@@ -226,7 +226,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided. This is not available if the apply conditions requires two values or a vector value. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-free.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-free.json
@@ -107,7 +107,7 @@
         },
         {
           "name": "acceleration-z",
-          "syntax": "acceleration-z 3D ONLY",
+          "syntax": "acceleration-z (3D ONLY)",
           "description": "Free \\(z\\) -acceleration."
         },
         {
@@ -127,7 +127,7 @@
         },
         {
           "name": "force-applied-z",
-          "syntax": "force-applied-z 3D ONLY",
+          "syntax": "force-applied-z (3D ONLY)",
           "description": "Fix applied force in the z -direction."
         },
         {
@@ -167,7 +167,7 @@
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z 3D ONLY",
+          "syntax": "velocity-z (3D ONLY)",
           "description": "Frees \\(z\\) -velocity."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "zone gridpoint group",
-      "syntax": "zone gridpoint group <s>[keyword] [range]",
+      "syntax": "zone gridpoint group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "remove",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-import.json
@@ -43,7 +43,7 @@
     },
     "9.0": {
       "command": "zone gridpoint import",
-      "syntax": "zone gridpoint import pore-pressure <sfile>[keyword ...] [range] 3D ONLY",
+      "syntax": "zone gridpoint import pore-pressure <sfile> [keyword ...] [range] (3D ONLY)",
       "keywords": [
         {
           "name": "cutoff",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-initialize.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-initialize.json
@@ -171,152 +171,152 @@
       "keywords": [
         {
           "name": "biot",
-          "syntax": "biot <f>[[gridpointinitializeblock]]",
+          "syntax": "biot <f> [[gridpointinitializeblock]]",
           "description": "Biot modulus for fluid-flow model (see See Biot Coefficient and Biot Modulus ). Only available if the model configure fluid has been given."
         },
         {
           "name": "displacement",
-          "syntax": "displacement <v>[[gridpointinitializeblock]]",
+          "syntax": "displacement <v> [[gridpointinitializeblock]]",
           "description": "Gridpoint displacement."
         },
         {
           "name": "displacement-x",
-          "syntax": "displacement-x <f>[[gridpointinitializeblock]]",
+          "syntax": "displacement-x <f> [[gridpointinitializeblock]]",
           "description": "Gridpoint displacement in the \\(x\\) -direction."
         },
         {
           "name": "displacement-y",
-          "syntax": "displacement-y <f>[[gridpointinitializeblock]]",
+          "syntax": "displacement-y <f> [[gridpointinitializeblock]]",
           "description": "Gridpoint displacement in the \\(y\\) -direction."
         },
         {
           "name": "displacement-z",
-          "syntax": "displacement-z <f>[[gridpointinitializeblock]]3D ONLY",
+          "syntax": "displacement-z <f> [[gridpointinitializeblock]] (3D ONLY)",
           "description": "Gridpoint displacement in the \\(z\\) -direction."
         },
         {
           "name": "displacement-small",
-          "syntax": "displacement-small <v>[[gridpointinitializeblock]]",
+          "syntax": "displacement-small <v> [[gridpointinitializeblock]]",
           "description": "Accumulated small-strain displacement at a gridpoint (used in interface calculations)."
         },
         {
           "name": "displacement-small-x",
-          "syntax": "displacement-small-x <f>[[gridpointinitializeblock]]",
+          "syntax": "displacement-small-x <f> [[gridpointinitializeblock]]",
           "description": "Accumulated small-strain \\(x\\) -displacement at a gridpoint (used in interface calculations)."
         },
         {
           "name": "displacement-small-y",
-          "syntax": "displacement-small-y <f>[[gridpointinitializeblock]]",
+          "syntax": "displacement-small-y <f> [[gridpointinitializeblock]]",
           "description": "Accumulated small-strain \\(y\\) -displacement at a gridpoint (used in interface calculations)."
         },
         {
           "name": "displacement-small-z",
-          "syntax": "displacement-small-z <f>[[gridpointinitializeblock]]3D ONLY",
+          "syntax": "displacement-small-z <f> [[gridpointinitializeblock]] (3D ONLY)",
           "description": "Accumulated small-strain \\(z\\) -displacement at a gridpoint (used in interface calculations)."
         },
         {
           "name": "extra",
-          "syntax": "extra <i><a>[[gridpointinitializeblock]]",
+          "syntax": "extra <i> <a> [[gridpointinitializeblock]]",
           "description": "Extra grid variable for extra array index i and a . [CS: this seems like a pretty thin description; previously was flagged for that reason]"
         },
         {
           "name": "force-applied",
-          "syntax": "force-applied <v>[[gridpointinitializeblock]]",
+          "syntax": "force-applied <v> [[gridpointinitializeblock]]",
           "description": "The total applied force at a gridpoint. This includes all sources, including forces due to gravity."
         },
         {
           "name": "force-applied-x",
-          "syntax": "force-applied-x <f>[[gridpointinitializeblock]]",
+          "syntax": "force-applied-x <f> [[gridpointinitializeblock]]",
           "description": "The total applied force in the \\(x\\) direction at a gridpoint. This includes all sources, including forces due to gravity."
         },
         {
           "name": "force-applied-y",
-          "syntax": "force-applied-y <f>[[gridpointinitializeblock]]",
+          "syntax": "force-applied-y <f> [[gridpointinitializeblock]]",
           "description": "The total applied force in the \\(y\\) direction at a gridpoint. This includes all sources, including forces due to gravity."
         },
         {
           "name": "force-applied-z",
-          "syntax": "force-applied-z <f>[[gridpointinitializeblock]]3D ONLY",
+          "syntax": "force-applied-z <f> [[gridpointinitializeblock]] (3D ONLY)",
           "description": "The total applied force in the \\(z\\) direction at a gridpoint. This includes all sources, including forces due to gravity."
         },
         {
           "name": "fluid-modulus",
-          "syntax": "fluid-modulus <f>[[gridpointinitializeblock]]",
+          "syntax": "fluid-modulus <f> [[gridpointinitializeblock]]",
           "description": "Fluid bulk modulus for fluid-flow model (can only be used for biot c = 1; see the material in Fluid-Mechanical Interaction ). Only available if the model configure fluid has been given."
         },
         {
           "name": "fluid-tension",
-          "syntax": "fluid-tension <f>[[gridpointinitializeblock]]",
+          "syntax": "fluid-tension <f> [[gridpointinitializeblock]]",
           "description": "Fluid tension limit for fluid-flow model (tension is negative, value is -1e15 by default; see the material in Fluid-Mechanical Interaction ). Only available if the model configure fluid has been given."
         },
         {
           "name": "head",
-          "syntax": "head <f>[[gridpointinitializeblock]]",
+          "syntax": "head <f> [[gridpointinitializeblock]]",
           "description": "Uses Head to initialize Pore Pressure at gridpoint. Fluid Density and Gravity need to be previously defined. Note that if the pore-pressure is changed this will not affect the total stress, but will change the effective stress. The zone gridpoint fix pore-pressure or zone gridpoint fix head commands can be used to change the total stress and leave the effective stress constant."
         },
         {
           "name": "multiplier",
-          "syntax": "multiplier <f>[[gridpointinitializeblock]]",
+          "syntax": "multiplier <f> [[gridpointinitializeblock]]",
           "description": "Integer multiplier of the gridpoint used in dynamic multi-stepping."
         },
         {
           "name": "position",
-          "syntax": "position <v>[[gridpointinitializeblock]]",
+          "syntax": "position <v> [[gridpointinitializeblock]]",
           "description": "Position of a gridpoint."
         },
         {
           "name": "position-x",
-          "syntax": "position-x <f>[[gridpointinitializeblock]]",
+          "syntax": "position-x <f> [[gridpointinitializeblock]]",
           "description": "\\(x\\) -coordinate of gridpoint"
         },
         {
           "name": "position-y",
-          "syntax": "position-y <f>[[gridpointinitializeblock]]",
+          "syntax": "position-y <f> [[gridpointinitializeblock]]",
           "description": "\\(y\\) -coordinate of gridpoint"
         },
         {
           "name": "position-z",
-          "syntax": "position-z <f>[[gridpointinitializeblock]]3D ONLY",
+          "syntax": "position-z <f> [[gridpointinitializeblock]] (3D ONLY)",
           "description": "\\(z\\) -coordinate of gridpoint"
         },
         {
           "name": "pore-pressure",
-          "syntax": "pore-pressure <f>[[gridpointinitializeblock]]",
+          "syntax": "pore-pressure <f> [[gridpointinitializeblock]]",
           "description": "Pore Pressure at gridpoint. Note that if the pore-pressure is changed this will not affect the total stress, but will change the effective stress. The zone gridpoint fix pore-pressure command can be used to change the total stress and leave the effective stress constant."
         },
         {
           "name": "ratio-target",
-          "syntax": "ratio-target <f>[[gridpointinitializeblock]]",
+          "syntax": "ratio-target <f> [[gridpointinitializeblock]]",
           "description": "Specifies the target local force ratio that is considered to be converged for mechanical calculations. The default value is 1e-4. A local force ratio of this value will result in a convergence value of 1.0 for the gridpoint. See the convergence keyword in the model solve command."
         },
         {
           "name": "saturation",
-          "syntax": "saturation <f>[[gridpointinitializeblock]]",
+          "syntax": "saturation <f> [[gridpointinitializeblock]]",
           "description": "Saturation at the gridpoint. Only available if the model configure fluid has been given."
         },
         {
           "name": "temperature",
-          "syntax": "temperature <f>[[gridpointinitializeblock]]",
+          "syntax": "temperature <f> [[gridpointinitializeblock]]",
           "description": "temperature at the gridpoint. Only available if the model configure thermal has been given."
         },
         {
           "name": "velocity",
-          "syntax": "velocity <v>[[gridpointinitializeblock]]",
+          "syntax": "velocity <v> [[gridpointinitializeblock]]",
           "description": "Velocity of a gridpoint."
         },
         {
           "name": "velocity-x",
-          "syntax": "velocity-x <f>[[gridpointinitializeblock]]",
+          "syntax": "velocity-x <f> [[gridpointinitializeblock]]",
           "description": "\\(x\\) -velocity of gridpoint"
         },
         {
           "name": "velocity-y",
-          "syntax": "velocity-y <f>[[gridpointinitializeblock]]",
+          "syntax": "velocity-y <f> [[gridpointinitializeblock]]",
           "description": "\\(y\\) -velocity of gridpoint"
         },
         {
           "name": "velocity-z",
-          "syntax": "velocity-z <f>[[gridpointinitializeblock]]3D ONLY",
+          "syntax": "velocity-z <f> [[gridpointinitializeblock]] (3D ONLY)",
           "description": "\\(z\\) -velocity of gridpoint"
         },
         {
@@ -326,7 +326,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-system.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-system.json
@@ -62,7 +62,7 @@
         },
         {
           "name": "local-direction-z",
-          "syntax": "direction-z <v>3D ONLY",
+          "syntax": "direction-z <v> (3D ONLY)",
           "description": "Set gridpoints in the range to use the local coordinate system. If only one direction is specified the other two will be determined automatically. If two directions are specified the second will be adjusted to ensure orthogonality and the third will be determined automatically. If three directions are specified the second and third will be adjusted to ensure orthogonality. At least one direction must be specified. Set the x-direction of the plane that defines the local coordinate system. Set the y-direction of the plane that defines the local coordinate system. Set the z-direction of the plane that defines the local coordinate system."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/group.json
@@ -37,7 +37,7 @@
     },
     "9.0": {
       "command": "zone group",
-      "syntax": "zone group <s>[keyword] [range]",
+      "syntax": "zone group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "remove",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/history.json
@@ -383,11 +383,6 @@
           "description": "Values are retrieved from the zone."
         },
         {
-          "name": "stress",
-          "syntax": "stress b",
-          "description": "A few of the tensor type quantity options do different things depending if the value is considered a stress. When coming from a value like extra, this cannot be determined automatically. This allows the user to specify that the incoming tensor value should be considered a stress quantity."
-        },
-        {
           "name": "type",
           "syntax": "type keyword",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned."

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/import.json
@@ -52,7 +52,7 @@
     },
     "9.0": {
       "command": "zone import",
-      "syntax": "zone import <s>[<s2>]keyword",
+      "syntax": "zone import <s> [<s2>]keyword",
       "keywords": [
         {
           "name": "use-given-ids",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/initialize-stresses.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/initialize-stresses.json
@@ -68,7 +68,7 @@
         },
         {
           "name": "ratio",
-          "syntax": "ratio <f>[<fs>]",
+          "syntax": "ratio <f> [<fs>]",
           "description": "Determine the horizontal to vertical stress ratio. Both horizontal stresses are set to the vertical stresses times this value. If the optional second parameter fs is given, then a different ratio is used in the local horizontal directions. Typically, the \\(z\\) -direction is assumed vertical in FLAC3D and the \\(y\\) -direction is assumed vertical in FLAC2D . Hence, the horizontal directions are the \\(x-\\) and \\(y-\\) directions in FLAC3D and the \\(x-\\) and \\(z-\\) directions in FLAC2D ."
         }
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/initialize.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/initialize.json
@@ -104,35 +104,6 @@
           "description": "Minimum (most negative) principal stress."
         },
         {
-          "name": "stress-xx",
-          "syntax": "stress-xx f [zoneinitializeblock]"
-        },
-        {
-          "name": "stress-xy",
-          "syntax": "stress-xy f [zoneinitializeblock]",
-          "description": "xy-component of stress"
-        },
-        {
-          "name": "stress-xz",
-          "syntax": "stress-xz f [zoneinitializeblock]",
-          "description": "xz-component of stress"
-        },
-        {
-          "name": "stress-yy",
-          "syntax": "stress-yy f [zoneinitializeblock]",
-          "description": "yy-component of stress"
-        },
-        {
-          "name": "stress-yz",
-          "syntax": "stress-yz f [zoneinitializeblock]",
-          "description": "yz-component of stress"
-        },
-        {
-          "name": "stress-zz",
-          "syntax": "stress-zz f [zoneinitializeblock]",
-          "description": "zz-component of stress"
-        },
-        {
           "name": "add",
           "syntax": "add",
           "description": "Add the specified value to the existing value."
@@ -169,22 +140,22 @@
       "keywords": [
         {
           "name": "density",
-          "syntax": "density <f>[zoneinitializeblock]",
+          "syntax": "density <f> [zoneinitializeblock]",
           "description": "Mass density of zone."
         },
         {
           "name": "extra",
-          "syntax": "extra <i><a>[zoneinitializeblock]",
+          "syntax": "extra <i> <a> [zoneinitializeblock]",
           "description": "Extra variable for array index i ."
         },
         {
           "name": "fluid-density",
-          "syntax": "fluid-density <f>[zoneinitializeblock]",
+          "syntax": "fluid-density <f> [zoneinitializeblock]",
           "description": "Fluid mass density in zone (only available if model configure fluid has been specified)"
         },
         {
           "name": "state",
-          "syntax": "state <i>[zoneinitializeblock]",
+          "syntax": "state <i> [zoneinitializeblock]",
           "description": "The plasticity indicators for tetrahedrons are set to i . Normally the value of i used is 0 in order to reset the failure indicators."
         },
         {
@@ -199,12 +170,12 @@
         },
         {
           "name": "stress-xx",
-          "syntax": "stress-xx <f>[zoneinitializeblock]",
+          "syntax": "stress-xx <f> [zoneinitializeblock]",
           "description": "xx -component of stress (See the description above for the difference between zone initialize stress-xx and zone initialize stress xx and for the next five keywords)."
         },
         {
           "name": "stress-xy",
-          "syntax": "stress-xy <f>[zoneinitializeblock]",
+          "syntax": "stress-xy <f> [zoneinitializeblock]",
           "description": "xy -component of stress."
         },
         {
@@ -214,7 +185,7 @@
         },
         {
           "name": "stress-yy",
-          "syntax": "stress-yy <f>[zoneinitializeblock]",
+          "syntax": "stress-yy <f> [zoneinitializeblock]",
           "description": "yy -component of stress."
         },
         {
@@ -229,7 +200,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-effective.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-effective.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "zone interface effective",
-      "syntax": "zone interface [<s>] effective <b>[range]"
+      "syntax": "zone interface [<s>] effective <b> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-element.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-element.json
@@ -101,7 +101,7 @@
         },
         {
           "name": "extra",
-          "syntax": "extra <i><a>[interfaceelementblock]",
+          "syntax": "extra <i> <a> [interfaceelementblock]",
           "description": "sets the extra interface element variable value for array index i. The standard [interfaceelementblock] list is available to modify this value in space."
         },
         {
@@ -126,7 +126,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-group.json
@@ -38,7 +38,7 @@
     },
     "9.0": {
       "command": "zone interface group",
-      "syntax": "zone interface [<s>] group <s>[keyword] [range]",
+      "syntax": "zone interface [<s>] group <s> [keyword] [range]",
       "keywords": [
         {
           "name": "remove",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-node.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-node.json
@@ -342,7 +342,7 @@
         },
         {
           "name": "extra",
-          "syntax": "extra <i><a>[interfacenodeblock]",
+          "syntax": "extra <i> <a> [interfacenodeblock]",
           "description": "Set the extra interface node variable value for array index i."
         },
         {
@@ -367,22 +367,22 @@
         },
         {
           "name": "stress-shear",
-          "syntax": "stress-shear <v>[interfacenodeblock]",
+          "syntax": "stress-shear <v> [interfacenodeblock]",
           "description": "sets the incremental shear stress v for all interface nodes in the range."
         },
         {
           "name": "stress-normal-increment",
-          "syntax": "stress-normal-increment <f>[interfacenodeblock]",
+          "syntax": "stress-normal-increment <f> [interfacenodeblock]",
           "description": "Sets the normal stress increment to f for all interface nodes in the range. Note that compressive stresses are positive. The normal stress increment is added to the normal stress calculated from interface penetration."
         },
         {
           "name": "property-tension-residual",
-          "syntax": "tension-residual <f>[interfacenodeblock]",
+          "syntax": "tension-residual <f> [interfacenodeblock]",
           "description": "Assigns one or more new property values to all interface nodes in the range. Slip is allowed, or not allowed, for a bonded interface segment. Default is off (i.e., slip is not allowed if bond is intact). This is only applicable if a bonded interface is specified ( tension is set). cohesion [stress] residual cohesion [stress]. If a value greater than of equal to zero is specified, this value is assigned to cohesion after frictional shear failure. Default is -1.0. if shear displacement reaches this value [in length unit, default value is infinity], the dilation becomes zero. dilation angle [degrees] friction angle [degrees] residual friction angle [degrees]. If a value greater than of equal to zero is specified, this value is assigned to friction after frictional shear failure. Default is -1.0. The shear bond strength is set to sbr times the normal bond strength (tension). Note that giving sbratio alone does not cause a bond to be established; the tensile bond strength must also be set. The default value for sbratio is 100 (i.e., shear bond is 100 times tensile bond). This is only applicable if a bonded interface is specified ( tension is set). normal stiffness [stress/displacement] shear stiffness [stress/displacement] tensile strength [stress] residual tensile strength [stress]. If a value greater than of equal to zero is specified, this value is assigned to tension after frictional shear failure. Default is -1.0."
         },
         {
           "name": "update",
-          "syntax": "update <b>[range]",
+          "syntax": "update <b> [range]",
           "description": "This command prevents the search for new contacts after movement occurs on an interface. The same contacts are preserved, whatever the magnitude of displacement. Use with caution, because physically unrealistic behavior can result if displacements are large. The default behavior is on , which allows normal searching for new and broken contacts."
         },
         {
@@ -392,7 +392,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-permeability.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-permeability.json
@@ -26,7 +26,7 @@
     },
     "9.0": {
       "command": "zone interface permeability",
-      "syntax": "zone interface [<s>] permeability <b>[range]"
+      "syntax": "zone interface [<s>] permeability <b> [range]"
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-tolerance-contact.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-tolerance-contact.json
@@ -31,7 +31,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the scalar-value provided. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/list.json
@@ -546,11 +546,6 @@
           "description": "Values are retrieved from the zone."
         },
         {
-          "name": "stress",
-          "syntax": "stress b",
-          "description": "A few of the tensor type quantity options do different things depending if the value is considered a stress. When coming from a value like extra, this cannot be determined automatically. This allows the user to specify that the incoming tensor value should be considered a stress quantity."
-        },
-        {
           "name": "type",
           "syntax": "type keyword",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned."

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/mechanical.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/mechanical.json
@@ -30,7 +30,7 @@
         },
         {
           "name": "damping-local",
-          "syntax": "local <f ><alternate>",
+          "syntax": "local <f > <alternate>",
           "description": "local damping (default is 0.8). If the alternate keyword is specified, an experimental alternate implementation of local damping is used that produces less sensitivity to small changes in the model."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/property-distribution.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/property-distribution.json
@@ -73,7 +73,7 @@
         },
         {
           "name": "gradient",
-          "syntax": "gradient <v>[origin <v>]",
+          "syntax": "gradient <v> [origin <v>]",
           "description": "Apply a gradient to the property value. Note the origin keyword is optional, however, the default value (0,0,0) is used if the origin keyword is not included in the command \u2014 which may not produce the intended result."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/reflect.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/reflect.json
@@ -56,7 +56,7 @@
       "keywords": [
         {
           "name": "dip-direction",
-          "syntax": "dip-direction <f>3D ONLY",
+          "syntax": "dip-direction <f> (3D ONLY)",
           "description": "Specify the dip direction f [degrees] of the plane measured in the global \\(xy\\) -plane clockwise from the positive \\(y\\) -axis. (The default is f = 0.)"
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/validate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/validate.json
@@ -46,7 +46,7 @@
       "keywords": [
         {
           "name": "group",
-          "syntax": "group <sgroup>[slot <sslot>]",
+          "syntax": "group <sgroup> [slot <sslot>]",
           "description": "Specify the group name assigned to surface faces attached to gridpoints that appear unconstrained. By default the group name used is Unconstrained . The slot keyword may be used to override the slot the group name is assigned to, which by default is Validate . Note that all group assignments on faces in that slot are removed before validation."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/vtk.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/vtk.json
@@ -111,7 +111,7 @@
         },
         {
           "name": "zone-extra",
-          "syntax": "zone-extra <b>[index <i>]",
+          "syntax": "zone-extra <b> [index <i>]",
           "description": "Extra variables with index i at zones."
         },
         {
@@ -126,22 +126,22 @@
         },
         {
           "name": "groups",
-          "syntax": "groups <b>[slot <s>]",
+          "syntax": "groups <b> [slot <s>]",
           "description": "Include group assignments to zones in the slot s in the vtk file."
         },
         {
           "name": "model-fluid",
-          "syntax": "model-fluid <b>[prop <s>]",
+          "syntax": "model-fluid <b> [prop <s>]",
           "description": "Include the fluid property s in the vtk file."
         },
         {
           "name": "model-mechanical",
-          "syntax": "model-mechanical <b>[prop <s>]",
+          "syntax": "model-mechanical <b> [prop <s>]",
           "description": "Include the mechanical property s in the vtk file."
         },
         {
           "name": "model-thermal",
-          "syntax": "model-thermal <b>[prop <s>]",
+          "syntax": "model-thermal <b> [prop <s>]",
           "description": "Include the thermal property s in the vtk file."
         },
         {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/index.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/index.json
@@ -3811,7 +3811,7 @@
           "name": "gridpoint-import",
           "file": "flac/command_docs/commands/zone/gridpoint-import.json",
           "short_description": "Imports grid point data",
-          "syntax": "zone gridpoint import pore-pressure <sfile>[keyword ...] [range] 3D ONLY",
+          "syntax": "zone gridpoint import pore-pressure <sfile> [keyword ...] [range] (3D ONLY)",
           "python_available": false
         },
         {


### PR DESCRIPTION
Batch 4 — the static-scan P0 hygiene items. Syntax strings are consumed verbatim by agents, so prose fused into them (`moi <f>2D ONLY`, `<sz>is 3D only`) gets copied straight into generated commands.

- **130 dimension annotations** normalized to parenthesized, space-separated form: `moi <f> (2D ONLY)`, `model domain condition <sx> [<sy> <sz>] <sz> (3D only)`, `(only 1 component in 2D)`
- **244 missing spaces** after `>`: `<v1><v2><v3>` → `<v1> <v2> <v3>`, `<s>[slot <s>]` → `<s> [slot <s>]`
- **Duplicate 7.0 keywords dropped** (dict-consumers were silently losing entries): zone initialize (stress-* ×2 each), zone list, zone history
- **domain/condition.json** empty keyword blocks filled with the live-verified enumeration: destroy / periodic / reflect / stop (FLAC3D 9.7)

`[beamcreateblock]`-style block references were intentionally kept — they follow the same convention as `[applyblock]`/`[gridpointfixblock]` and carry real structure.

Tests: full suite passes (321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)