### PR TITLE
docs: annotate 2D-only tangential keywords in zone face apply-remove (Batch 7)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply-remove.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply-remove.json
@@ -214,7 +214,8 @@
         },
         {
           "name": "acceleration-tangential",
-          "syntax": "acceleration-tangential (2D ONLY)"
+          "syntax": "acceleration-tangential (2D ONLY)",
+          "description": "(2D only.) Rejected by FLAC3D 9.7 as a trailing keyword (keyword-level probe, 2026-08-13); matches the 2D-only annotation on the corresponding 'zone face apply' keywords."
         },
         {
           "name": "acceleration-x",
@@ -285,7 +286,8 @@
         },
         {
           "name": "quiet-tangential",
-          "syntax": "quiet-tangential (2D ONLY)"
+          "syntax": "quiet-tangential (2D ONLY)",
+          "description": "(2D only.) Rejected by FLAC3D 9.7 as a trailing keyword (keyword-level probe, 2026-08-13); matches the 2D-only annotation on the corresponding 'zone face apply' keywords."
         },
         {
           "name": "reaction",
@@ -309,7 +311,8 @@
         },
         {
           "name": "reaction-tangential",
-          "syntax": "reaction-tangential (2D ONLY)"
+          "syntax": "reaction-tangential (2D ONLY)",
+          "description": "(2D only.) Rejected by FLAC3D 9.7 as a trailing keyword (keyword-level probe, 2026-08-13); matches the 2D-only annotation on the corresponding 'zone face apply' keywords."
         },
         {
           "name": "reaction-x",
@@ -342,7 +345,8 @@
         },
         {
           "name": "stress-tangential",
-          "syntax": "stress-tangential (2D ONLY)"
+          "syntax": "stress-tangential (2D ONLY)",
+          "description": "(2D only.) Rejected by FLAC3D 9.7 as a trailing keyword (keyword-level probe, 2026-08-13); matches the 2D-only annotation on the corresponding 'zone face apply' keywords."
         },
         {
           "name": "stress-xx",
@@ -395,7 +399,8 @@
         },
         {
           "name": "velocity-tangential",
-          "syntax": "velocity-tangential (2D ONLY)"
+          "syntax": "velocity-tangential (2D ONLY)",
+          "description": "(2D only.) Rejected by FLAC3D 9.7 as a trailing keyword (keyword-level probe, 2026-08-13); matches the 2D-only annotation on the corresponding 'zone face apply' keywords."
         },
         {
           "name": "velocity-x",


### PR DESCRIPTION
Full-sweep round 3 results (ledgers in the verification workspace):

- **Keyword-level pass** over the 56 keyword-optional commands: all 419 documented keywords probed individually against FLAC3D 9.7 — **312 confirmed recognized**, ~100 apparent rejections triaged as probe false-positives (flattened compound names like `force-node-global`; keywords that follow a positional filename in `structure * import`). The one real corpus fix: the five `*-tangential` keywords in `zone face apply-remove` lacked their `(2D only.)` annotation — engine rejects them in 3D, consistent with `zone face apply`.
- **Value-then-probe pass** over the 82 positional-arg commands: 19 yielded post-value keyword enums (the `range/remove/slot` group-command pattern, matching docs), 49 take no trailing keywords, 14 remain gated on file arguments.
- Safety addendum recorded: `zone densify repeat` multiplies zones past the demo cap without erroring (12k zones from an 8-zone brick), then every subsequent zone-touching command fails with a misleading license error — blocklisted in the harness.

Tests: full suite passes (321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)