### PR TITLE
docs: resolve the gated commands from the full-corpus sweep (Batch 9)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/block-transform.json
@@ -46,9 +46,9 @@
       "syntax": "building-blocks block transform [origin <v>] keyword [control-point <b>] [range]",
       "keywords": [
         {
-          "name": "reflect-plane",
-          "syntax": "plane <v_1> <v_2> <v_3>",
-          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
+          "name": "reflect",
+          "syntax": "reflect plane <v1 > <v2 > <v3 > | reflect dip ...",
+          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 . CORRECTED: the keyword is 'reflect', followed by 'plane' (three points defining the reflection plane) or 'dip'; the previously documented flattened form 'reflect-plane' is rejected and hid the 'dip' alternative. Verified live against FLAC3D 9.7 (module error-message enumeration, 2026-08-13)."
         },
         {
           "name": "rotate",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/edge-transform.json
@@ -46,9 +46,9 @@
       "syntax": "building-blocks edge transform [origin <v_o>] keyword [control-point <b>] [range]",
       "keywords": [
         {
-          "name": "reflect-plane",
-          "syntax": "plane <v_1> <v_2> <v_3>",
-          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
+          "name": "reflect",
+          "syntax": "reflect plane <v1 > <v2 > <v3 > | reflect dip ...",
+          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 . CORRECTED: the keyword is 'reflect', followed by 'plane' (three points defining the reflection plane) or 'dip'; the previously documented flattened form 'reflect-plane' is rejected and hid the 'dip' alternative. Verified live against FLAC3D 9.7 (module error-message enumeration, 2026-08-13)."
         },
         {
           "name": "rotate",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/face-transform.json
@@ -46,9 +46,9 @@
       "syntax": "building-blocks face transform [origin <v_o>] [control-point <b>] keyword [range]",
       "keywords": [
         {
-          "name": "reflect-plane",
-          "syntax": "plane <v_1> <v_2> <v_3>",
-          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
+          "name": "reflect",
+          "syntax": "reflect plane <v1 > <v2 > <v3 > | reflect dip ...",
+          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 . CORRECTED: the keyword is 'reflect', followed by 'plane' (three points defining the reflection plane) or 'dip'; the previously documented flattened form 'reflect-plane' is rejected and hid the 'dip' alternative. Verified live against FLAC3D 9.7 (module error-message enumeration, 2026-08-13)."
         },
         {
           "name": "rotate",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-transform.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/body/point-transform.json
@@ -46,9 +46,9 @@
       "syntax": "building-blocks point transform [origin <v_o>] keyword [control-point <b>] [range]",
       "keywords": [
         {
-          "name": "reflect-plane",
-          "syntax": "plane <v_1> <v_2> <v_3>",
-          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 ."
+          "name": "reflect",
+          "syntax": "reflect plane <v1 > <v2 > <v3 > | reflect dip ...",
+          "description": "Make a reflection transformation about a plane. Specify the mirror plane defined by dip angle f1 and dip direction f2 . Angles are defined in degrees. Specify the mirror plane defined by three points v_1 v_2 v_3 . CORRECTED: the keyword is 'reflect', followed by 'plane' (three points defining the reflection plane) or 'dip'; the previously documented flattened form 'reflect-plane' is rejected and hid the 'dip' alternative. Verified live against FLAC3D 9.7 (module error-message enumeration, 2026-08-13)."
         },
         {
           "name": "rotate",


### PR DESCRIPTION
Final round of the 9.0 full-corpus sweep: all 52 gated commands resolved.

Key insight: the building-blocks module uses a hand-rolled parser (typos like `szie` in engine messages) whose **error messages enumerate the legal keywords directly** — no kernel `Expected tokens` needed. The file/context gates were unlocked live: gravity for `zone initialize-stresses`, a real `zone export`→`zone import` .f3grid round-trip, structure elements for `refine`, name pairs for renames.

Results: 11 of 12 keyword-bearing building-blocks commands match the corpus exactly. One fix: the four `building-blocks * transform` files documented `reflect-plane`, but the keyword is `reflect` followed by `plane <3 points>` **or** `dip` — the flattened form also hid the dip alternative. Everything else verified as value/range-only. Bonus behavioral note: `zone delete` aborts on unused tokens instead of executing first — safer than the `apply-remove` family.

**Milestone: every one of the 333 FLAC command files' 9.0 blocks now has an explicit live verdict** (and the 290 7.0 blocks were swept against live 7.0 in #83).

Tests: full suite passes (321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)