### PR TITLE
docs: fix FLAC 7.0 blocks against a live FLAC3D 7.0 engine (Batch 8)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/edge-delete.json
@@ -13,7 +13,13 @@
     "7.0": {
       "command": "extrude edge delete",
       "syntax": "extrude edge delete <invalid> <range>",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "invalid",
+          "syntax": "invalid",
+          "description": "Delete invalid edges. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        }
+      ],
       "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
       "description": "Delete edges. All edges are deleted if < range > is not supplied. Only edges that not connected to a block will be deleted when invalid is used."
     },

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-delete.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/extruder/point-delete.json
@@ -13,7 +13,13 @@
     "7.0": {
       "command": "extrude point delete",
       "syntax": "extrude point delete <invalid> <range>",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "invalid",
+          "syntax": "invalid",
+          "description": "Delete invalid points. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        }
+      ],
       "source": "Backfilled from the official FLAC3D 7.0 documentation tree (out_commands.txt index + command pages), 2026-08-13.",
       "description": "Delete points. All points are deleted if < range > is not supplied. When invalid is used, only points not connected to an edge will be deleted."
     },

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/model/configure.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/model/configure.json
@@ -50,6 +50,51 @@
           "name": "thermal",
           "syntax": "thermal",
           "description": "Thermal analysis"
+        },
+        {
+          "name": "array",
+          "syntax": "array",
+          "description": "Configure the array process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "cfd",
+          "syntax": "cfd",
+          "description": "Configure the cfd process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "cluster",
+          "syntax": "cluster",
+          "description": "Configure the cluster process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "energy",
+          "syntax": "energy",
+          "description": "Configure the energy process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "feblock",
+          "syntax": "feblock",
+          "description": "Configure the feblock process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "highorder",
+          "syntax": "highorder",
+          "description": "Configure the highorder process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "hotetra",
+          "syntax": "hotetra",
+          "description": "Configure the hotetra process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "matrixflow",
+          "syntax": "matrixflow",
+          "description": "Configure the matrixflow process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "mechanical",
+          "syntax": "mechanical",
+          "description": "Configure the mechanical process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "examples": [

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-history.json
@@ -69,6 +69,11 @@
           "name": "position",
           "syntax": "position v",
           "description": "the particular element is identified by (v) coordinates (the nearest element is taken). If this keyword is used, component-id should not be used."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-property.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-property.json
@@ -21,9 +21,9 @@
           "description": "density (needed if dynamic mode or gravity are active), \\(\u03c1\\)"
         },
         {
-          "name": "youngs",
-          "syntax": "youngs f",
-          "description": "Young\u2019s modulus, \\(E\\)"
+          "name": "young",
+          "syntax": "young f",
+          "description": "Young\u2019s modulus, \\(E\\) CORRECTED: the official FLAC3D 7.0 documentation spells this 'youngs', but the live 7.0 engine REJECTS 'youngs' and accepts 'young'. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
           "name": "poisson",
@@ -64,6 +64,16 @@
           "name": "direction-y",
           "syntax": "direction-y v",
           "description": "\\(y\\)-axis vector components (Yx, Yy, Yz) whose projection onto the element cross-section defines the \\(y\\)-axis of the element system"
+        },
+        {
+          "name": "plastic-moment-y",
+          "syntax": "plastic-moment-y <f >",
+          "description": "Plastic moment about local y. Missing from the official 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "plastic-moment-z",
+          "syntax": "plastic-moment-z <f >",
+          "description": "Plastic moment about local z. Missing from the official 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-history.json
@@ -64,6 +64,11 @@
           "name": "position",
           "syntax": "position v",
           "description": "the particular element is identified by (v) coordinates (the nearest element is taken). If this keyword is used, component-id should not be used."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-history.json
@@ -111,19 +111,19 @@
           "description": "stress resultant \\(Q_y\\) in the element surface system. This option uses the surface-x keyword."
         },
         {
-          "name": "principal-intermediate",
-          "syntax": "principal-intermediate [geogridhistoryblock]",
-          "description": "principal intermediate stress, global system. This option uses the depth-factor keyword."
+          "name": "stress-intermediate",
+          "syntax": "stress-intermediate [geogridhistoryblock]",
+          "description": "principal intermediate stress, global system. This option uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-intermediate'; 'principal-intermediate' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
-          "name": "principal-maximum",
-          "syntax": "principal-maximum [geogridhistoryblock]",
-          "description": "principal maximum stress, global system. This option uses the depth-factor keyword."
+          "name": "stress-maximum",
+          "syntax": "stress-maximum [geogridhistoryblock]",
+          "description": "principal maximum stress, global system. This option uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-maximum'; 'principal-maximum' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
-          "name": "principal-minimum",
-          "syntax": "principal-minimum [geogridhistoryblock]",
-          "description": "principal minimum stress, global system. This option uses the depth-factor keyword."
+          "name": "stress-minimum",
+          "syntax": "stress-minimum [geogridhistoryblock]",
+          "description": "principal minimum stress, global system. This option uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-minimum'; 'principal-minimum' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
           "name": "stress-xx",
@@ -179,6 +179,11 @@
           "name": "surface-x",
           "syntax": "surface-x v",
           "description": "the local \\(x\\)-direction used to determine the local surface coordinate system. Only available if noted."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-history.json
@@ -83,6 +83,16 @@
           "name": "position",
           "syntax": "position v",
           "description": "the particular element is identified by (v) coordinates (the nearest element is taken). This could apply to a \u201ccable\u201d element or dowel, depending on what history quantitiy is being queried. If this keyword is used, component-id should not be used."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "yield",
+          "syntax": "yield",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-property.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-property.json
@@ -99,6 +99,16 @@
           "name": "young",
           "syntax": "young f",
           "description": "Young\u2019s modulus"
+        },
+        {
+          "name": "grout-cohesion-table",
+          "syntax": "grout-cohesion-table <s >",
+          "description": "Cohesion vs displacement table. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "grout-friction-table",
+          "syntax": "grout-friction-table <s >",
+          "description": "Friction vs displacement table. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-history.json
@@ -121,19 +121,19 @@
           "description": "stress resultant \\(Q_y\\) in the element surface system. This option uses the surface-x keyword."
         },
         {
-          "name": "principal-intermediate",
-          "syntax": "principal-intermediate [linerhistoryblock]",
-          "description": "principal intermediate stress, global system. This option uses the depth-factor keyword."
+          "name": "stress-intermediate",
+          "syntax": "stress-intermediate [linerhistoryblock]",
+          "description": "principal intermediate stress, global system. This option uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-intermediate'; 'principal-intermediate' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
-          "name": "principal-maximum",
-          "syntax": "principal-maximum [linerhistoryblock]",
-          "description": "principal maximum stress, global system. This option uses the depth-factor keyword."
+          "name": "stress-maximum",
+          "syntax": "stress-maximum [linerhistoryblock]",
+          "description": "principal maximum stress, global system. This option uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-maximum'; 'principal-maximum' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
-          "name": "principal-minimum",
-          "syntax": "principal-minimum [linerhistoryblock]",
-          "description": "principal minimum stress, global system. This option uses the depth-factor keyword."
+          "name": "stress-minimum",
+          "syntax": "stress-minimum [linerhistoryblock]",
+          "description": "principal minimum stress, global system. This option uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-minimum'; 'principal-minimum' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
           "name": "stress-xx",
@@ -194,6 +194,11 @@
           "name": "surface-x",
           "syntax": "surface-x v",
           "description": "the local \\(x\\)-direction used to determine the local surface coordinate system. Only available if noted."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-history.json
@@ -89,6 +89,11 @@
           "name": "side",
           "syntax": "side i",
           "description": "specifies which side of the node indicated in position should be used to find the link. By default, side 1 is used."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-history.json
@@ -134,6 +134,41 @@
           "name": "position",
           "syntax": "position v",
           "description": "the particular node is identified by (v) coordinates (the nearest node is taken). If this keyword is used, component-id should not be used."
+        },
+        {
+          "name": "acceleration-x",
+          "syntax": "acceleration-x",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "acceleration-y",
+          "syntax": "acceleration-y",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "acceleration-z",
+          "syntax": "acceleration-z",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "acceleration-rotational-x",
+          "syntax": "acceleration-rotational-x",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "acceleration-rotational-y",
+          "syntax": "acceleration-rotational-y",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "acceleration-rotational-z",
+          "syntax": "acceleration-rotational-z",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-history.json
@@ -99,6 +99,11 @@
           "name": "position",
           "syntax": "position v",
           "description": "the particular element is identified by (v) coordinates (the nearest element is taken). If this keyword is used, component-id should not be used."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-history.json
@@ -96,19 +96,19 @@
           "description": "stress resultant \\(Q_y\\) (surface system). Uses the surface-x keyword."
         },
         {
-          "name": "principal-intermediate",
-          "syntax": "principal-intermediate [shellhistoryblock]",
-          "description": "principal intermediate stress, global system. Uses the depth-factor keyword."
+          "name": "stress-intermediate",
+          "syntax": "stress-intermediate [shellhistoryblock]",
+          "description": "principal intermediate stress, global system. Uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-intermediate'; 'principal-intermediate' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
-          "name": "principal-maximum",
-          "syntax": "principal-maximum [shellhistoryblock]",
-          "description": "principal maximum stress, global system. Uses the depth-factor keyword."
+          "name": "stress-maximum",
+          "syntax": "stress-maximum [shellhistoryblock]",
+          "description": "principal maximum stress, global system. Uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-maximum'; 'principal-maximum' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
-          "name": "principal-minimum",
-          "syntax": "principal-minimum [shellhistoryblock]",
-          "description": "principal minimum stress, global system. Uses the depth-factor keyword."
+          "name": "stress-minimum",
+          "syntax": "stress-minimum [shellhistoryblock]",
+          "description": "principal minimum stress, global system. Uses the depth-factor keyword. CORRECTED: 7.0 uses 'stress-minimum'; 'principal-minimum' is the 9.x-era name and is rejected by the live 7.0 engine. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         },
         {
           "name": "stress-xx",
@@ -164,6 +164,11 @@
           "name": "surface-x",
           "syntax": "surface-x v",
           "description": "the local \\(x\\)-direction used to determine the local surface coordinate system. Only available if noted."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/attach.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/attach.json
@@ -102,6 +102,11 @@
           "name": "list",
           "syntax": "list <range>",
           "description": "List information on all attach conditions in the range. This information includes the slave gridpoints, the master targets, and the weighting factors if appropriate."
+        },
+        {
+          "name": "gp",
+          "syntax": "gp ...",
+          "description": "Gridpoint-level attach variant (alias family). Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply.json
@@ -352,6 +352,21 @@
           "name": "vary",
           "syntax": "vary v",
           "description": "Apply a linear variation to the scalar-value provided. This is not available if the apply conditions requires two values or a vector value."
+        },
+        {
+          "name": "free-field",
+          "syntax": "free-field",
+          "description": "Free-field boundary condition (dynamic analysis). Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "stress-tensor",
+          "syntax": "stress-tensor <t >",
+          "description": "Apply a full stress tensor on faces. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "westergaard",
+          "syntax": "westergaard",
+          "description": "Westergaard hydrodynamic pressure condition (moved to the dedicated zone face westergaard command in 9.x). Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-free.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-free.json
@@ -74,6 +74,26 @@
           "name": "well",
           "syntax": "well",
           "description": "Frees an applied fluid source."
+        },
+        {
+          "name": "force-applied",
+          "syntax": "force-applied",
+          "description": "Free the force-applied condition. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "force-applied-x",
+          "syntax": "force-applied-x",
+          "description": "Free the force-applied-x condition. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "force-applied-y",
+          "syntax": "force-applied-y",
+          "description": "Free the force-applied-y condition. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "force-applied-z",
+          "syntax": "force-applied-z",
+          "description": "Free the force-applied-z condition. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-import.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-import.json
@@ -29,6 +29,11 @@
           "name": "translate",
           "syntax": "translate v",
           "description": "If this keyword is used, the node locations in the file will be translate by the specified vector on import. The default value is (0,0,0)."
+        },
+        {
+          "name": "pore-pressure",
+          "syntax": "pore-pressure",
+          "description": "Import pore pressures. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-initialize.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-initialize.json
@@ -153,6 +153,26 @@
           "name": "vary",
           "syntax": "vary v",
           "description": "Apply a linear variation to the scalar-value provided."
+        },
+        {
+          "name": "force",
+          "syntax": "force <f >",
+          "description": "Initialize gridpoint force. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "force-x",
+          "syntax": "force-x <f >",
+          "description": "Initialize gridpoint force-x. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "force-y",
+          "syntax": "force-y <f >",
+          "description": "Initialize gridpoint force-y. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "force-z",
+          "syntax": "force-z <f >",
+          "description": "Initialize gridpoint force-z. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/history.json
@@ -411,6 +411,31 @@
           "name": "zoneid",
           "syntax": "zoneid i",
           "description": "Specifies the location of the history is at the centroid of zone with ID i."
+        },
+        {
+          "name": "convergence",
+          "syntax": "convergence",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "density-fluid",
+          "syntax": "density-fluid",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "fluid-biot-modulus",
+          "syntax": "fluid-biot-modulus",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "multiplier",
+          "syntax": "multiplier",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "ratio-target",
+          "syntax": "ratio-target",
+          "description": "Missing from the crawled 7.0 docs. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-create.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/interface-create.json
@@ -79,6 +79,11 @@
           "name": "node",
           "syntax": "node v",
           "description": "This creates an interface node at position v. If a node already exists at the selected location, an error is reported. The created node is fixed in space."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Interface name. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/list.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/list.json
@@ -574,6 +574,21 @@
           "name": "zoneid",
           "syntax": "zoneid i",
           "description": "Specifies the location of the history is at the centroid of zone with ID i."
+        },
+        {
+          "name": "apply",
+          "syntax": "apply",
+          "description": "List apply conditions. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "face-join-map",
+          "syntax": "face-join-map",
+          "description": "List face join map. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "gp",
+          "syntax": "gp",
+          "description": "Alias for gridpoint listings. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/trace.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/trace.json
@@ -28,6 +28,16 @@
           "name": "position",
           "syntax": "position v",
           "description": "Add a trace at position v, which must fall in or on some zone."
+        },
+        {
+          "name": "gp",
+          "syntax": "gp ...",
+          "description": "Gridpoint trace variant. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s >",
+          "description": "Trace name. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/water.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/water.json
@@ -72,6 +72,11 @@
           "name": "plane-skip-assignment",
           "syntax": "skip-assignment",
           "description": "the plane to use for the purpose of calculate pore pressures is specified, but pore pressures are not actually assigned to gridpoints in the range."
+        },
+        {
+          "name": "clear",
+          "syntax": "clear",
+          "description": "Remove the water table. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
         }
       ],
       "legacy_documentation": {


### PR DESCRIPTION
Batch 8 — the user started FLAC3D 7.0 with the bridge, so the full-corpus sweep harness ran against a **live 7.0 engine**: all 290 non-tombstone 7.0 blocks probed (100 enumerable → 23 exact matches, 77 diffs; ledger in the verification workspace). This upgrades the 7.0 corpus from static-grade (official HTML) to syntax-grade evidence — and caught places where **the official 7.0 docs themselves are wrong**:

- `structure beam property`: official 7.0 HTML says `youngs` — the live engine rejects it and accepts `young` (+ `plastic-moment-y/z` missing from the docs entirely)
- shell/geogrid/liner `history`: 7.0 uses `stress-intermediate/-maximum/-minimum`; the crawl had backfilled 9.x-era `principal-*` names, which 7.0 rejects
- `zone face apply` 7.0 was missing `free-field`, `stress-tensor`, `westergaard` (the latter became a dedicated command in 9.x)
- `zone gridpoint free` force-applied family, `gridpoint initialize` force family, `gridpoint import pore-pressure`
- `model configure` 7.0 +9 modules; structure histories +`name` (hybrid +`yield`); node history +acceleration families; misc singles (water clear, list apply/gp, trace gp/name, interface name, hybrid grout tables, zone history fluid entries)

Remaining 7.0 diffs are the same systematic non-bug patterns as 9.0 (flattened compound names, apply-block modifiers, optional-boolean placeholders).

Tests: full suite passes (321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)