### PR TITLE
docs: backfill FLAC3D 7.0 blocks for body/ and extruder/ (Batch 5)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-create.json
@@ -13,6 +13,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block create",
+      "syntax": "building-blocks block create keyword",
+      "keywords": [
+        {
+          "name": "from-faces",
+          "syntax": "from-faces <distance <f> > [range]",
+          "description": "Create blocks attached to the faces specified by the range . All faces here must be external faces — each face is attached to one block only. New blocks will be “extruded” from the faces along the average face normal. The extruded distance is defined by f . If f is not supplied the default distance will be related to the maximum diagonal extent of a block among all the blocks attached to supplied faces."
+        },
+        {
+          "name": "hexahedron",
+          "syntax": "hexahedron <by-points <v1> <v2> <v3> <v4> <v5> <v6> <v7> <v8> > <group <s> <slot <s> >>",
+          "description": "Create a hexahedral block. by-points , if present, must be followed by points that define the block (a hexahedron requires eight points). The optional keywords group and slot assign the created block to the specified group and slot."
+        },
+        {
+          "name": "tetrahedron",
+          "syntax": "tetrahedron <by-points <v1> <v2> <v3> <v4> > <group <s> <slot <s> >>",
+          "description": "Create a tetrahedral block. by-points , if present, must be followed by points that define the block (a tetrahedron requires four points). The optional keywords group and slot assign the created block to the specified group and slot."
+        },
+        {
+          "name": "wedge",
+          "syntax": "wedge <by-points <v1> <v2> <v3> <v4> <v5> <v6> > <group <s> <slot <s> >>",
+          "description": "Create a wedge block. by-points , if present, must be followed by points that define the block (a wedge requires six points). The optional keywords group and slot assign the created block to the specified group and slot."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Create a block or blocks."
+    },
     "9.0": {
       "command": "building-blocks block create",
       "syntax": "building-blocks block create keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-delete.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block delete",
+      "syntax": "building-blocks block delete <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete blocks. If < range > is not supplied, all blocks will be deleted."
+    },
     "9.0": {
       "command": "building-blocks block delete",
       "syntax": "building-blocks block delete [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-export.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-export.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block export",
+      "syntax": "building-blocks block export keyword <range>",
+      "keywords": [
+        {
+          "name": "to-file",
+          "syntax": "to-file <s>",
+          "description": "Export the blocks to a file named s ."
+        },
+        {
+          "name": "to-geometry-set",
+          "syntax": "to-geometry-set <s>",
+          "description": "Export the blocks to a geometric set named s . It only creates “external” faces of the supplied blocks as a set of polygons (quads or triangles)."
+        },
+        {
+          "name": "to-set",
+          "syntax": "to-set <s> <offset <v> >",
+          "description": "Export the blocks to a building block set named s . If the optional <offset v > is supplied, all coordinates will be shifted by that vector in the destination set."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Export blocks. If < range > is not supplied, all blocks will be exported."
+    },
     "9.0": {
       "command": "building-blocks block export",
       "syntax": "building-blocks block export keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-group.json
@@ -13,6 +13,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block group",
+      "syntax": "building-blocks block group <s> <keyword> <range>",
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Remove the group name."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Assign the group name to slot s ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign or remove a group name to blocks. If remove is present, the group name will be removed from blocks in the specified range. If < range > is not supplied, all blocks are affected."
+    },
     "9.0": {
       "command": "building-blocks block group",
       "syntax": "building-blocks block group <s> [keyword] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-hide.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-hide.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block hide",
+      "syntax": "building-blocks block hide <b> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the blocks to be hide or not."
+    },
     "9.0": {
       "command": "building-blocks block hide",
       "syntax": "building-blocks block hide <b> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-id.json
@@ -13,6 +13,19 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block id",
+      "syntax": "building-blocks block id <i> keyword",
+      "keywords": [
+        {
+          "name": "split",
+          "syntax": "split face-id <i2> <v1> <v2>",
+          "description": "Split a block. The splitting is defined by the splitting line on a block face with id i2 . The splitting line is defined by the points v1 and v2 . When the points are on opposite edges of a face this is called an edge-to-edge split. When the points are on opposite corners of a face this is called a diagonal split. When the points are on a corner and opposite edge of a face this is called a corner split. When the points are inside a face this is a central split, in which case v1 must be equal to v2 within the tolerance (see building-blocks set tolerance ). In the case of a triangular face, i..."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Perform an operation on a block (by ID). The operation is performed on block ID i in the current building blocks set."
+    },
     "9.0": {
       "command": "building-blocks block id",
       "syntax": "building-blocks block id <i>keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-import.json
@@ -13,6 +13,19 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block import",
+      "syntax": "building-blocks block import keyword",
+      "keywords": [
+        {
+          "name": "from-file",
+          "syntax": "from-file name <s> <keyword>",
+          "description": "Import blocks from the file named s ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Import blocks from a file."
+    },
     "9.0": {
       "command": "building-blocks block import",
       "syntax": "building-blocks block import keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-list.json
@@ -13,6 +13,54 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block list",
+      "syntax": "building-blocks block list keyword <range>",
+      "keywords": [
+        {
+          "name": "edges",
+          "syntax": "edges",
+          "description": "Edge IDs for each block are listed."
+        },
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "FISH extra information printed. A valid index i must be supplied."
+        },
+        {
+          "name": "faces",
+          "syntax": "faces",
+          "description": "Face IDs for each block are listed."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Group information is listed."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Comprehensive information is listed, including groups, extras, degeneracy, and zone multiplier."
+        },
+        {
+          "name": "nodes",
+          "syntax": "nodes",
+          "description": "Node IDs for each block are listed."
+        },
+        {
+          "name": "points",
+          "syntax": "points",
+          "description": "List point information."
+        },
+        {
+          "name": "status",
+          "syntax": "status",
+          "description": "Validation status for each block is listed."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about blocks. If < range > is not supplied, the requested information is listed for all blocks in the current building blocks set."
+    },
     "9.0": {
       "command": "building-blocks block list",
       "syntax": "building-blocks block list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-make-hex-only.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-make-hex-only.json
@@ -16,6 +16,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block make-hex-only",
+      "syntax": "building-blocks block make-hex-only",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Split all triangular faces of wedge and tetrahedral blocks. The faces will be split into quads by a central point split. After this command is given only hexahedral blocks remain in the current building blocks set."
+    },
     "9.0": {
       "command": "building-blocks block make-hex-only",
       "syntax": "building-blocks block make-hex-only",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-multiplier.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-multiplier.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block multiplier",
+      "syntax": "building-blocks block multiplier <i> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the zone multiplier coefficient for final zone generation. The default value is 1 . It will be applied to zone generation after all edge sizes and ratios are taken into account. If < range > is not supplied, all blocks will be modified."
+    },
     "9.0": {
       "command": "building-blocks block multiplier",
       "syntax": "building-blocks block multiplier <i> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-snapon.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block snapon",
+      "syntax": "building-blocks block snapon id <i> set <s> keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "edge",
+          "syntax": "edge id <i> <<f> >",
+          "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
+        },
+        {
+          "name": "point",
+          "syntax": "point id <i>",
+          "description": "The target point is the point with id i of the geometric set."
+        },
+        {
+          "name": "polygon",
+          "syntax": "polygon id <i> <(<f1,> <f2> )>",
+          "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Snap a block to a geometric set. Points are translated on blocks that are in the specified < range >, if supplied. If not, all points are translated. A translation vector is defined from the point with id i in the current building blocks set to the target point on a geometric set s . The target point on a geometric set is specified by keyword . The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a..."
+    },
     "9.0": {
       "command": "building-blocks block snapon",
       "syntax": "building-blocks block snapon id <i>set <s>keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-transform.json
@@ -13,6 +13,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks block transform",
+      "syntax": "building-blocks block transform <origin <v> > keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "reflect",
+          "syntax": "reflect keyword",
+          "description": "Make a reflection transformation about a plane."
+        },
+        {
+          "name": "rotate",
+          "syntax": "rotate direction <v> angle <f>",
+          "description": "Perform a rotation by angle f , in degrees, using rotation axes that go through the coordinate origin in the direction v ."
+        },
+        {
+          "name": "scale",
+          "syntax": "scale <v>",
+          "description": "Scale the point positions by expanding or contracting their distance from the origin by a factor of v in the \\(x\\) -, \\(y\\) -, and \\(z\\) -directions, respectively."
+        },
+        {
+          "name": "translate",
+          "syntax": "translate <v>",
+          "description": "Perform a translation — adding v to each coordinate point of the blocks to be transformed."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Perform a general geometric transformation on points of blocks. If < range > is not specified all blocks are transformed. For those options that require an origin ( rotate , reflect , and scale ) the optional origin may be supplied to specify the origin for the operation. The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a face should move if not all of the face points are moved. The default is..."
+    },
     "9.0": {
       "command": "building-blocks block transform",
       "syntax": "building-blocks block transform [origin <v>] keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-add-controls.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-add-controls.json
@@ -15,6 +15,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge add-controls",
+      "syntax": "building-blocks edge add-controls keyword <range>",
+      "keywords": [
+        {
+          "name": "adummy",
+          "syntax": "adummy",
+          "description": "Add exactly i control points per each edge ( i must be a positive integer no greater than 20). Added control points will be evenly spaced."
+        },
+        {
+          "name": "use-size",
+          "syntax": "use-size",
+          "description": "Add a number of control points equal to the number of zones on each edge (see building-blocks edge size )."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Add control points to edges. Control points are added on all edges in the current building blocks set if < range > is not supplied."
+    },
     "9.0": {
       "command": "building-blocks edge add-controls",
       "syntax": "building-blocks edge add-controls keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-delete.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge delete",
+      "syntax": "building-blocks edge delete <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete edges. This operation will also delete any blocks attached to the deleted edges. If < range > is not supplied, all edges (and blocks) will be deleted from the current set."
+    },
     "9.0": {
       "command": "building-blocks edge delete",
       "syntax": "building-blocks edge delete [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-drape.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-drape.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge drape",
+      "syntax": "building-blocks edge drape keyword <novalidate> <range>",
+      "keywords": [
+        {
+          "name": "direction",
+          "syntax": "direction <v>",
+          "description": "Set the beam-line as a constant direction vector v ."
+        },
+        {
+          "name": "inwards",
+          "syntax": "inwards <v>",
+          "description": "Extend the beam-line from each point to the focus point v ."
+        },
+        {
+          "name": "outwards",
+          "syntax": "outwards <v>",
+          "description": "Extend the beam-line from the focus point v to each point."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Move the points of edges onto an external geometric set. The points to be moved are defined by the < range >. Movement of each point is done along the beam-line defined by keyword until it intersects the external geometric set. The < novalidate > option skips validation of all blocks moved as part of the drape operation."
+    },
     "9.0": {
       "command": "building-blocks edge drape",
       "syntax": "building-blocks edge drape keyword [novalidate] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-factor.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-factor.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge factor",
+      "syntax": "building-blocks edge factor <f> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Apply a sizing factor to zones on edges. The factor is applied to edges in the current < range >, if supplied, or on all edges if not. The factor f must be between 0.001 and 1000.0 (the default is 1.0). When zones are generated from the blocks, the factor (like a ratio, see building-blocks edge ratio ) defines zone sizes of relative length along the edge block. Factor specifies a ratio of last zone length to the first zone length along an edge. When the factor for an edge is changed, the change is propagated to all face-connected opposite edges. If building-blocks edge ratio-isolate is set..."
+    },
     "9.0": {
       "command": "building-blocks edge factor",
       "syntax": "building-blocks edge factor <f> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-group.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge group",
+      "syntax": "building-blocks edge group <s> <slot <s> > <remove> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign or remove a group name to edges. The command is applied to edges in the < range >, if supplied, or to all edges if not. If the < remove > option is used, the edges in the range will be removed from the group s ."
+    },
     "9.0": {
       "command": "building-blocks edge group",
       "syntax": "building-blocks edge group <s> [slot <s>] [remove] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-id.json
@@ -13,6 +13,39 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge id",
+      "syntax": "building-blocks edge id <i> keyword",
+      "keywords": [
+        {
+          "name": "control-point",
+          "syntax": "control-point keyword",
+          "description": "Modify control points of the edge."
+        },
+        {
+          "name": "ratio",
+          "syntax": "ratio <f>",
+          "description": "Specify a ratio size parameter f for zones on the edge. The ratio parameter f is a float number that must be between 0.1 and 10.0. When zones are generated from the blocks, the ratio defines zones relatively along the edge of the block. The size of each zone will be f of the previous zone length. The default value is 1.0 (uniform zones — same length). Each time the ratio of an edge is changed, the changes are propagated to all face-connected opposite edges. If ratio-isolate is set to true the changes will not propagate from the edge; the default setting for this flag is false (meaning the r..."
+        },
+        {
+          "name": "ratio-isolate",
+          "syntax": "ratio-isolate <b>",
+          "description": "Set a flag to isolate ratio or factor assignments on an edge. If true then ratio/factor assignments do not propagate to all face-connected opposite edges. This setting is set to false by default."
+        },
+        {
+          "name": "size",
+          "syntax": "size <i>",
+          "description": "Specify the number of zones on an edge. The value of i must be positive (up to 1000). The default value is 3 . When zones are generated from the building blocks set, all blocks attached to this edge will be have i zones along the direction defined by the edge. Each time size of an edge is changed, the changes are propagated to face-connected opposite edges."
+        },
+        {
+          "name": "type",
+          "syntax": "type keyword",
+          "description": "Specify the curve-type of the edge."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Modify the properties of an edge. In the current building block set the edge with ID i will be modified."
+    },
     "9.0": {
       "command": "building-blocks edge id",
       "syntax": "building-blocks edge id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-list.json
@@ -13,6 +13,39 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge list",
+      "syntax": "building-blocks edge list keyword <range>",
+      "keywords": [
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "FISH extra information printed. A valid index i must be supplied."
+        },
+        {
+          "name": "faces",
+          "syntax": "faces",
+          "description": "IDs for each face connected to the edge(s) are listed."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Group information is listed."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Comprehensive information is listed, including groups, extras, length of the edge, direction, zone size, zone ratio, type and number of control points."
+        },
+        {
+          "name": "nodes",
+          "syntax": "nodes",
+          "description": "IDs for the nodes of the edge(s) are listed."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about edges. If < range > is not supplied, the requested information is listed for all edges in the current building blocks set."
+    },
     "9.0": {
       "command": "building-blocks edge list",
       "syntax": "building-blocks edge list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio-isolate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio-isolate.json
@@ -15,6 +15,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge ratio-isolate",
+      "syntax": "building-blocks edge ratio-isolate <b> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Determine whether zone ratios or factors propagate. Each time the zone size factor ( building-blocks edge factor ) or ratio ( building-blocks edge ratio ) of an edge is changed, the changes are propagated to all face connected opposite edges. If building-blocks edge ratio-isolate is set to true , the changes will not propagate from the edge. The default setting is false ."
+    },
     "9.0": {
       "command": "building-blocks edge ratio-isolate",
       "syntax": "building-blocks edge ratio-isolate <b> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-ratio.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge ratio",
+      "syntax": "building-blocks edge ratio <f> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Apply a sizing ratio to zones on edges. The ratio is applied to edges in the current < range >, if supplied, or on all edges if not. The ratio f must be between 0.1 and 10.0 (the default is 1.0). When zones are generated from the blocks, the ratio (like a factor, see building-blocks edge factor ) defines zones relatively along the edge of the block. The size of each zone will be f of the previous zone length. The default value is 1.0 (uniform zones \u2014 same length). When the ratio for an edge is changed, the change is propagated to all face-connected opposite edges. If building-blocks edge ra..."
+    },
     "9.0": {
       "command": "building-blocks edge ratio",
       "syntax": "building-blocks edge ratio <f> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-size.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge size",
+      "syntax": "building-blocks edge size <i> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify the number of zones on an edge. The value of i must be positive (up to 1000 ). The default value is 3 . When zones are generated from the building blocks set, all blocks attached to an edge in < range > will have i zones along the direction defined by the edge. If < range > is not supplied all edges are affected. Each time the size on an edge is changed, the changes are propagated to face-connected opposite edges."
+    },
     "9.0": {
       "command": "building-blocks edge size",
       "syntax": "building-blocks edge size <i> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-snapon.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge snapon",
+      "syntax": "building-blocks edge snapon id <i> set <s> keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "edge",
+          "syntax": "edge id <i> <<f> >",
+          "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
+        },
+        {
+          "name": "point",
+          "syntax": "point id <i>",
+          "description": "The target point is the point with id i of the geometric set."
+        },
+        {
+          "name": "polygon",
+          "syntax": "polygon id <i> <(<f1,> <f2> )>",
+          "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Snap an edge to a geometric set. Points are translated on edges that are in the specified < range >, if supplied. If not, all points are translated. A translation vector is defined from the point with :lkwd`id` i in the current building blocks set to the target point on a geometric set s . The target point on a geometric set is specified by keyword . The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-point..."
+    },
     "9.0": {
       "command": "building-blocks edge snapon",
       "syntax": "building-blocks edge snapon id <i>set <s>keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-transform.json
@@ -13,6 +13,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge transform",
+      "syntax": "building-blocks edge transform <origin <v_o> > keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "reflect",
+          "syntax": "reflect keyword",
+          "description": "Make a reflection transformation about a plane."
+        },
+        {
+          "name": "rotate",
+          "syntax": "rotate direction <v> angle <f>",
+          "description": "Perform rotation by angle f , in degrees, using rotation axes that goes through the coordinate origin in the direction v ."
+        },
+        {
+          "name": "scale",
+          "syntax": "scale <v>",
+          "description": "Scale the point positions by expanding or contracting their distance from the origin by a factor of v in the \\(x\\) -, \\(y\\) -, and \\(z\\) -directions, respectively."
+        },
+        {
+          "name": "translate",
+          "syntax": "translate <v>",
+          "description": "Perform a translation — adding v to each coordinate point of the blocks to be transformed."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Transform and edge (via its points). If < range > is not specified all edges are transformed. For those options that require an origin ( rotate , reflect , and scale ) the optional origin may be supplied to specify the origin for the operation. The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a face should move if not all of the face points are moved. The default is true . This option has no ef..."
+    },
     "9.0": {
       "command": "building-blocks edge transform",
       "syntax": "building-blocks edge transform [origin <v_o>] keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-type.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-type.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks edge type",
+      "syntax": "building-blocks edge type keyword <range>",
+      "keywords": [
+        {
+          "name": "arc",
+          "syntax": "arc",
+          "description": "Specify an arc edge. An arc can have one control point only."
+        },
+        {
+          "name": "polyline",
+          "syntax": "polyline",
+          "description": "Specify a polyline edge (the is the default type )."
+        },
+        {
+          "name": "spline",
+          "syntax": "spline",
+          "description": "Specify a spline edge."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify edge curve-type. Edge(s) in the current < range > are affected, if supplied; all edges are affected if not."
+    },
     "9.0": {
       "command": "building-blocks edge type",
       "syntax": "building-blocks edge type keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-add-controls.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-add-controls.json
@@ -15,6 +15,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face add-controls",
+      "syntax": "building-blocks face add-controls keyword <no-edges-cp> <range>",
+      "keywords": [
+        {
+          "name": "adummy",
+          "syntax": "adummy",
+          "description": "Add exactly i X i control points (grid) per each face ( i must be a positive integer 0,2,3,…,20). Added control points will be evenly spaced. Also will add i CPs per each internal edge from the list of the faces. If i = 0 control points are removed."
+        },
+        {
+          "name": "no-edges-cp",
+          "syntax": "no-edges-cp",
+          "description": "Optional. Skip adding-removing CPs to-from edges."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Add control points to faces. Control points are added on all faces in the current building blocks set if < range > is not supplied."
+    },
     "9.0": {
       "command": "building-blocks face add-controls",
       "syntax": "building-blocks face add-controls keyword [no-edges-cp] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-cycle.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-cycle.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face cycle",
+      "syntax": "building-blocks face cycle <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Rotate (cycle) the topology of triangular faces. Aspects of the face, such as the degeneracy point, edge zone sizes, and ratio, are affected when the topology is changed. The operation is performed on faces in the < range >, if supplied, or on all faces if not. However, note only triangular faces are affected by the command. The cycle operation will propagate through wedge or tetrahedral blocks across attached faces."
+    },
     "9.0": {
       "command": "building-blocks face cycle",
       "syntax": "building-blocks face cycle [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-delete.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face delete",
+      "syntax": "building-blocks face delete <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete faces. This operation will also delete any blocks attached to the deleted faces. If < range > is not supplied, all faces (and blocks) will be deleted from the current set."
+    },
     "9.0": {
       "command": "building-blocks face delete",
       "syntax": "building-blocks face delete [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-drape.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-drape.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face drape",
+      "syntax": "building-blocks face drape keyword <novalidate> <range>",
+      "keywords": [
+        {
+          "name": "direction",
+          "syntax": "direction <v>",
+          "description": "Set the beam-line as a constant direction vector v ."
+        },
+        {
+          "name": "inwards",
+          "syntax": "inwards <v>",
+          "description": "Extend the beam-line from each point to the focus point v ."
+        },
+        {
+          "name": "outwards",
+          "syntax": "outwards <v>",
+          "description": "Extend the beam-line from the focus point v to each point."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Move the points of faces onto an external geometric set. The points to be moved are defined by the < range >. Movement of each point is done along the beam-line defined by keyword until it intersects the external geometric set. The < novalidate > option skips validation of all blocks moved as part of the drape operation."
+    },
     "9.0": {
       "command": "building-blocks face drape",
       "syntax": "building-blocks face drape keyword [novalidate] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-group.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face group",
+      "syntax": "building-blocks face group <s> <slot <s> > <remove> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign a group name to faces. The command is applied to faces in the current < range >, if supplied, or to all faces if not. If the < remove > option is used, the faces in the range will be removed from the group s ."
+    },
     "9.0": {
       "command": "building-blocks face group",
       "syntax": "building-blocks face group <s> [slot <s>] [remove] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-id.json
@@ -13,6 +13,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face id",
+      "syntax": "building-blocks face id <i> keyword",
+      "keywords": [
+        {
+          "name": "control-point",
+          "syntax": "control-point keyword",
+          "description": "Modify control points of the face."
+        },
+        {
+          "name": "type",
+          "syntax": "type keyword",
+          "description": "Specify the curve-type of the face. Can be non-curved or bi-cubic-spline."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Modify the properties of a face. In the current building block set the face with ID i will be modified."
+    },
     "9.0": {
       "command": "building-blocks face id",
       "syntax": "building-blocks face id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-list.json
@@ -13,6 +13,44 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face list",
+      "syntax": "building-blocks face list keyword <range>",
+      "keywords": [
+        {
+          "name": "blocks",
+          "syntax": "blocks",
+          "description": "Print block IDs for each face."
+        },
+        {
+          "name": "edges",
+          "syntax": "edges",
+          "description": "Print edge IDs for each face."
+        },
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "Print FISH extra information. A valid index i must be supplied."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Print group information."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Comprehensive information is listed, including groups, extras, area of the face, and normal vector."
+        },
+        {
+          "name": "nodes",
+          "syntax": "nodes",
+          "description": "Print IDs for the nodes of the face(s)."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about faces. If < range > is not supplied, the requested information is listed for all faces in the current building blocks set."
+    },
     "9.0": {
       "command": "building-blocks face list",
       "syntax": "building-blocks face list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-snapon.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face snapon",
+      "syntax": "building-blocks face snapon id <i> set <s> keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "edge",
+          "syntax": "edge id <i> <<f> >",
+          "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
+        },
+        {
+          "name": "point",
+          "syntax": "point id <i>",
+          "description": "The target point is the point with id i of the geometric set."
+        },
+        {
+          "name": "polygon",
+          "syntax": "polygon id <i> <(<f1,> <f2> )>",
+          "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Snap a face to a geometric set. Points are translated on faces that are in the specified < range >, if supplied. If not, all points are translated. A translation vector is defined from the point with id i in the current building blocks set to the target point on a geometric set s . The target point on a geometric set is specified by keyword . The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a f..."
+    },
     "9.0": {
       "command": "building-blocks face snapon",
       "syntax": "building-blocks face snapon id <i>set <s>keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-transform.json
@@ -13,6 +13,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks face transform",
+      "syntax": "building-blocks face transform <origin <v_o> > <control-point <b> > keyword <range>",
+      "keywords": [
+        {
+          "name": "reflect",
+          "syntax": "reflect keyword",
+          "description": "Make a reflection transformation about a plane."
+        },
+        {
+          "name": "rotate",
+          "syntax": "rotate direction <v> angle <f>",
+          "description": "Rotate by angle f , in degrees, using rotation axes that go through the coordinate origin in the direction v ."
+        },
+        {
+          "name": "scale",
+          "syntax": "scale <v>",
+          "description": "Scale the point positions by expanding or contracting their distance from the origin by a factor of v in the \\(x\\) -, \\(y\\) -, and \\(z\\) -directions, respectively."
+        },
+        {
+          "name": "translate",
+          "syntax": "translate <v>",
+          "description": "Perform a translation — adding v to each coordinate point of the face to be transformed."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Transform a face (via its points). If < range > is not specified all faces are transformed. For those options that require an origin ( rotate , reflect , and scale ) the optional origin may be supplied to specify the origin for the operation. The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a face should move if not all of the face points are moved. The default is true . This option has no effe..."
+    },
     "9.0": {
       "command": "building-blocks face transform",
       "syntax": "building-blocks face transform [origin <v_o>] [control-point <b>] keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-delete.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point delete",
+      "syntax": "building-blocks point delete <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete points. This operation will also delete all blocks attached to the deleted points. If < range > is not supplied, all points (and blocks) will be deleted from the current set."
+    },
     "9.0": {
       "command": "building-blocks point delete",
       "syntax": "building-blocks point delete [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-drape.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-drape.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point drape",
+      "syntax": "building-blocks point drape keyword <novalidate> <range>",
+      "keywords": [
+        {
+          "name": "direction",
+          "syntax": "direction <v>",
+          "description": "Set the beam-line as a constant direction vector v ."
+        },
+        {
+          "name": "inwards",
+          "syntax": "inwards <v>",
+          "description": "Extend the beam-line from each point to the focus point v ."
+        },
+        {
+          "name": "outwards",
+          "syntax": "outwards <v>",
+          "description": "Extend the beam-line from the focus point v to each point."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Move points onto an external geometric set. The points to be moved are defined by the < range >. Movement of each point is done along the beam-line defined by keyword until it intersects the external geometric set. The < novalidate > option skips validation of all blocks moved as part of the drape operation."
+    },
     "9.0": {
       "command": "building-blocks point drape",
       "syntax": "building-blocks point drape keyword [novalidate] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-group.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point group",
+      "syntax": "building-blocks point group <s> <slot <s> > <remove> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign a group name to points. The command is applied to points in the current < range >, if supplied, or to all points if not. If the < remove > option is used, the points in the range will be removed from the group s ."
+    },
     "9.0": {
       "command": "building-blocks point group",
       "syntax": "building-blocks point group <s> [slot <s>] [remove] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-list.json
@@ -13,6 +13,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point list",
+      "syntax": "building-blocks point list keyword <range>",
+      "keywords": [
+        {
+          "name": "edges",
+          "syntax": "edges",
+          "description": "Print IDs for the edges that are connected to the point(s)."
+        },
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "Print FISH extra information. A valid index i must be supplied."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Print group information."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Comprehensive information is listed, including groups and extras."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about points. If < range > is not supplied, the requested information is listed for all points."
+    },
     "9.0": {
       "command": "building-blocks point list",
       "syntax": "building-blocks point list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-merge.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-merge.json
@@ -13,6 +13,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point merge",
+      "syntax": "building-blocks point merge <i1> <i2>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Merge two points. The two points are given by ID i1 and ID i2 . Merging points will also induce merging of edges and faces, if applicable."
+    },
     "9.0": {
       "command": "building-blocks point merge",
       "syntax": "building-blocks point merge <i1> <i2>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-move-to.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-move-to.json
@@ -15,6 +15,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point move-to",
+      "syntax": "building-blocks point move-to keyword <f> <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "x",
+          "syntax": "x",
+          "description": "Set the \\(x\\) -component of the point(s)."
+        },
+        {
+          "name": "y",
+          "syntax": "y",
+          "description": "Set the \\(y\\) -component of the point(s)."
+        },
+        {
+          "name": "z",
+          "syntax": "z",
+          "description": "Set the \\(z\\) -component of the point(s)."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Move points. Position components ( \\(x\\) , \\(y\\) , or \\(z\\) ) of points in the < range >, if supplied, are moved to the value f ; all points are moved if no range is supplied. The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a face should move if not all of the face points are moved. The default is true ."
+    },
     "9.0": {
       "command": "building-blocks point move-to",
       "syntax": "building-blocks point move-to keyword <f> [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-snapon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-snapon.json
@@ -13,6 +13,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point snapon",
+      "syntax": "building-blocks point snapon id <i> set <s> keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "edge",
+          "syntax": "edge id <i> <<f> >",
+          "description": "The target point is on the edge in the geometric set with id i . The exact location on the edge is defined by float number parameter f . If f = 0.0 the target point is the first (start) point of the edge, if f = 1.0 the target point is the second (end) point of the edge. The default value is f = 0.5 (center of the edge)."
+        },
+        {
+          "name": "point",
+          "syntax": "point id <i>",
+          "description": "The target point is the point with id i of the geometric set."
+        },
+        {
+          "name": "polygon",
+          "syntax": "polygon id <i> <(<f1,> <f2> )>",
+          "description": "The target point is on the polygon in the geometric set with id i . The exact point on the polygon is defined by two local coordinates ( f1 , f2 ) defined in such a way that (0.0,0.0) corresponds to centroid of the polygon. By default ( f1 , f2 ) is always set initially to correspond to the centroid of the polygon."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Snap points to a geometric set. Points in the specified < range >, if supplied, are translated. If not, all points are translated. A translation vector is defined from the point with id i in the current building blocks set to the target point on a geometric set s . The target point on a geometric set is specified by keyword . The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a face should move i..."
+    },
     "9.0": {
       "command": "building-blocks point snapon",
       "syntax": "building-blocks point snapon id <i>set <s>keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-transform.json
@@ -13,6 +13,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks point transform",
+      "syntax": "building-blocks point transform <origin <v_o> > keyword <control-point <b> > <range>",
+      "keywords": [
+        {
+          "name": "reflect",
+          "syntax": "reflect keyword",
+          "description": "Make a reflection transformation about a plane."
+        },
+        {
+          "name": "rotate",
+          "syntax": "rotate direction <v> angle <f>",
+          "description": "performs rotation by angle f , in degrees, using rotation axes that goes through the coordinate origin in the direction v ."
+        },
+        {
+          "name": "scale",
+          "syntax": "scale <v>",
+          "description": "Scale the point positions by expanding or contracting their distance from the origin by a factor of v in the \\(x\\) -, \\(y\\) -, and \\(z\\) -directions, respectively."
+        },
+        {
+          "name": "translate",
+          "syntax": "translate <v>",
+          "description": "Perform a translation — adding v to each coordinate point of the face to be transformed."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Transform points. If < range > is not specified all points are transformed. For those options that require an origin ( rotate , reflect , and scale ) the optional origin may be supplied to specify the origin for the operation. The < control-point b > option for the edges with control points indicates whether control-points on an edge should move if only one of the points of that edge is moved. For the faces with control points the option indicates where control-points of a face should move if not all of the face points are moved. The default is true . This option has no effect with reflect..."
+    },
     "9.0": {
       "command": "building-blocks point transform",
       "syntax": "building-blocks point transform [origin <v_o>] keyword [control-point <b>] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-arrest-triangle.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-arrest-triangle.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set arrest-triangle",
+      "syntax": "building-blocks set arrest-triangle <b>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify how to split a wedge block. The default for this flag is false . When a split starts from a quadrilateral face of a wedge block (an edge-to-edge split) and the split line is aligned with opposite edge of the starting face, there are at least two possibilities how it goes through the block. When arrest-triangle is true the wedge block is divided in two new wedge blocks and both of them share the opposite edge. When false , the wedge block is divided into two blocks, a hexahedron and a wedge. [CS: a picture here might be in order]"
+    },
     "9.0": {
       "command": "building-blocks set arrest-triangle",
       "syntax": "building-blocks set arrest-triangle <b>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-auto-tolerance.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-auto-tolerance.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set auto-tolerance",
+      "syntax": "building-blocks set auto-tolerance <b>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the auto-tolerance flag for geometric manipulations. When auto-tolerance flag is on , any geometric manipulation of building blocks/faces/edges/points will update the tolerance with the value that is average length of all edges × \\(10^{-8}\\) . The tolerance update will happen before validation of all affected blocks."
+    },
     "9.0": {
       "command": "building-blocks set automatic-tolerance",
       "syntax": "building-blocks set automatic-tolerance <b>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-automatic-zone.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-automatic-zone.json
@@ -12,6 +12,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set automatic-zone",
+      "syntax": "building-blocks set automatic-zone keyword",
+      "keywords": [
+        {
+          "name": "extent",
+          "syntax": "extent <i>",
+          "description": "Specify zoning by setting i zones to be created across the largest extent of the set."
+        },
+        {
+          "name": "length",
+          "syntax": "length <f>",
+          "description": "Specify zoning by setting a fixed length of f for all zones generated from the set ( f must be positive)."
+        },
+        {
+          "name": "total",
+          "syntax": "total <i>",
+          "description": "Specify zoning by setting the total number of zones in the set to i ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify a automatic zoning method."
+    },
     "9.0": {
       "command": "building-blocks set automatic-zone",
       "syntax": "building-blocks set automatic-zone keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-break-angle.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-break-angle.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set break-angle",
+      "syntax": "building-blocks set break-angle <<f> >",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the break angle. The break angle f , specified in degrees, is the dihedral angle between faces. It is used to determine whether faces are adjacent when generating proto-blocks (review Building Blocks-Based Grids for illustration). The default value is 135 degrees."
+    },
     "9.0": {
       "command": "building-blocks set break-angle",
       "syntax": "building-blocks set break-angle [<f>]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-create.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set create",
+      "syntax": "building-blocks set create <s>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Create a building block set. The set named s is created and becomes the current set."
+    },
     "9.0": {
       "command": "building-blocks set create",
       "syntax": "building-blocks set create <s>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-delete.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set delete",
+      "syntax": "building-blocks set delete <<s> >",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete a building block set. If a set name s is not supplied the current set is deleted."
+    },
     "9.0": {
       "command": "building-blocks set delete",
       "syntax": "building-blocks set delete [<s>]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-export.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-export.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set export",
+      "syntax": "building-blocks set export <<s> > <binary>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Export current building blocks to a file. If a file name s is not supplied, the name of the current set will be used. The extension of the file will be “.f3bset”. The optional switch binary specifies binary output. The default is text format."
+    },
     "9.0": {
       "command": "building-blocks set export",
       "syntax": "building-blocks set export [<s>] [binary]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-geometry.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-geometry.json
@@ -10,6 +10,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set geometry",
+      "syntax": "building-blocks set geometry keyword",
+      "keywords": [
+        {
+          "name": "add",
+          "syntax": "add <s>",
+          "description": "Add a geometric set with name s to be associated with current building blocks set."
+        },
+        {
+          "name": "clear",
+          "syntax": "clear",
+          "description": "Clear the list of geometric sets associated with the current building blocks set."
+        },
+        {
+          "name": "remove",
+          "syntax": "remove <s>",
+          "description": "Remove the geometric set with name s from the list of geometric sets associated with the current building blocks set."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Associate a geometry set with the current set. Geometric sets may be added, removed, or cleared for use with the current building blocks set. Geometric sets may be used with the \u201csnapon\u201d and \u201cdrape\u201d commands available for face, edge, and point objects (and in some cases block objects; see building-blocks block snapon or building-blocks face drape , for instance)."
+    },
     "9.0": {
       "command": "building-blocks set geometry",
       "syntax": "building-blocks set geometry keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-import.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set import",
+      "syntax": "building-blocks set import keyword",
+      "keywords": [
+        {
+          "name": "adummy",
+          "syntax": "adummy <set <s2> > <<v> >",
+          "description": "Import blocks from the file s1 . The file must have one of the extensions “.f3bset”, “.f3grid” or “.flac3d” (and be a valid file of that type). The destination building blocks set is s2 . If s2 is not supplied a new set is created and given a set name that derives from the file name s1 . When < v > is supplied the coordinates of all the points of imported blocks will be shifted by that vector."
+        },
+        {
+          "name": "extruder",
+          "syntax": "extruder <to-set <s> > <<v> >",
+          "description": "Import building blocks from the current set in the Extrusion Pane . If the to-set s option is used, the destination will be the building blocks set with the name s . If not, the destination will be the current building blocks set. When < v > is supplied the coordinates of all the points of imported blocks will be shifted by that vector."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Import a building blocks set."
+    },
     "9.0": {
       "command": "building-blocks set import",
       "syntax": "building-blocks set import keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-list.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set list",
+      "syntax": "building-blocks set list <<s> >",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about a building blocks set. Information about the set named s is listed. If s is omitted, information on all building blocks sets will be printed."
+    },
     "9.0": {
       "command": "building-blocks set list",
       "syntax": "building-blocks set list [<s>]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-select.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-select.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set select",
+      "syntax": "building-blocks set select <s>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify the current building blocks set. The set with the name s becomes the current building blocks set. All commands that operate on blocks, faces, edges, and points act on the current set only."
+    },
     "9.0": {
       "command": "building-blocks set select",
       "syntax": "building-blocks set select <s>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-tolerance.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-tolerance.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set tolerance",
+      "syntax": "building-blocks set tolerance <f>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the tolerance for geometric manipulations. For instance, if the distance between two points is less than f they will be treated as one point (merged). The tolerance value f must be positive. Invoking the command will set off the auto-tolerance flag (see building-blocks set auto-tolerance ). If f is not supplied the default value ( average length of all edges \u00d7 \\(10^{-8}\\) ) is used."
+    },
     "9.0": {
       "command": "building-blocks set tolerance",
       "syntax": "building-blocks set tolerance <f>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-validate-all.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/set-validate-all.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "building-blocks set validate-all",
+      "syntax": "building-blocks set validate-all",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Check the validity of blocks. Invalid blocks are marked."
+    },
     "9.0": {
       "command": "building-blocks set validate-all",
       "syntax": "building-blocks set validate-all",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-create.json
@@ -10,6 +10,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block create",
+      "syntax": "extrude block create keyword",
+      "keywords": [
+        {
+          "name": "at",
+          "syntax": "at <f1> <f2> <keyword>",
+          "description": "Create a block from the edges surrounding the point with the 2D coordinates f1 , f2 ."
+        },
+        {
+          "name": "automatic",
+          "syntax": "automatic <keyword> <[range]>",
+          "description": "Create regular and/or irregular blocks from pre-existing edges within the range. Only edges which form closed polygons are used. If no range is provided, blocks will be created from all closed polygons present in the set."
+        },
+        {
+          "name": "by-edges",
+          "syntax": "by-edges <i1> <i2> <i3> ... <keyword>",
+          "description": "Create a block from the edges with specified IDs i1 i2 i3 … Order of edges is irrelevant. For polygons with internal boundaries, only the edges forming the external boundary need to be specified."
+        },
+        {
+          "name": "by-points",
+          "syntax": "by-points <i1> <i2> <i3> ...",
+          "description": "Create a block from the points specified IDs i1 i2 i3 … Order of points is irrelevant. Points must be connected by edges. For polygons with internal boundaries, only the points on the external boundary need to be specified."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Create block(s)."
+    },
     "9.0": {
       "command": "sketch block create",
       "syntax": "sketch block create keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-delete.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block delete",
+      "syntax": "extrude block delete <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete block(s). If < range > is not supplied, all blocks are deleted."
+    },
     "9.0": {
       "command": "sketch block delete",
       "syntax": "sketch block delete [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-group.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block group",
+      "syntax": "extrude block group <s> <keyword> <range>",
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Remove the specified group/slot assignment."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s2>",
+          "description": "Designate the slot for the group assignment. If omitted, the slot is set to Default ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign/remove a group name to blocks. Use of the group logic is described in Groups ."
+    },
     "9.0": {
       "command": "sketch block group",
       "syntax": "sketch block group <s> [keyword] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-id.json
@@ -10,6 +10,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block id",
+      "syntax": "extrude block id <i> keyword",
+      "keywords": [
+        {
+          "name": "cycle",
+          "syntax": "cycle keyword",
+          "description": "The command only applies to regular 3-sided blocks. Cycle the edge assignments of the block, effectively rotating the orientation of the block in either a counterclockwise or clockwise direction. The command is used to change the corner where wedge zones will be created."
+        },
+        {
+          "name": "group",
+          "syntax": "group <s1> <slot <s2> > <remove>",
+          "description": "Assign the group name s1 in slot s2 (if supplied) to the block. The block is removed from the group/slot if remove is present. The slot is Default if not supplied. Use of the group logic is described in the Groups topic."
+        },
+        {
+          "name": "multiplier",
+          "syntax": "multiplier <f>",
+          "description": "The command only applies to regular (3- or 4-sided) blocks. Set the zone multiplier to f ."
+        },
+        {
+          "name": "split",
+          "syntax": "split <<v2> > <tolerance-merge <f> >",
+          "description": "The command only applies to regular (3- or 4-sided) blocks. Split the regular block at v2 (2D coordinate vector). If a location is not provided, then the block will be split at the centroid. If supplied, tolerance-merge specifies the tolerance for merging points during splitting (that is, when new blocks are created from the split operation, any two points within tolerance-merge will be merged automatically to one point)."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Modify a single block by ID."
+    },
     "9.0": {
       "command": "sketch block id",
       "syntax": "sketch block id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-list.json
@@ -10,6 +10,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block list",
+      "syntax": "extrude block list keyword <range>",
+      "keywords": [
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "List FISH extra information. A valid integer index i must be supplied."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Print group information."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Print comprehensive block information. This includes: groups, extras, zone multiplier, number of zones, and edge IDs for each block."
+        },
+        {
+          "name": "points",
+          "syntax": "points",
+          "description": "Print point IDs for each block."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about blocks. If < range > is not supplied, information for all blocks is provided."
+    },
     "9.0": {
       "command": "sketch block list",
       "syntax": "sketch block list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-multiplier.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-multiplier.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block multiplier",
+      "syntax": "extrude block multiplier <i> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "The command only applies to regular (3- or 4-sided) blocks with structured mesh. Multiplier for irregular blocks is always 1. Set the zone multiplier. This setting applies to all regular blocks if < range > is not supplied. The zone multiplier is used to multiply by i the number of zones in the area(s) of interest."
+    },
     "9.0": {
       "command": "sketch block multiplier",
       "syntax": "sketch block multiplier <i> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-position.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/block-position.json
@@ -10,6 +10,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude block position",
+      "syntax": "extrude block position <v2> keyword",
+      "keywords": [
+        {
+          "name": "cycle",
+          "syntax": "cycle keyword",
+          "description": "The command only applies to regular 3-sided blocks. Cycle the edge assignments of the block, effectively rotating the orientation of the block in either a counterclockwise or clockwise direction. This command is used to change the corner where wedge zones will be created."
+        },
+        {
+          "name": "group",
+          "syntax": "group <s1> <slot <s2> > <remove>",
+          "description": "Assign the group name s1 in slot s2 (if supplied) to the block. The block is removed from the group/slot if remove is present. The slot is Default if not supplied."
+        },
+        {
+          "name": "multiplier",
+          "syntax": "multiplier <f>",
+          "description": "The command only applies to regular (3- or 4-sided) blocks. Set the zone multiplier to f ."
+        },
+        {
+          "name": "split",
+          "syntax": "split <tolerance-merge <f> >",
+          "description": "The command only applies to regular (3- or 4-sided) blocks. Split the regular block at v2 (2D coordinate vector). If a location is not provided, then the block will be split at the centroid. If supplied, tolerance-merge specifies the tolerance for merging points during splitting (that is, when new blocks are created from the split operation, any two points within tolerance-merge will be merged automatically to one point)."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Modify a block by position. The block containing point v2 (2D vector coordinates) is modified."
+    },
     "9.0": {
       "command": "sketch block position",
       "syntax": "sketch block position <v2>keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-clear.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-clear.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge clear",
+      "syntax": "extrude edge clear",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Clear all zone size and ratio settings on edges. All blocks present in the set will be removed."
+    },
     "9.0": {
       "command": "sketch edge clear",
       "syntax": "sketch edge clear",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-combine.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-combine.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge combine",
+      "syntax": "extrude edge combine keyword",
+      "keywords": [
+        {
+          "name": "id",
+          "syntax": "id <i1> <i2> <i3> ...",
+          "description": "Combines edges with specified ID i1 i2 i3 … into a single spline-type edge. A number of control points are inserted automatically to best approximate the original polyline (consisting of the specified edges). Only the edges connected to no more than one other edge from each end can be combined."
+        },
+        {
+          "name": "tolerance",
+          "syntax": "tolerance <f>",
+          "description": "Specifies the tolerance of original polyline approximation by the new spline-type edge. Tolerance f can vary from 0.001 to 0.999 with the default value of 0.1. The smaller the tollernce value the more control points are inserted on the new single edge."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Combines edges into a single edge."
+    },
     "9.0": {
       "command": "sketch edge combine",
       "syntax": "sketch edge combine keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-create.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge create",
+      "syntax": "extrude edge create keyword",
+      "keywords": [
+        {
+          "name": "automatic",
+          "syntax": "automatic",
+          "description": "Automatically create edges from a background geometry present in a set. The background geometry usually represents an imported CAD geometry (e.g. a DXF or STL files)."
+        },
+        {
+          "name": "by-points",
+          "syntax": "by-points <i1> <i2> <keyword>",
+          "description": "Create an edge between two points with ID i1 and ID i2 ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Creates an edge or a set of edges."
+    },
     "9.0": {
       "command": "sketch edge create",
       "syntax": "sketch edge create keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-delete.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge delete",
+      "syntax": "extrude edge delete <invalid> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete edges. All edges are deleted if < range > is not supplied. Only edges that not connected to a block will be deleted when invalid is used."
+    },
     "9.0": {
       "command": "sketch edge delete",
       "syntax": "sketch edge delete [invalid] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-group.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge group",
+      "syntax": "extrude edge group <s> <keyword> <range>",
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Remove the specified group/slot assignment."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s2>",
+          "description": "Designate the slot for the group assignment. If omitted, the slot is set to Default ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign/remove a group name to edges. Use of the group logic is described in the Groups topic."
+    },
     "9.0": {
       "command": "sketch edge group",
       "syntax": "sketch edge group <s> [keyword] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-id.json
@@ -10,6 +10,48 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge id",
+      "syntax": "extrude edge id <i> <keyword ...>",
+      "keywords": [
+        {
+          "name": "control-point",
+          "syntax": "control-point keyword"
+        },
+        {
+          "name": "group",
+          "syntax": "group <s1> <slot <s2> > <remove>",
+          "description": "Assign the group name s1 in slot s2 (if supplied) to the edge. The edge is removed from the group/slot if remove is present. The slot is Default if not supplied."
+        },
+        {
+          "name": "ratio",
+          "syntax": "ratio <f>",
+          "description": "Set the ratio f (a number between 0.1 and 10.1 ), which is used to distribute zone lengths along the edge (each zone will be f of the size of the zone preceding it). This setting automatically propagates across dependent edges of regular blocks while Ratio-Isolate is false ."
+        },
+        {
+          "name": "ratio-isolate",
+          "syntax": "ratio-isolate <b>",
+          "description": "The option only applies to the edges which form regular (3- or 4-sided) blocks. Set the flag to control ratio propagation. Ratio settings propagate when false (the default). If set true , a ratio assignment on this edge will not propagate to dependent edges."
+        },
+        {
+          "name": "size",
+          "syntax": "size <i>",
+          "description": "Set the number of zones on the edge. This will also automatically propagate across dependent edges of regular blocks."
+        },
+        {
+          "name": "split",
+          "syntax": "split <v2> <keyword>",
+          "description": "Split the edge at location v2 , a 2D coordinate vector ( \\(x\\) , \\(y\\) ). If keyword \u201cblock\u201d is not provided or the edge belongs to an irregular block, the command splits the edge and deletes the block."
+        },
+        {
+          "name": "type",
+          "syntax": "type keyword",
+          "description": "Specify the curve type of the edge."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Modify a single edge by ID."
+    },
     "9.0": {
       "command": "sketch edge id",
       "syntax": "sketch edge id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-list.json
@@ -10,6 +10,39 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge list",
+      "syntax": "extrude edge list keyword <range>",
+      "keywords": [
+        {
+          "name": "blocks",
+          "syntax": "blocks",
+          "description": "Print blocks IDs for each edge."
+        },
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "Print FISH extra information. A valid integer index i must be supplied."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Print group information."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Print comprehensive edge information, which includes: groups, extras, end points IDs, length, zone size, ratio, ratio isolate flag."
+        },
+        {
+          "name": "type",
+          "syntax": "type",
+          "description": "Print information about curve type of the edge and control points."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about edges. If < range > is not supplied, information for all edges is provided."
+    },
     "9.0": {
       "command": "sketch edge list",
       "syntax": "sketch edge list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio-isolate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio-isolate.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge ratio-isolate",
+      "syntax": "extrude edge ratio-isolate <b> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "The option only applies to the edges which form regular (3- or 4-sided) blocks. Set the flag to control ratio propagation. Ratio settings propagate when false (the default). If set true , a ratio assignment on this edge will not propagate to dependent edges."
+    },
     "9.0": {
       "command": "sketch edge ratio-isolate",
       "syntax": "sketch edge ratio-isolate <b> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio-reverse.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio-reverse.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "7.0 'extrude edge' exposes ratio / ratio-isolate and size / size-default / length / length-default instead of this 9.x keyword."
+    },
     "9.0": {
       "command": "sketch edge ratio-reverse",
       "syntax": "sketch edge ratio-reverse [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-ratio.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge ratio",
+      "syntax": "extrude edge ratio <f> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the ratio. The value f (a number between 0.1 and 10.1 ) is used to distribute zone lengths along the edge (each zone will be f of the size of the zone preceding it). This setting automatically propagates across dependent edges of regular blocks while Ratio-Isolate is false ."
+    },
     "9.0": {
       "command": "sketch edge ratio",
       "syntax": "sketch edge ratio <f>keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-size-default.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-size-default.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge size-default",
+      "syntax": "extrude edge size-default <i>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the default number of zones on the edge. Number of zones is limited to 1 - 10000 per edge. This will also automatically be set to any new edges."
+    },
     "9.0": {
       "command": "sketch edge size-default",
       "syntax": "sketch edge size-default <i>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-size.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude edge size",
+      "syntax": "extrude edge size <i> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the number of zones on the edge. Number of zones is limited to 1 - 10000 per edge. Changed edge size will automatically propagate across dependent edges of blocks with structured mesh. Blocks with unstructured mesh connected to the edge will be deleted. All edges are affected if < range > is not supplied."
+    },
     "9.0": {
       "command": "sketch edge size",
       "syntax": "sketch edge size <i> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-zone-length-default.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-zone-length-default.json
@@ -13,6 +13,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "7.0 'extrude edge' exposes ratio / ratio-isolate and size / size-default / length / length-default instead of this 9.x keyword."
+    },
     "9.0": {
       "command": "sketch edge zone-length-default",
       "syntax": "sketch edge zone-length-default <f>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-zone-length.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-zone-length.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "7.0 'extrude edge' exposes ratio / ratio-isolate and size / size-default / length / length-default instead of this 9.x keyword."
+    },
     "9.0": {
       "command": "sketch edge zone-length",
       "syntax": "sketch edge zone-length <f> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-gradation.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-gradation.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh gradation",
+      "syntax": "extrude mesh gradation <f>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify maximum gradation f > 0 for the unstructured mesher. The default value is 0.5. This parameter controls the gradation of zone sizes from those specified on block boundaries to the size defined by target-size (see extrude mesh target-size ) inside of the block. A value close to 0 leads to a more progressive variation of zone sizes (smoother)."
+    },
     "9.0": {
       "command": "sketch mesh gradation",
       "syntax": "sketch mesh gradation <f>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-list.json
@@ -10,6 +10,19 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh list",
+      "syntax": "extrude mesh list keyword",
+      "keywords": [
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Print detailed information about all current meshing parameters."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Display information about meshing settings."
+    },
     "9.0": {
       "command": "sketch mesh list",
       "syntax": "sketch mesh list keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-mode.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-mode.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh mode",
+      "syntax": "extrude mesh mode keyword",
+      "keywords": [
+        {
+          "name": "mixed",
+          "syntax": "mixed",
+          "description": "Use triangles and quadrilaterals to create an unstructured mesh. In this mode, the mesher creates a quad-dominant (by area) mesh; in certain cases it may be able to create purely quadrilateral mesh."
+        },
+        {
+          "name": "quad",
+          "syntax": "quad",
+          "description": "Force to use quadrilaterals only to create an unstructured mesh. Under certain conditions, the mesher may fail to create purely quadrilateral mesh (e.g. odd number of zones per block perimeter); an error will be displayed in this case."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify the operating mode for the unstructured mesher."
+    },
     "9.0": {
       "command": "sketch mesh mode",
       "syntax": "sketch mesh mode keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-optimization.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-optimization.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh optimization",
+      "syntax": "extrude mesh optimization <i>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify optimization level 0 ≤ i ≤ 10 for the unstructured mesher. The default value is 5. A zero value makes the mesher to skip the optimization step. The speed is maximal but the quality may be poor. From value 1 on, the optimization algorithm uses several techniques to improve both the shape quality and the size quality of the zones. Level 5 is usually a good trade-off between quality and speed."
+    },
     "9.0": {
       "command": "sketch mesh optimization",
       "syntax": "sketch mesh optimization <i>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-quad-weight.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-quad-weight.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh quad-weight",
+      "syntax": "extrude mesh quad-weight <f>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify weight on quadrilaterals 0 ≤ f ≤ 1 for the unstructured mesher. The default value is 0.75. This parameter controls the trade-off between a higher ratio of quads and a better mesh with more triangles. With f = 0, quadrilaterals are never used. With f = 0.5, quadrilaterals are used only when they improve the quality of the mesh (when a quadrilateral is better than two triangles). For 0.5 < f < 1, quadrilaterals are more and more used even if this lead to a lesser global quality of the mesh. With f = 1, the minimum number of triangles is used to get a valid mesh (it may be of poor qual..."
+    },
     "9.0": {
       "command": "sketch mesh quad-weight",
       "syntax": "sketch mesh quad-weight <f>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-reset.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-reset.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh reset",
+      "syntax": "extrude mesh reset",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Reset all meshing parameters to defaults. Use extrude mesh list command to list the default paramters after reseting."
+    },
     "9.0": {
       "command": "sketch mesh reset",
       "syntax": "sketch mesh reset",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-shape-quality.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-shape-quality.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh shape-quality",
+      "syntax": "extrude mesh shape-quality <f>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify value for the shape-quality 0 ≤ f ≤ 1 for the unstructured mesher. The default value is 0.7. This parameter controls the trade-off between shape optimization and size optimization. It is the weight of the shape quality in the measure of the global quality of a zone. The default value (0.7) gives a slight preference to the shape quality over the size quality."
+    },
     "9.0": {
       "command": "sketch mesh shape-quality",
       "syntax": "sketch mesh shape-quality <f>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-target-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-target-size.json
@@ -12,6 +12,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh target-size",
+      "syntax": "extrude mesh target-size <f>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify desired zone size (target size) inside of a block, f ≥ 0. The default value is 0. The target-size is the radius of a circle encompassing a quadrilateral or triangular zone. Zone sizes tend toward this value as they get away from the block boundaries. The target-size may be smaller or bigger than the default zone sizes specified at the block edges."
+    },
     "9.0": {
       "command": "sketch mesh target-size",
       "syntax": "sketch mesh target-size <f>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-type.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/mesh-type.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude mesh type",
+      "syntax": "extrude mesh type keyword",
+      "keywords": [
+        {
+          "name": "mixed",
+          "syntax": "mixed",
+          "description": "Use structured mesh for 3- and 4-sided blocks and unstructured mesh for all other blocks. This is the default option."
+        },
+        {
+          "name": "unstructured",
+          "syntax": "unstructured",
+          "description": "Use unstructured mesh for all blocks. If this option is used and mesh mode (see extrude mesh mode ) is set to quad, triangular blocks will be meshed with quadrilaterals only (amount of zones per perimeter should be even)."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Specify the type of mesh. By default, 3- and 4-sided regular blocks use structured mesh; this command specifies if unstructured mesh should be used for such blocks."
+    },
     "9.0": {
       "command": "sketch mesh type",
       "syntax": "sketch mesh type keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-clear.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-clear.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "In 7.0 the extrusion path is managed through 'extrude segment' commands (add / origin / delete / index / list) rather than a 'path' noun."
+    },
     "9.0": {
       "command": "sketch path clear",
       "syntax": "sketch path clear keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-continuous.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-continuous.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "In 7.0 the extrusion path is managed through 'extrude segment' commands (add / origin / delete / index / list) rather than a 'path' noun."
+    },
     "9.0": {
       "command": "sketch path continuous",
       "syntax": "sketch path continuous <b>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-ends-parallel.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-ends-parallel.json
@@ -14,6 +14,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "In 7.0 the extrusion path is managed through 'extrude segment' commands (add / origin / delete / index / list) rather than a 'path' noun."
+    },
     "9.0": {
       "command": "sketch path ends-parallel",
       "syntax": "sketch path ends-parallel <b>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-extrude-mode.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-extrude-mode.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "In 7.0 the extrusion path is managed through 'extrude segment' commands (add / origin / delete / index / list) rather than a 'path' noun."
+    },
     "9.0": {
       "command": "sketch path extrude-mode",
       "syntax": "sketch path extrude-mode keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-translate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/path-translate.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "In 7.0 the extrusion path is managed through 'extrude segment' commands (add / origin / delete / index / list) rather than a 'path' noun."
+    },
     "9.0": {
       "command": "sketch path translate",
       "syntax": "sketch path translate keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-create.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude point create",
+      "syntax": "extrude point create <v2> keyword",
+      "keywords": [
+        {
+          "name": "group",
+          "syntax": "group <s1> <slot <s2> >",
+          "description": "Assign the created point the group name s1 (in slot s2 if provided, in slot Default if not). Use of the group logic is described in the Groups topic."
+        },
+        {
+          "name": "merge-tolerance",
+          "syntax": "merge-tolerance <f>",
+          "description": "The point creation is canceled if there are existing points within a tolerance f from the position."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Create a point. The point is created in the supplied position v2 (2D vector coordinates)."
+    },
     "9.0": {
       "command": "sketch point create",
       "syntax": "sketch point create <v2>keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-delete.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude point delete",
+      "syntax": "extrude point delete <invalid> <range>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete points. All points are deleted if < range > is not supplied. When invalid is used, only points not connected to an edge will be deleted."
+    },
     "9.0": {
       "command": "sketch point delete",
       "syntax": "sketch point delete [invalid] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-group.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude point group",
+      "syntax": "extrude point group <s> <keyword> <range>",
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Remove the specified group/slot assignment."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s2>",
+          "description": "Designate the slot for the group assignment. If omitted, the slot is set to Default ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Assign/remove a group name to points. Use of the group logic is described in the Groups topic."
+    },
     "9.0": {
       "command": "sketch point group",
       "syntax": "sketch point group <s> [keyword] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-id.json
@@ -10,6 +10,24 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude point id",
+      "syntax": "extrude point id <i> keyword",
+      "keywords": [
+        {
+          "name": "merge",
+          "syntax": "merge <point> <i2>",
+          "description": "Merge the point with point i2 (point ID positive integer)."
+        },
+        {
+          "name": "move-to",
+          "syntax": "move-to <v> <merge-tolerance <f> >",
+          "description": "Moves the point to location v , 2D coordinate vector ( \\(x\\) , \\(y\\) ). If supplied, merge-tolerance f will be used as a tolerance for merging points during moving."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Modify a single point by ID."
+    },
     "9.0": {
       "command": "sketch point id",
       "syntax": "sketch point id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-list.json
@@ -10,6 +10,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude point list",
+      "syntax": "extrude point list keyword",
+      "keywords": [
+        {
+          "name": "edges",
+          "syntax": "edges",
+          "description": "Print edge IDs for each point."
+        },
+        {
+          "name": "extra",
+          "syntax": "extra <i>",
+          "description": "Print FISH extra information. A valid integer index i must be supplied."
+        },
+        {
+          "name": "group",
+          "syntax": "group",
+          "description": "Print group information."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Print comprehensive point information. This includes: groups, extras, edge IDs, position."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Print information about points. If < range > is not supplied, information for all points is provided."
+    },
     "9.0": {
       "command": "sketch point list",
       "syntax": "sketch point list keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-transform.json
@@ -10,6 +10,44 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude point transform",
+      "syntax": "extrude point transform keyword <range>",
+      "keywords": [
+        {
+          "name": "control-point",
+          "syntax": "control-point <b>",
+          "description": "Move/freeze control points. When true (the default), control points are moved when the points they are associated with are moved. Control points will be “frozen” when false ."
+        },
+        {
+          "name": "merge-tolerance",
+          "syntax": "merge-tolerance <f> <[range]>",
+          "description": "Set the merge tolerance. When supplied, this will be used as tolerance for merging points."
+        },
+        {
+          "name": "origin",
+          "syntax": "origin <v2>",
+          "description": "Set the origin (point center) of the transformation v2 (2D vector coordinates)."
+        },
+        {
+          "name": "rotate",
+          "syntax": "rotate <f>",
+          "description": "Set an angle of rotation f in degrees."
+        },
+        {
+          "name": "scale",
+          "syntax": "scale <f1> <<f2> >",
+          "description": "Scale the points; f1 = scale factor along the \\(x\\) coordinate, f2 = scale factor along \\(y\\) coordinate."
+        },
+        {
+          "name": "translate",
+          "syntax": "translate <v2>",
+          "description": "Translate points. Points are moved by v2 (2D vector coordinates)."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Transform points. The geometric transformation may be a rotation, move (translation), or scaling, or any combination of the three. If combined, the operations are performed in the order: scale rotate translate . The scale and rotate operations are always performed with respect to origin . All points are transformed if < range > is not supplied."
+    },
     "9.0": {
       "command": "sketch point transform",
       "syntax": "sketch point transform keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-circle.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-circle.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "Predefined section shapes are new in the 9.x sketch workflow."
+    },
     "9.0": {
       "command": "sketch section circle",
       "syntax": "sketch section circle keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-polygon.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-polygon.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "Predefined section shapes are new in the 9.x sketch workflow."
+    },
     "9.0": {
       "command": "sketch section polygon",
       "syntax": "sketch section polygon keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-rectangle.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/section-rectangle.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "Predefined section shapes are new in the 9.x sketch workflow."
+    },
     "9.0": {
       "command": "sketch section rectangle",
       "syntax": "sketch section rectangle keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-clear.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-clear.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude segment clear",
+      "syntax": "extrude segment clear",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Clear all segment data. The number of segments is set to zero."
+    },
     "9.0": {
       "command": "sketch segment clear",
       "syntax": "sketch segment clear",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-create.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment create",
       "syntax": "sketch segment create keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-delete.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude segment delete",
+      "syntax": "extrude segment delete <i> ...",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete segment(s). Each segment index i given will be deleted, and the remaining segments will be renumbered."
+    },
     "9.0": {
       "command": "sketch segment delete",
       "syntax": "sketch segment delete [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-group.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment group",
       "syntax": "sketch segment group <s> [keyword] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-id.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment id",
       "syntax": "sketch segment id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-list.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude segment list",
+      "syntax": "extrude segment list information",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "List the segments and their values."
+    },
     "9.0": {
       "command": "sketch segment list",
       "syntax": "sketch segment list keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-create.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment-node create",
       "syntax": "sketch segment-node create <v3> [keyword]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-delete.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment-node delete",
       "syntax": "sketch segment-node delete [invalid] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-group.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-group.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment-node group",
       "syntax": "sketch segment-node group <s> [keyword] [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-id.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-id.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment-node id",
       "syntax": "sketch segment-node id <i> keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-list.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment-node list",
       "syntax": "sketch segment-node list keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-node-transform.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment-node transform",
       "syntax": "sketch segment-node transform keyword [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-ratio-reverse.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-ratio-reverse.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment ratio-reverse",
       "syntax": "sketch segment ratio-reverse [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-ratio.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-ratio.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment ratio",
       "syntax": "sketch segment ratio <f> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-size.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-size.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment size",
       "syntax": "sketch segment size <i> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-zone-length.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/segment-zone-length.json
@@ -12,6 +12,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "The 2D sketch 'segment'/'segment-node' objects are new in the 9.x sketch workflow; in 7.0 the equivalent 2D geometry is built with 'extrude point' and 'extrude edge' commands."
+    },
     "9.0": {
       "command": "sketch segment zone-length",
       "syntax": "sketch segment zone-length <f> [range]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-automatic-validate.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-automatic-validate.json
@@ -12,6 +12,19 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set automatic-validate",
+      "syntax": "extrude set automatic-validate <b> <keyword>",
+      "keywords": [
+        {
+          "name": "tolerance",
+          "syntax": "tolerance <f>",
+          "description": "The optional tolerance value f changes the tolerance used in this check. The default value is 1e-6."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set off/on automatic validation. This controls whether or not the program checks for valid geometry during changes. The default is true (on)."
+    },
     "9.0": {
       "command": "sketch set automatic-validate",
       "syntax": "sketch set automatic-validate <b> [keyword]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-automatic-zone.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-automatic-zone.json
@@ -12,6 +12,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set automatic-zone",
+      "syntax": "extrude set automatic-zone keyword",
+      "keywords": [
+        {
+          "name": "direction",
+          "syntax": "direction keyword",
+          "description": "Control which part(s) of the extrusion are auto-zoned. If not specified, the last value specified is retained (the default is both )."
+        },
+        {
+          "name": "edge",
+          "syntax": "edge <f>",
+          "description": "Auto-zoning will attempt to keep the average length of a zone edge to the value f . If not supplied, the previous value will be used. The default value is 1.0."
+        },
+        {
+          "name": "size",
+          "syntax": "size <i>",
+          "description": "Auto-zoning will assign zone sizes so that there are approximately i zones across the largest model dimension. If not supplied, the previous value will be used. The default value is 100."
+        },
+        {
+          "name": "total",
+          "syntax": "total <i>",
+          "description": "Auto zoning will assign zone sizes so that the total number of 3D zones created is approximately (but not more than) i ."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set automatic zoning of the extrusion set."
+    },
     "9.0": {
       "command": "sketch set automatic-zone",
       "syntax": "sketch set automatic-zone keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-clear.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-clear.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set clear",
+      "syntax": "extrude set clear",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Clear all set data (points, edges, blocks in the 2D construction data, and segments in the 1D extrusion data)."
+    },
     "9.0": {
       "command": "sketch set clear",
       "syntax": "sketch set clear",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-create.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "7.0 'extrude set' has clear / delete / list / select / system etc. but no create / rename."
+    },
     "9.0": {
       "command": "sketch set create",
       "syntax": "sketch set create <s>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-delete.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set delete",
+      "syntax": "extrude set delete <<s> >",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Delete an extrude set. The set named s is deleted if supplied; the current set is deleted if not."
+    },
     "9.0": {
       "command": "sketch set delete",
       "syntax": "sketch set delete [<s>]",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-list.json
@@ -10,6 +10,39 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set list",
+      "syntax": "extrude set list keyword",
+      "keywords": [
+        {
+          "name": "all",
+          "syntax": "all",
+          "description": "List all extrude sets."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Print detailed information about the current extrude set."
+        },
+        {
+          "name": "metadata",
+          "syntax": "metadata",
+          "description": "Print all metadata assigned to the current extrude set."
+        },
+        {
+          "name": "polygons",
+          "syntax": "polygons",
+          "description": "For each closed polygon detected in the set, list edge IDs which form polygon’s external boundary."
+        },
+        {
+          "name": "quality",
+          "syntax": "quality",
+          "description": "Print a zone quality report for the current extrude set. This includes the number of zones that, when extruded, may result in “bad geometry” errors."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "List extrude set information."
+    },
     "9.0": {
       "command": "sketch set list",
       "syntax": "sketch set list keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-metadata.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-metadata.json
@@ -10,6 +10,29 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set metadata",
+      "syntax": "extrude set metadata keyword",
+      "keywords": [
+        {
+          "name": "clear",
+          "syntax": "clear",
+          "description": "Clear all metadata."
+        },
+        {
+          "name": "list",
+          "syntax": "list",
+          "description": "List all metadata assigned to the extrude set."
+        },
+        {
+          "name": "set",
+          "syntax": "set <s1> <s2>",
+          "description": "Set the string value s2 to the string key s1 in the extrude set metadata. If a value was already assigned to the key, it is overwritten. Otherwise, a new key/value pair is created."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Manipulate extrude set metadata. Metadata values are keyword/string pairs that can be used to store arbitrary information in the set. They are used by the FLAC3D user interface to store interface-specific data, for example. The following keywords are available."
+    },
     "9.0": {
       "command": "sketch set metadata",
       "syntax": "sketch set metadata keyword",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-rename.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-rename.json
@@ -10,6 +10,15 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "available": false,
+      "reason": "Not listed in the official FLAC3D 7.0 contents command index.",
+      "source_urls": [
+        "https://docs.itascacg.com/flac3d700/contents.html"
+      ],
+      "target_version": "7.0",
+      "note": "7.0 'extrude set' has clear / delete / list / select / system etc. but no create / rename."
+    },
     "9.0": {
       "command": "sketch set rename",
       "syntax": "sketch set <s1>rename <s2>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-select.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-select.json
@@ -10,6 +10,13 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set select",
+      "syntax": "extrude set select <s>",
+      "keywords": [],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the current extrude set. If there is not a set named s , a new set with that name is created."
+    },
     "9.0": {
       "command": "sketch set select",
       "syntax": "sketch set select <s>",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-system.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-system.json
@@ -10,6 +10,34 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set system",
+      "syntax": "extrude set system keyword ...",
+      "keywords": [
+        {
+          "name": "normal-axis",
+          "syntax": "normal-axis <v>",
+          "description": "Set the normal axis v (3D vector). This is the direction of extrusion (perpendicular to 2D local \\(x\\) , \\(y\\) )."
+        },
+        {
+          "name": "origin",
+          "syntax": "origin <v>",
+          "description": "Set the origin of the extrusion transformation v (3D vector). When extruded, the 2D extrusion coordinate (0,0) is mapped to ( \\(x,y,z\\) ) before being rotated into the u,v,n coordinate system."
+        },
+        {
+          "name": "u-axis",
+          "syntax": "u-axis <v>",
+          "description": "Set the u-axis (3D vector v ). This axis is the direction of \\(x\\) from the 2D coordinate system when the model is extruded into 3D."
+        },
+        {
+          "name": "v-axis",
+          "syntax": "v-axis <v>",
+          "description": "Sets the v-axis (3D vector v ). This axis is the direction of \\(y\\) from the 2D coordinate system when the model is extruded into 3D."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Set the coordinate system. These settings affect how extruded object coordinates (u,v,n) map to global coordinates ( \\(x,y,z\\) )."
+    },
     "9.0": {
       "command": "sketch set system",
       "syntax": "sketch set system keyword ...",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-update-polygons.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/set-update-polygons.json
@@ -12,6 +12,19 @@
     "available": false
   },
   "versions": {
+    "7.0": {
+      "command": "extrude set update-polygons",
+      "syntax": "extrude set update-polygons <b> <keyword>",
+      "keywords": [
+        {
+          "name": "no-warning",
+          "syntax": "no-warning <f>",
+          "description": "Suppress any warning issued during polygons search and update."
+        }
+      ],
+      "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
+      "description": "Update the internal list of closed polygons to assure that it reflects current geometry. The command outputs the number of closed polygons detected and it is typically used before creating and meshing blocks."
+    },
     "9.0": {
       "command": "sketch set update-polygons",
       "syntax": "sketch set update-polygons [no-warning]",


### PR DESCRIPTION
Batch 5 — the largest P1 from the static scan: the crawler skipped body/ and extruder/ entirely for 7.0 (126 files had only a 9.0 block), even though `building-blocks.*` (176 entries) and `extrude.*` (172 entries) are present in the official FLAC3D 7.0 command index.

**100 commands backfilled** from the official FLAC3D 7.0 doc tree — command + keyword syntax rebuilt from `out_commands.txt` (var spans → `<f>`/`<v1>` placeholders, command-name spans dropped, entities unescaped), descriptions extracted from the per-command HTML pages (`command:`/`kwd:` anchors). Coverage: 100/100 command descriptions, 170/171 keyword descriptions.

**Verb mapping**: extruder/ 9.0 `sketch` ↔ 7.0 `extrude`; body/ keeps `building-blocks` (one keyword rename: `automatic-tolerance` ↔ `auto-tolerance`, consistent with the Batch 1 finding).

**26 genuine 9.x-new commands** get the standard 7.0 tombstone plus an explanatory note instead of silence: sketch `segment`/`segment-node`/`section` are new 9.x drawing objects (7.0 sketches with `point`+`edge`), 9.0 `sketch path` was 7.0 `extrude segment` (add/origin/...), `edge zone-length`/`ratio-reverse` replace 7.0 `size`/`ratio-isolate`, and `extrude set` had no `create`/`rename`. (The static scan's guess that `extrude.segment-node.*` existed in 7.0 was wrong — the index has no such noun.)

Tests: full suite passes (321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)