### PR TITLE
docs: resolve process-gated FLAC semantics from live FLAC3D 9.7 verification

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/face-apply.json
@@ -391,6 +391,7 @@
     "9.0": {
       "command": "zone face apply",
       "syntax": "zone face apply keyword [range]",
+      "description": "This command is used to apply boundary conditions at surface faces of the model. Process gating (verified against FLAC3D 9.7): the keyword ENUMERATION below is context-free -- the parser lists the identical 47-keyword set whether or not thermal/dynamic/creep/fluid are configured -- but EXECUTION is gated per process: thermal keywords (temperature, flux, convection) require 'model configure thermal', dynamic keywords (quiet*, acceleration*) require 'model configure dynamic', fluid keywords (pore-pressure*, head*, discharge, leakage) require a fluid configure; without the configure the engine rejects with a message naming the missing process. Applying a condition to gridpoints that already carry a conflicting apply removes the old condition (reported in the command output).",
       "keywords": [
         {
           "name": "acceleration",
@@ -470,7 +471,7 @@
         {
           "name": "pore-pressure-maximum",
           "syntax": "pore-pressure-maximum [<f >] [applyblock]",
-          "description": "Apply a pore-pressure condition with a maximum limit; the value is optional. Requires the model configured for fluid. Keyword and optional argument shape verified against FLAC3D 9.7; exact semantics are undocumented upstream (absent from the official 9.x HTML documentation)."
+          "description": "Seepage-type limited-pore-pressure boundary. Gridpoint pore pressure on the face is left FREE while below f (it follows the flow field, unlike a plain pore-pressure apply which pins the value from both directions) and is clamped at f whenever flow would push it higher -- the face acts as a drain at pp = f. At apply time, any pore pressure above f in the range is immediately reduced to f. Omitting f is equivalent to f = 0 (zero-pressure seepage face). Requires the model configured for fluid. State-verified against FLAC3D 9.7 (fluid-explicit diffusion tests with gp.pp() readback, contrasted against a plain pore-pressure face); absent from the official 9.x HTML documentation."
         },
         {
           "name": "pore-pressure-saturation",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-fix.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-fix.json
@@ -177,7 +177,7 @@
         {
           "name": "saturation",
           "syntax": "saturation [<f >] <[gridpointfixblock]>",
-          "description": "Fix saturation at the gridpoints. If f is given, the saturation is fixed at that value. Requires the model to be configured for fluid (model configure fluid-flow). Verified against FLAC3D 9.7; absent from the official 9.x HTML documentation."
+          "description": "Fix saturation at the gridpoints. If f is given, the saturation is fixed at that value. Executing requires the model configured for fluid (any fluid mode; without it the engine rejects with 'Not configured for fluid calculations', though the keyword still appears in parser enumerations -- keyword enumeration is context-free in 9.7). Fixed saturation values hold in both fluid-flow (implicit) and fluid-explicit modes. State-verified against FLAC3D 9.7; absent from the official 9.x HTML documentation."
         },
         {
           "name": "source",
@@ -187,7 +187,7 @@
         {
           "name": "temperature",
           "syntax": "temperature [<f>] [[gridpointfixblock]]",
-          "description": "Fixes temperatures. If f is given, the temperature is fixed at that value. This is only available if model configure thermal has been specified."
+          "description": "Fixes temperatures. If f is given, the temperature is fixed at that value. This is only available if model configure thermal has been specified: without it the engine rejects with 'Not configured for thermal calculations' (the keyword still appears in parser enumerations -- keyword enumeration is context-free in 9.7). State-verified against FLAC3D 9.7: 'fix temperature 42' reads back 42.0 via gp.temp()."
         },
         {
           "name": "velocity",

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-initialize.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/zone/gridpoint-initialize.json
@@ -312,12 +312,12 @@
         {
           "name": "saturation",
           "syntax": "saturation <f> [[gridpointinitializeblock]]",
-          "description": "Saturation at the gridpoint. Only available if the model configure fluid has been given."
+          "description": "Saturation at the gridpoint. Only available if the model configure fluid has been given. MODE-DEPENDENT in 9.7: in fluid-flow (implicit) mode, initialized values on unfixed gridpoints are clamped back by the engine (the command reports 'saturation modified' but the value reads back 1.0) -- fix saturation instead to impose a value; in fluid-explicit mode initialized values hold (0.8 reads back 0.8). State-verified against FLAC3D 9.7 under both modes with otherwise identical models."
         },
         {
           "name": "temperature",
           "syntax": "temperature <f> [[gridpointinitializeblock]]",
-          "description": "temperature at the gridpoint. Only available if the model configure thermal has been given."
+          "description": "temperature at the gridpoint. Only available if the model configure thermal has been given (without it the engine rejects with 'Not configured for thermal calculation'). Unlike saturation, initialized temperature holds on unfixed gridpoints ('initialize temperature 25' reads back 25.0 via gp.temp()). State-verified against FLAC3D 9.7."
         },
         {
           "name": "velocity",

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/gridpoint/Gridpoint.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/gridpoint/Gridpoint.json
@@ -327,7 +327,7 @@
     {
       "name": "fix",
       "signature": "gridpoint.fix(component: int) -> bool",
-      "description": "Get the gridpoint fixity condition. The component index is 1-based: 1 = x, 2 = y, 3 = z (accepted range 1-5; components 4 and 5 do not map to the velocity, pore-pressure, or saturation fixity flags and were observed always True -- read pore-pressure fixity via pp_fix() instead). WARNING: asymmetric with set_fix, whose component index is 0-based. Verified against FLAC3D 9.7.",
+      "description": "Get the gridpoint fixity condition. The component index is 1-based: 1 = x, 2 = y, 3 = z (accepted range 1-5; components 4 and 5 read True regardless of model state -- verified unchanged in a model with thermal AND fluid configured while fixing/freeing pore-pressure, temperature, and saturation -- so they do not map to pore-pressure, saturation, or temperature fixity; read pore-pressure fixity via pp_fix() instead). Note fixity from 'zone gridpoint fix acceleration-*' is also NOT reflected in components 1-3 (those track velocity fixity only). WARNING: asymmetric with set_fix, whose component index is 0-based. State-verified against FLAC3D 9.7.",
       "parameters": [
         {
           "name": "component",
@@ -693,7 +693,7 @@
     {
       "name": "sat",
       "signature": "gridpoint.sat() -> float",
-      "description": "Get the gridpoint fluid saturation. Note: unfixed saturation is engine-managed -- values written via set_sat() or 'zone gridpoint initialize saturation' are immediately clamped back (observed snapping to 1.0 in a fluid-flow configured model even though the command reports 'saturation modified'); to impose a saturation value, fix it ('zone gridpoint fix saturation <f>'), which holds. Verified against FLAC3D 9.7.",
+      "description": "Get the gridpoint fluid saturation. Note: unfixed-saturation write behavior depends on the fluid configure MODE -- in fluid-flow (implicit) mode, values written via set_sat() or 'zone gridpoint initialize saturation' are immediately clamped back to 1.0 (even though the command reports 'saturation modified'); in fluid-explicit mode the written values hold. Fixing saturation ('zone gridpoint fix saturation <f>') holds the value in both modes. State-verified against FLAC3D 9.7 under both modes with otherwise identical models.",
       "returns": {
         "type": "float"
       }
@@ -1216,7 +1216,7 @@
     {
       "name": "set_sat",
       "signature": "gridpoint.set_sat(value: float) -> None",
-      "description": "Set the gridpoint fluid saturation. WARNING: on an unfixed gridpoint the written value is immediately clamped back by the engine (observed reading 1.0 right after set_sat(0.8) in a fluid-flow configured model); fix saturation first if the value must hold. Verified against FLAC3D 9.7.",
+      "description": "Set the gridpoint fluid saturation. WARNING: mode-dependent -- in a fluid-flow (implicit) configured model the written value on an unfixed gridpoint is immediately clamped back to 1.0 (reads 1.0 right after set_sat(0.8)); in a fluid-explicit configured model the written value holds (set_sat(0.7) reads back 0.7). Fix saturation first if the value must hold in implicit mode. State-verified against FLAC3D 9.7 under both modes.",
       "parameters": [
         {
           "name": "value",


### PR DESCRIPTION
Batch 10 of the FLAC corpus verification effort ([workspace checklist](https://github.com/yusong652/itasca-mcp) tracked externally). Closes all five open live-verification items via live FLAC3D 9.7 experiments with state readback.

## Findings folded into the corpus

- **`zone face apply pore-pressure-maximum` semantics solved (state-grade)** — seepage-type limited-pore-pressure boundary: face pp is *free* while below `f` (a plain `pore-pressure` face pins from both directions), clamped at `f` when flow would exceed it, and immediately reduced to `f` at apply time. Bare form ≡ `f = 0` (zero-pressure seepage face). Previously syntax-grade with explicitly unknown semantics.
- **Keyword enumeration is context-free in 9.7** — re-running first-token enumeration of `zone gridpoint fix/free`, `zone apply`, `zone face apply`, `zone gridpoint initialize` after configuring thermal → dynamic → creep → fluid produced zero enumeration change. Execution is the actual gate ('Not configured for thermal/fluid/dynamic calculations'). Documented in the face-apply 9.0 block and the affected keyword entries.
- **Saturation clamp-back is fluid-mode-dependent** — controlled A/B with otherwise identical models: `fluid-flow` (implicit) clamps unfixed writes back to 1.0 (Batch 1 behavior); `fluid-explicit` holds them (init 0.8 → 0.8, `set_sat(0.7)` → 0.7). `fix saturation` holds in both. `Gridpoint.sat`/`set_sat` and `zone gridpoint initialize saturation` updated.
- **Temperature state-verified** (thermal configured): `initialize temperature 25` holds on unfixed gridpoints (unlike implicit-mode saturation); `fix temperature 42` reads back 42.0 via `gp.temp()`.
- **`Gridpoint.fix` components 4–5 confirmed inert under full thermal+fluid configuration** while fixing/freeing pp/temperature/saturation — not process fixity flags. Also documented: acceleration fixity is not reflected in components 1–3 (velocity fixity only; sanity-checked with velocity-x fix/free).

Tests: `test_phase2_tools.py` + `test_tool_contracts.py` pass (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)