### PR TITLE
docs: verify FLAC reference files against live FLAC3D 9.7 (Batch 11)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/fluid-flow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/fluid-flow.json
@@ -27,6 +27,19 @@
       ]
     },
     {
+      "group": "limited / combined pressure conditions (face apply, FLAC3D 9.x live-verified)",
+      "keywords": [
+        "pore-pressure-maximum",
+        "pore-pressure-saturation",
+        "head-saturation"
+      ],
+      "notes": [
+        "'pore-pressure-maximum <f>' is a seepage-type limited-pp boundary: face pp stays FREE below f and is drain-clamped at f when flow would exceed it; bare form = f 0 (zero-pressure seepage face). State-verified against FLAC3D 9.7; absent from the official 9.x HTML docs.",
+        "'pore-pressure-saturation <v2>' applies pore pressure and saturation together; 'head-saturation <f>' is the head-based companion (needs fluid density + gravity set first). Both absent from the official 9.x HTML docs.",
+        "See the zone face apply command doc for the full verified keyword entries."
+      ]
+    },
+    {
       "group": "flux and leakage (face apply)",
       "keywords": [
         "discharge",

--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/gridpoint-fixity.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/gridpoint-fixity.json
@@ -54,6 +54,7 @@
       "keywords": [
         "pore-pressure",
         "temperature",
+        "saturation",
         "source",
         "well"
       ],
@@ -61,8 +62,9 @@
         "head"
       ],
       "notes": [
-        "Fluid and thermal keywords require the corresponding model configuration when solving coupled processes.",
+        "Fluid and thermal keywords require the corresponding model configuration to EXECUTE (FLAC3D 9.7 rejects with 'Not configured for fluid/thermal calculations'); the keywords still appear in parser enumerations regardless of configuration.",
         "'source' is a heat-source term (thermal); 'well' is a fluid source/sink.",
+        "'saturation' fixity holds the value in both fluid-flow (implicit) and fluid-explicit modes; it is also the only way to impose a saturation value in implicit mode (unfixed writes clamp back to 1.0). State-verified against FLAC3D 9.7.",
         "'head' (hydraulic-head fixity) is accepted by 'zone gridpoint fix' in FLAC3D 9.0 but NOT in FLAC2D 9.0 — use 'pore-pressure' on FLAC2D gridpoints."
       ]
     }

--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/mechanical-face.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/mechanical-face.json
@@ -32,7 +32,8 @@
         "Use stress-normal for pressure-like loading normal to selected faces.",
         "Use tensor components for global-axis stress loading; 'stress-tensor' accepts a full 6-component tensor.",
         "Out-of-plane components (stress-zz/-xz/-yz) are accepted by FLAC2D for plane-strain state tracking even though they are 3D-flavored.",
-        "stress-dip / stress-strike are dimension-non-obvious 3D-only forms (FLAC2D uses angle-based alternatives). Accepted by FLAC3D 9.0 binary."
+        "stress-dip / stress-strike are dimension-non-obvious 3D-only forms (FLAC2D uses angle-based alternatives). Accepted by FLAC3D 9.0 binary.",
+        "'stress-shear' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (the 3D in-plane forms are stress-dip/-strike)."
       ]
     },
     {
@@ -53,7 +54,8 @@
       "notes": [
         "Velocity boundary conditions are usually preferred for roller/fixed displacement boundaries.",
         "Local components are interpreted from automatically generated gridpoint local axes.",
-        "velocity-dip / velocity-strike are dimension-non-obvious 3D-only forms; rejected by FLAC2D."
+        "velocity-dip / velocity-strike are dimension-non-obvious 3D-only forms; rejected by FLAC2D.",
+        "'velocity-tangential' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (use -dip/-strike in 3D)."
       ]
     },
     {
@@ -74,7 +76,8 @@
       "notes": [
         "Reaction conditions apply forces where the corresponding direction is fixed.",
         "Use after fixity has been established.",
-        "reaction-dip / reaction-strike are dimension-non-obvious 3D-only forms; rejected by FLAC2D."
+        "reaction-dip / reaction-strike are dimension-non-obvious 3D-only forms; rejected by FLAC2D.",
+        "'reaction-tangential' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (use -dip/-strike in 3D)."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/thermal-dynamic.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/thermal-dynamic.json
@@ -46,9 +46,9 @@
         "quiet-strike"
       ],
       "notes": [
-        "Dynamic keywords require 'model configure dynamic' first.",
-        "FLAC2D users should avoid z-directed acceleration keywords; quiet normal/tangential forms and acceleration-local are dimension-neutral.",
-        "'acceleration-dip / acceleration-strike / quiet-dip / quiet-strike' accepted by FLAC3D 9.0 binary.",
+        "Dynamic keywords require 'model configure dynamic' first to EXECUTE ('The model must be configured for dynamic' otherwise; state-verified against FLAC3D 9.7 — quiet applied and accepted right after configuring). The keywords appear in parser enumerations regardless.",
+        "DIMENSION SPLIT for the tangential forms: 'acceleration-tangential' and 'quiet-tangential' are FLAC2D-only — FLAC3D 9.7 does NOT enumerate them (the 3D tangent-plane forms are -dip/-strike). 'acceleration-local' and the -normal forms exist in both.",
+        "'acceleration-dip / acceleration-strike / quiet-dip / quiet-strike' accepted by FLAC3D 9.0 binary and enumerated by FLAC3D 9.7.",
         "CAVEAT: 'zone face apply acceleration-dip <value>' was observed to crash the FLAC3D 9.0 process when applied to all faces without a configured dip axis. Probe with '?' first, or supply an explicit range and dip-axis setup before applying."
       ]
     }

--- a/src/itasca_mcp/knowledge/resources/flac/references/fish-intrinsics/field-query.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/fish-intrinsics/field-query.json
@@ -50,6 +50,7 @@
     }
   ],
   "validation_notes": [
+    "All nine primary_intrinsics verified present in the live FLAC3D 9.7 'fish list intrinsics' output (2026-08-13).",
     "For a single exact gridpoint value, direct gp.* intrinsics are simpler.",
     "For arbitrary probe points, zone.field avoids nearest-gridpoint ambiguity.",
     "Record field name, quantity, and interpolation method with exported results."

--- a/src/itasca_mcp/knowledge/resources/flac/references/fish-intrinsics/structure-interface.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/fish-intrinsics/structure-interface.json
@@ -31,7 +31,7 @@
         "struct.shell.stress"
       ],
       "notes": [
-        "FISH intrinsic naming differs between FLAC2D and FLAC3D: 'struct.beam.force' and 'struct.shell.stress' exist in FLAC3D 9.0 but are rejected in FLAC2D 9.0 (FLAC2D has 'struct.beam.moment' and no shell type).",
+        "FISH intrinsic naming differs between FLAC2D and FLAC3D: 'struct.beam.force' and 'struct.shell.stress' exist in FLAC3D 9.0 but are rejected in FLAC2D 9.0 (FLAC2D has 'struct.beam.moment' and no shell type). FLAC3D 9.7 has BOTH 'struct.beam.moment' and 'struct.beam.force' (all intrinsic names in this file verified present in the live 9.7 'fish list intrinsics' output, 2026-08-13).",
         "Plot 'structure-beam contour force' attribute names also do NOT mirror FISH intrinsic names directly.",
         "Probe live with 'fish list intrinsics' (paginate output) when an expected name is rejected.",
         "Choose local/global force interpretation deliberately (e.g. 'struct.node.disp.global' vs '.local')."

--- a/src/itasca_mcp/knowledge/resources/flac/references/fish-intrinsics/zone-gridpoint.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/fish-intrinsics/zone-gridpoint.json
@@ -2,7 +2,7 @@
   "name": "zone-gridpoint",
   "dimension": "mixed",
   "full_name": "Zone and Gridpoint FISH Intrinsics",
-  "description": "Zone and gridpoint FISH intrinsics provide pointer-based access to model objects. They are best used for scripted checks, custom measurements, and compact validation reports after command-driven setup.",
+  "description": "Zone and gridpoint FISH intrinsics provide pointer-based access to model objects. They are best used for scripted checks, custom measurements, and compact validation reports after command-driven setup. All intrinsic names in this file were verified present in the live FLAC3D 9.7 'fish list intrinsics' output (2026-08-13).",
   "intrinsic_families": [
     {
       "family": "object iteration",
@@ -30,7 +30,7 @@
       ],
       "notes": [
         "FLAC2D positions use x/y model space; FLAC3D positions use x/y/z.",
-        "Use 'zone.face.normal(z, side)' for face normal vectors; 'zone.face.gp(z, side, i)' for face gridpoints. 'zone.face' alone is NOT a valid intrinsic in FLAC2D 9.0.",
+        "Use 'zone.face.normal(z, side)' for face normal vectors; 'zone.face.gp(z, side, i)' for face gridpoints. 'zone.face' alone is NOT a valid intrinsic in FLAC2D 9.0 nor in FLAC3D 9.7 (only the dotted zone.face.* family exists).",
         "Zone face and node orientation differs between 2D and 3D zone shapes."
       ]
     },
@@ -46,7 +46,7 @@
         "gp.extra"
       ],
       "notes": [
-        "Use 'zone.model(z)' to query the constitutive-model name; 'zone.cmodel' is NOT a valid intrinsic in FLAC2D 9.0.",
+        "Use 'zone.model(z)' to query the constitutive-model name; 'zone.cmodel' is NOT a valid intrinsic in FLAC2D 9.0 nor in FLAC3D 9.7.",
         "Use property keywords from the constitutive-models reference with zone.prop.",
         "Use groups rather than geometric coordinates when checking staged regions."
       ]

--- a/src/itasca_mcp/knowledge/resources/flac/references/initial-conditions/fluid-thermal.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/initial-conditions/fluid-thermal.json
@@ -29,7 +29,9 @@
       "notes": [
         "Pore-pressure, saturation, and head are nodal scalar quantities → use 'zone gridpoint initialize <kw>' (NOT 'zone initialize <kw>').",
         "Gridpoint pore pressures are used to derive zone pore pressures.",
-        "Effective stresses depend on pore pressure when using effective-stress constitutive behavior."
+        "Effective stresses depend on pore pressure when using effective-stress constitutive behavior.",
+        "SATURATION TRAP (state-verified, FLAC3D 9.7): in fluid-flow (implicit) mode, 'initialize saturation' on unfixed gridpoints is clamped back to 1.0 (the command still reports 'saturation modified') — fix saturation to impose a value; in fluid-explicit mode initialized values hold.",
+        "'biot', 'fluid-modulus', and 'fluid-tension' are accepted and execute ('-biot modified in N gridpoints') but never appear in the parser's keyword enumeration in 9.7 — enumeration-invisible keywords; do not conclude from an enumeration diff that they are gone."
       ]
     },
     {

--- a/src/itasca_mcp/knowledge/resources/flac/references/range-elements/index.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/range-elements/index.json
@@ -229,6 +229,27 @@
     "Use 'union' keyword for OR logic",
     "Unspecified range affects all objects of target type"
   ],
+  "live_enumeration_flac3d_97": {
+    "description": "Full range-element keyword set enumerated live from FLAC3D 9.7 ('<cmd> range <bogus>' error enumeration, 2026-08-13). All 22 elements documented above are present. The unified 9.x kernel enumerates elements from ALL engines -- acceptance does not imply the element selects anything meaningful for FLAC data (same caveat as plot-items).",
+    "flac_relevant_undocumented": [
+      "active", "aspect-ratio", "cmodel", "component-id", "component-id-list",
+      "concave", "deformable", "deselected", "displacement", "edge-length",
+      "excavated", "face-area", "geometry-distance", "geometry-space",
+      "group-intersection", "index-list", "interface", "name", "orientation",
+      "project-range", "region", "remove", "seed", "selected", "set",
+      "sregion", "state", "structure-type", "surface", "use-hidden",
+      "velocity", "volume"
+    ],
+    "other_engine_elements": [
+      "bmaterial", "contact", "dfn", "dfn-3dec", "fid", "fidlist",
+      "fracture-id", "jmaterial", "jmodel", "joint-set", "leader-id",
+      "marker-type", "mintersection", "rintersection", "wall"
+    ],
+    "notes": [
+      "dfn/fid/fidlist/fracture-id may still be FLAC-relevant when the DFN module is used; they are grouped by primary origin (DFN/3DEC/PFC), not by hard rejection.",
+      "Evidence grade: syntax (enumeration only); per-element parameter shapes of the undocumented elements are not yet curated."
+    ]
+  },
   "related_commands": [
     "model range create",
     "model range delete",

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/beam-pile.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/beam-pile.json
@@ -27,7 +27,7 @@
         "plastic-shear"
       ],
       "notes": [
-        "'moi' is the single in-plane moment of inertia in FLAC2D. The 'moi-y'/'moi-z'/'moi-polar' family is FLAC3D-only and rejected by FLAC2D.",
+        "'moi' is the single in-plane moment of inertia in FLAC2D. The split 'moi-y'/'moi-z' family is FLAC3D-only and rejected by FLAC2D. NOTE: FLAC3D 9.7 has NO 'moi-polar' -- torsional stiffness is set via 'torsion-constant' (live-enumerated).",
         "'shear-coefficient' is a single scalar in FLAC2D; 'shear-coefficient-y'/'shear-coefficient-z' are FLAC3D-only.",
         "'spacing' is the out-of-plane element spacing (FLAC2D-only concept; FLAC3D models real spacing geometrically).",
         "'direction-y' orients the local y-axis of the beam cross section.",
@@ -84,8 +84,10 @@
     ],
     "notes": [
       "FLAC3D beam/pile use the SPLIT principal-axis form (moi-y/-z, shear-coefficient-y/-z, plastic-moment-y/-z, plastic-shear-y/-z) and accept 'torsion-constant' + 'thermal-expansion'. FLAC2D uses the unified scalars (moi, shear-coefficient, plastic-moment, plastic-shear) and does NOT accept the -y/-z forms or 'thermal-expansion' or 'torsion-constant'.",
+      "FLAC3D 9.7 additionally accepts the UNIFIED 'plastic-moment' and 'plastic-shear' scalars alongside the split -y/-z forms (live-enumerated; sets both axes at once). The unified 'moi' and 'shear-coefficient' are still rejected in 3D.",
       "'spacing' is FLAC2D-only (out-of-plane spacing); FLAC3D rejects it.",
-      "Property keyword sets verified against FLAC3D 9.0 'structure beam property ?' and FLAC2D 9.0 binary."
+      "Property keyword sets verified against FLAC2D 9.0 binary and live FLAC3D 9.7 error enumeration ('structure beam/pile property <bogus>' with elements present).",
+      "9.x beam/pile also carry constitutive models ('structure beam cmodel assign', 5 models: concrete/elastic/mohr-coulomb/strain-softening/von-mises) -- see structure-cmodels.json for the mechanism and the elastic->plastic assignment trap."
     ]
   },
   "common_patterns": [

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/cable.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/cable.json
@@ -42,7 +42,10 @@
         "spacing"
       ],
       "notes": [
-        "spacing is a FLAC2D-only out-of-plane spacing property."
+        "spacing is a FLAC2D-only out-of-plane spacing property.",
+        "The full FLAC3D 9.7 cable property set was live-enumerated and matches this file exactly (all reinforcement + grout + slide keywords, minus the 2D-only 'spacing').",
+        "cable is the one structural type WITHOUT a 9.x constitutive model ('structure cable cmodel' is rejected); see structure-cmodels.json.",
+        "'structure cable apply' takes only 'tension', with sub-keywords 'value' and 'active' (live-enumerated FLAC3D 9.7)."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/index.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/index.json
@@ -25,11 +25,18 @@
       "file": "link.json",
       "description": "Structural link per-DOF property selectors (x / y / rotation in FLAC2D) plus attachment concepts.",
       "common_use": "Control how structural nodes interact with zones or other structural objects."
+    },
+    {
+      "name": "structure-cmodels",
+      "file": "structure-cmodels.json",
+      "description": "FLAC3D 9.x structural constitutive models: cmodel support per element type, per-model property sets, and the elastic->plastic assignment trap.",
+      "common_use": "Choosing/assigning shell, liner, geogrid, beam, or pile constitutive models and knowing which property names each unlocks."
     }
   ],
   "notes": [
-    "Property keyword sets are binary-validated against FLAC2D 9.0 (probed via 'structure <type> property ?').",
-    "'shell' and 'geogrid' are FLAC3D-only structure types — rejected by FLAC2D 9.0. They are documented inline in liner.json under 'related_3d_only'."
+    "Property keyword sets are binary-validated against FLAC2D 9.0 (probed via 'structure <type> property ?') and re-verified against live FLAC3D 9.7 error enumeration (2026-08-13).",
+    "'shell' and 'geogrid' are FLAC3D-only structure types — rejected by FLAC2D 9.0. They are documented inline in liner.json under 'related_3d_only'.",
+    "In 9.x the property keyword set is cmodel-dependent for shell/liner/geogrid/beam/pile: material property names only parse after the matching 'structure <type> cmodel assign'. See structure-cmodels.json."
   ],
   "official_sources": [
     "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/cables/cables.html",

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/liner.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/liner.json
@@ -137,7 +137,8 @@
       "thickness"
     ],
     "notes": [
-      "FLAC3D shells take only the basic surface-element properties; mechanical stiffness is set via a separate shell constitutive model."
+      "FLAC3D shells take only the basic surface-element properties WITHOUT a cmodel assigned; assigning a shell constitutive model ('structure shell cmodel assign <model>', 7 models available) EXPANDS the property keyword set with that model's material properties (e.g. elastic adds young + poisson). The same mechanism applies to liner and geogrid. See structure-cmodels.json for the per-model property sets and the elastic->plastic assignment trap. Live-verified against FLAC3D 9.7.",
+      "The FLAC3D liner and geogrid base property sets in this file were re-verified against live FLAC3D 9.7 error enumeration (exact match, including the 12 coupling-*/-2 liner keywords and geogrid's shear-only bare coupling-* names)."
     ]
   },
   "flac3d_geogrid_property_set": {

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/link.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/link.json
@@ -20,9 +20,9 @@
         "rotation"
       ],
       "notes": [
-        "'structure link property' is followed by a DOF selector ('x', 'y', or 'rotation' for FLAC2D), then per-DOF sub-keywords like 'attach', 'model', 'area', 'stiffness', etc.",
-        "FLAC2D nodes have 3 DOFs: x, y, rotation. FLAC3D adds 'z', 'rotation-x', 'rotation-y' / 'rotation-z'.",
-        "Probe live with 'structure link property x ?' to see per-DOF sub-keywords."
+        "'structure link property' is followed by a DOF selector, then per-DOF sub-keywords. FLAC3D 9.7 live enumeration: DOF selectors are x, y, z, rotation-x, rotation-y, rotation-z (no bare 'rotation' in 3D); per-DOF sub-keywords are area, cohesion, for-structure-type, friction, gap, stiffness.",
+        "FLAC2D nodes have 3 DOFs: x, y, rotation. FLAC3D uses the 6-DOF selector set above.",
+        "'structure link' subcommands (FLAC3D 9.7 live enumeration): attach, create, delete, dynamic-damping, group, hide, history, list, property, select, slide, tolerance-contact, tolerance-node, tolerance-slide."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/structure-cmodels.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/structure-cmodels.json
@@ -1,0 +1,41 @@
+{
+  "name": "structure-cmodels",
+  "dimension": "3D",
+  "full_name": "Structural-Element Constitutive Models (FLAC3D 9.x)",
+  "description": "In the 9.x series, structural elements carry their own constitutive models, assigned with 'structure <type> cmodel assign <model>'. The 'structure <type> property' keyword set is MODEL-DEPENDENT: material property names (young, poisson, cohesion, ...) only parse after the corresponding cmodel is assigned, on top of a fixed per-type base set (thickness, density, coupling-*, ...). All facts below were live-verified against FLAC3D 9.7 (error-enumeration probing plus set-and-list readback).",
+  "cmodel_support_by_type": {
+    "shell": ["anisotropic", "concrete", "elastic", "mohr-coulomb", "orthotropic", "strain-softening", "von-mises"],
+    "liner": ["anisotropic", "concrete", "elastic", "mohr-coulomb", "orthotropic", "strain-softening", "von-mises"],
+    "geogrid": ["anisotropic", "concrete", "elastic", "mohr-coulomb", "orthotropic", "strain-softening", "von-mises"],
+    "beam": ["concrete", "elastic", "mohr-coulomb", "strain-softening", "von-mises"],
+    "pile": ["concrete", "elastic", "mohr-coulomb", "strain-softening", "von-mises"],
+    "cable": [],
+    "notes": [
+      "beam/pile omit the anisotropic/orthotropic surface models (1D elements).",
+      "cable has NO cmodel subcommand at all ('structure cable cmodel' is rejected with 'Unused extra parameter'); cable material behavior is fully driven by its fixed property set.",
+      "'structure <type> cmodel' subcommands: assign, list, plastic-integration."
+    ]
+  },
+  "assignment_trap": {
+    "description": "Once an elastic-family model (elastic/anisotropic/orthotropic) has been explicitly assigned, reassigning a PLASTIC model (concrete/mohr-coulomb/strain-softening/von-mises) to the same elements is rejected: 'Cannot replace an elastic model with a plastic model'. The reverse direction (plastic -> elastic) IS accepted, as are swaps within the elastic family. Freshly created elements (default state, no explicit assign yet) accept any model.",
+    "workaround": "Assign the plastic model first on fresh elements, or delete and recreate the elements ('structure <type> delete' then create).",
+    "verified": "Reproduced on both shell and liner elements against FLAC3D 9.7."
+  },
+  "property_sets_by_cmodel": {
+    "description": "Full 'structure shell property' keyword enumeration per assigned cmodel (FLAC3D 9.7; 'range' omitted). Each set = the type's base set (density, thermal-expansion, thickness for shell) + the model's material properties. liner/geogrid/beam/pile follow the same expansion pattern on top of their own base sets (spot-verified: liner + elastic adds young, poisson).",
+    "shell_base_no_cmodel": ["density", "thermal-expansion", "thickness"],
+    "elastic": ["density", "poisson", "thermal-expansion", "thickness", "young"],
+    "anisotropic": ["aniso-bend-constants", "aniso-bend-thickness", "aniso-memb-constants", "aniso-memb-thickness", "density", "material-x", "thermal-expansion", "thickness"],
+    "orthotropic": ["density", "material-x", "ortho-bend-constants", "ortho-bend-thickness", "ortho-memb-constants", "ortho-memb-thickness", "thermal-expansion", "thickness"],
+    "mohr-coulomb": ["bulk", "cohesion", "density", "dilation", "flag-brittle", "friction", "plastic-strain", "poisson", "shear", "tension", "thermal-expansion", "thickness", "young"],
+    "strain-softening": ["bulk", "cohesion", "density", "dilation", "flag-brittle", "friction", "length-calibration", "plastic-strain", "poisson", "shear", "strain-shear-plastic", "strain-tension-plastic", "table-cohesion", "table-dilation", "table-friction", "table-tension", "tension", "thermal-expansion", "thickness", "young"],
+    "von-mises": ["bulk", "density", "modulus-plastic", "poisson", "shear", "strength-yield", "thermal-expansion", "thickness", "young"],
+    "concrete": ["bulk", "compression", "compression-d", "compression-energy-fracture", "compression-initial", "compression-length-reference", "compression-strength", "damage", "damage-compression", "damage-tension", "density", "dilation", "poisson", "ratio-biaxial", "shear", "strain-plastic-compression", "strain-plastic-tension", "tension", "tension-d", "tension-energy-fracture", "tension-initial", "tension-length-reference", "tension-recovery", "tension-strength", "thermal-expansion", "thickness", "young"]
+  },
+  "enumeration_caveats": [
+    "The 'structure <type> property' error enumeration only lists properties valid for the CURRENTLY assigned cmodel -- it is not the union across models. Probing with no elements of the type present enumerates nothing but 'range'.",
+    "The legacy 7.0-style vector property 'isotropic (E, nu)' is still ACCEPTED by 9.7 shells even though it never appears in any error enumeration (it maps onto the elastic material).",
+    "Evidence grade: property names are enumeration-verified; young/poisson additionally state-verified (set 3.21e9, read back via 'structure shell list property young')."
+  ],
+  "official_documentation": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/shelltypes/shelltypes.html"
+}


### PR DESCRIPTION
First slice of the `references/` systematic pass (checklist item: *references/ (44 files) systematic pass*), covering the hard-fact files — structural-properties, fish-intrinsics, range-elements — plus BC/IC cross-checks against the Batch 1/10 live verdicts. All probing done against live FLAC3D 9.7 with a sacrificial model.

## New: `structure-cmodels.json`

9.x structural elements turn out to use the zone-style constitutive-model mechanism, previously undocumented in the corpus:

- `structure <type> cmodel assign` — **7 models** for shell/liner/geogrid (anisotropic, concrete, elastic, mohr-coulomb, orthotropic, strain-softening, von-mises), **5** for beam/pile (no aniso/ortho), **none** for cable.
- The `property` keyword set is **cmodel-dependent**: material names (young, cohesion, …) only parse after the matching assign. Per-model property enumerations captured for all 7 shell models.
- **One-way assignment trap**: once an elastic-family model is explicitly assigned, plastic reassignment is rejected (`Cannot replace an elastic model with a plastic model`) — reverse allowed, fresh elements accept anything. Reproduced on shell and liner.
- `young`/`poisson` state-verified (set 3.21e9 → read back via `structure shell list property young`).

## Fixes to existing files

- **beam-pile**: `moi-polar` does not exist in 9.7 (torsion = `torsion-constant`); 9.7 accepts unified `plastic-moment`/`plastic-shear` alongside the split -y/-z forms.
- **link**: real per-DOF sub-keywords are area/cohesion/for-structure-type/friction/gap/stiffness (file previously guessed 'attach'/'model'); full subcommand list added.
- **fish-intrinsics** (3 files): all 45 documented intrinsic names verified present in the live `fish list intrinsics` output (2046 intrinsics); `zone.face`/`zone.cmodel` confirmed absent in 3D too.
- **range-elements**: all 22 documented elements confirmed; full 70-element live enumeration recorded (32 FLAC-relevant undocumented, 15 other-engine, unified-kernel caveat).
- **BC/IC**: pore-pressure-maximum/-saturation/head-saturation group added with the Batch 10 solved semantics; saturation fixity/clamp mode dependence; `*-tangential` and `stress-shear` marked FLAC2D-only (9.7 uses -dip/-strike); enumeration-invisible `biot`/`fluid-modulus`/`fluid-tension` documented as a probe false-positive family.

Tests: `test_phase2_tools.py` + `test_tool_contracts.py` pass (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)