### PR TITLE
docs: verify remaining FLAC reference files against live FLAC3D 9.7 (Batch 12)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/references/geometry-data-table/data-sets.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/geometry-data-table/data-sets.json
@@ -53,5 +53,21 @@
     "Group imported data immediately so later plots and exports remain selectable.",
     "Use plot data items to confirm imported data align with the model domain."
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/flac3dhome.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/flac3dhome.html",
+  "live_verification_flac3d_97": {
+    "scalar_vector_tensor_subcommands": [
+      "create",
+      "delete",
+      "export",
+      "group",
+      "import",
+      "list",
+      "results"
+    ],
+    "notes": [
+      "data scalar / data vector / data tensor share the identical subcommand set above (live-enumerated, FLAC3D 9.7) — all primary commands in this file confirmed.",
+      "'data label' parses positionally (no subcommand enumeration at that slot); its subcommand shapes are not yet curated.",
+      "Top-level 'data <bogus>' does not enumerate the type names (scalar/vector/tensor/label) — probe one level down."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/geometry-data-table/geometry-workflow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/geometry-data-table/geometry-workflow.json
@@ -46,5 +46,39 @@
     "dxf",
     "Itasca geometry format"
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/common/geometry/doc/manual/geometry.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/common/geometry/doc/manual/geometry.html",
+  "live_verification_flac3d_97": {
+    "top_level_subcommands": [
+      "assign-groups",
+      "copy",
+      "delete",
+      "edge",
+      "export",
+      "fill",
+      "generate",
+      "group",
+      "import",
+      "list",
+      "merge",
+      "move-to",
+      "node",
+      "paint-extra",
+      "paint-extra-block",
+      "polygon",
+      "refine",
+      "results",
+      "rotate",
+      "scale",
+      "select",
+      "separate",
+      "set",
+      "tessellate",
+      "translate",
+      "triangulate"
+    ],
+    "notes": [
+      "All primary commands in this file are present in the live FLAC3D 9.7 enumeration above (26 subcommands).",
+      "'geometry polygon' (and edge/node) parse positionally below this level — per-object subcommands not enumerated."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/geometry-data-table/table-curves.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/geometry-data-table/table-curves.json
@@ -13,7 +13,7 @@
     "table list",
     "history export <id|name> table '<name>'"
   ],
-  "syntax_note": "Every table subcommand except 'table list' REQUIRES a table name first: 'table <name-string-or-int> <subcommand> ...'. PR-6 forms like 'table add' without a name are rejected by FLAC2D 9.0 with 'A table has not been specified.'",
+  "syntax_note": "Every table subcommand except 'table list' REQUIRES a table name first: 'table <name-string-or-int> <subcommand> ...'. PR-6 forms like 'table add' without a name are rejected by FLAC2D 9.0 with 'A table has not been specified.' FLAC3D 9.7 reproduces the same behavior verbatim ('A table has not been specified.') — the name-first requirement holds in 3D too.",
   "common_patterns": [
     {
       "name": "Time-dependent load table",
@@ -44,5 +44,9 @@
     "Use table list after import to catch delimiter or unit mistakes.",
     "Prefer named tables over numeric IDs in generated scripts."
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/flac3dhome.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/flac3dhome.html",
+  "live_verification_flac3d_97": [
+    "\"table 'tt' add (0,0) (1,1)\" state-verified: engine reports 'The table with name tt had 2 values added.'",
+    "The subcommand slot after the table name is NOT keyword-enumerated ('Unused extra parameter') — probe by acceptance, not enumeration."
+  ]
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/history-workflow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/history-workflow.json
@@ -97,5 +97,44 @@
     "For staged analysis, export or purge histories at stage boundaries when the baseline changes.",
     "Use product-specific coordinates: avoid z-position probes in FLAC2D commands."
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/common/kernel/doc/manual/history_manual/history.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/common/kernel/doc/manual/history_manual/history.html",
+  "live_verification_flac3d_97": {
+    "top_level_subcommands": [
+      "ball",
+      "block",
+      "ccfd",
+      "clump",
+      "contact",
+      "contactfluid",
+      "delete",
+      "dfn",
+      "element",
+      "export",
+      "fish",
+      "flow",
+      "fpx",
+      "interval",
+      "label",
+      "list",
+      "measure",
+      "model",
+      "mpoint",
+      "mpoint-node",
+      "name",
+      "purge",
+      "rblock",
+      "rename",
+      "results",
+      "struct",
+      "structure",
+      "wall",
+      "zone"
+    ],
+    "notes": [
+      "All management keywords documented in this file (interval/list/delete/purge/export/rename/name/label/results) are present in the live FLAC3D 9.7 enumeration.",
+      "The unified 9.x kernel enumerates history SOURCES from all engines (ball/clump/wall = PFC, block = 3DEC, mpoint/mpoint-node = MPoint, ...) — acceptance does not imply the source type has data in a FLAC model. Both 'struct' and 'structure' are accepted.",
+      "'history list' sub-keywords live-verified: all / labels / limits / series (exact match with this file).",
+      "The 16-token quantity selector set documented here is an exact match with the live 'zone history stress quantity <bogus>' enumeration."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/results-export.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/results-export.json
@@ -113,5 +113,6 @@
       ]
     }
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/zone/doc/manual/zone_manual/zone_commands/cmd_zone.results.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/zone/doc/manual/zone_manual/zone_commands/cmd_zone.results.html",
+  "live_verification_flac3d_97": "The 19 keywords documented in this file are an EXACT match with the live FLAC3D 9.7 'zone results <bogus>' enumeration (no missing, no extra; 2026-08-13)."
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/zone-field-data.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/zone-field-data.json
@@ -91,7 +91,8 @@
       "notes": [
         "Fluid fields require fluid configuration where applicable.",
         "Thermal fields require thermal configuration where applicable.",
-        "'thermal-flux' is NOT a zone field name — use 'property-thermal' for thermal material constants and a thermal-specific FISH query for flux."
+        "'thermal-flux' is NOT a zone field name — use 'property-thermal' for thermal material constants and a thermal-specific FISH query for flux.",
+        "DIMENSION SPLIT (live-verified): 'saturation-apparent' and 'fluid-bulk-modulus' are FLAC2D-only — FLAC3D 9.7 does not enumerate them in 'zone history' (matches the plot-contour finding). FLAC3D 9.7 instead adds fluid names absent in 2D: mobility-coefficient (+ -xx/-xy/-xz/-yy/-yz/-zz), porosity, density-fluid, oob-flow."
       ]
     }
   ],
@@ -133,5 +134,13 @@
       ]
     }
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/zones/zones.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/zones/zones.html",
+  "live_verification_flac3d_97": {
+    "notes": [
+      "Full 'zone history <bogus>' first-token enumeration captured (76 names). All names documented in this file are present EXCEPT saturation-apparent and fluid-bulk-modulus (FLAC2D-only, see fluid-thermal group note).",
+      "'condition' is confirmed present and 'state' confirmed absent in 9.7 — the file's claim holds in 3D too.",
+      "3D names beyond this file's groups: balloon, density-wet, mobility-coefficient family, oob-flow, porosity, name, stress-effective (+ six components), per-component strain-increment/strain-rate/unbalanced-force forms.",
+      "The quantity_names list is an exact match with the live 'quantity' enumeration (plus the six tensor components xx/yy/zz/xy/xz/yz, which the enumeration folds into the same slot)."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/interface-and-joints/joint-workflow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/interface-and-joints/joint-workflow.json
@@ -47,5 +47,12 @@
     "Check that discontinuities cross the expected zones.",
     "Use histories or FISH to monitor slip/opening at representative locations."
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/flac3dhome.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/flac3dhome.html",
+  "live_verification_flac3d_97": {
+    "notes": [
+      "'fracture joint-set' confirmed in the live 27-subcommand 'fracture' enumeration.",
+      "'zone joint' exists in FLAC3D 9.7 with subcommands: configure, create, create-contacts, delete, delete-attach, gridpoint-stiffness, initialize-stresses, permeability, pore-pressure-update, results.",
+      "'zone separate' accepted (executes; '0 grid points duplicated' on a no-op range)."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/interface-and-joints/zone-interface.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/interface-and-joints/zone-interface.json
@@ -91,5 +91,39 @@
     "Verify normal direction and selected faces before assigning properties.",
     "For coupled flow, set and inspect permeability behavior explicitly."
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/command_summary.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/command_summary.html",
+  "live_verification_flac3d_97": {
+    "top_level_subcommands": [
+      "create",
+      "create-from-3dec",
+      "effective",
+      "element",
+      "group",
+      "list",
+      "name",
+      "node",
+      "permeability",
+      "tolerance-contact"
+    ],
+    "node_subcommands": [
+      "displacement-shear",
+      "displacement-small",
+      "extra",
+      "group",
+      "history",
+      "initialize-stresses",
+      "list",
+      "property",
+      "stress-normal-increment",
+      "stress-shear",
+      "update"
+    ],
+    "notes": [
+      "All 12 node property keywords documented in property_groups were acceptance-verified on a live interface (engine confirms each: 'Property <X> set in 16 interface nodes').",
+      "Negative claims confirmed: 'gap' and 'permeability' are rejected as node property keywords ('Unused extra parameter'); permeability is the interface-level command as documented.",
+      "'zone interface <name> node list' sub-keywords are an exact match with this file's list: displacement / extra / host / information / property / state / stress / target / velocity.",
+      "The property-name slot is not keyword-enumerated ('Unused extra parameter' on a bogus name) — probe by acceptance.",
+      "9.7 top-level extras not previously documented here: create-from-3dec, element, name."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/building-blocks.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/building-blocks.json
@@ -37,7 +37,8 @@
     "FLAC2D 9.0 rejects 'building-blocks ...' commands at the parser level ('Bad conversion of parameter number 1 (building-blocks)'). 'zone generate from-building-blocks' is also rejected by FLAC2D — only 'zone generate from-sketch' is accepted in 2D.",
     "FLAC3D 9.0 'zone generate ?' valid forms: from-building-blocks, from-geometry, from-sketch, from-topography.",
     "Use sketch-workflow for FLAC2D zone generation.",
-    "Sketch can send fully structured FLAC3D sketches to Building Blocks."
+    "Sketch can send fully structured FLAC3D sketches to Building Blocks.",
+    "FLAC3D 9.7 live re-check: top-level 'building-blocks' enumerates exactly block / edge / face / point / set (matches the 9.0 validation); 'zone generate' enumerates the four from-* forms PLUS 'domain' (undocumented in the 9.0 note above)."
   ],
   "binary_validated_subcommands_flac3d": [
     "block",

--- a/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/sketch-workflow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/sketch-workflow.json
@@ -84,5 +84,21 @@
     "In FLAC 9.0, sketch replaces the older extrude naming.",
     "Some legacy documentation and command resources may still use extruder/extrude terminology."
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/sketch/sketch.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/sketch/sketch.html",
+  "flac3d_97_subcommands": {
+    "subcommands": [
+      "block",
+      "edge",
+      "mesh",
+      "path",
+      "point",
+      "section",
+      "segment",
+      "segment-node",
+      "set"
+    ],
+    "notes": [
+      "Live FLAC3D 9.7 enumeration: the 2D six (block/edge/mesh/point/section/set) plus the 3D-only drawing objects path / segment / segment-node — confirming from the 3D side that 'sketch segment' and 'sketch path' are 3D-only (this file already records their rejection by FLAC2D 9.0)."
+    ]
+  }
 }


### PR DESCRIPTION
Second and final slice of the `references/` systematic pass — geometry-data-table, histories-and-results, interface-and-joints, sketch-and-building-blocks (10 files), all probed against live FLAC3D 9.7 with enumeration + acceptance + state readback.

## Exact matches (verification stamps added)

- **results-export**: all 19 `zone results` keywords match the live enumeration exactly — no missing, no extra.
- **history-workflow**: `history list` sub-keywords (all/labels/limits/series) and the 16-token `quantity` selector set are exact matches; every management keyword present.
- **zone-interface**: all 12 documented node property keywords acceptance-verified (engine confirms each set); `node list` 9 sub-keywords exact; both negative claims (`gap`, `permeability` are not node properties) reproduced.
- **building-blocks**: 5 top-level subcommands exact.

## Fixes / additions

- **zone-field-data**: `saturation-apparent` and `fluid-bulk-modulus` are **FLAC2D-only** — absent from the 9.7 `zone history` enumeration (independently matches the Batch 2 plot-contour finding). Recorded the 3D-only names the file lacked (mobility-coefficient family, porosity, density-wet, oob-flow, balloon, stress-effective components).
- **table-curves**: the name-first requirement ('A table has not been specified.') reproduces verbatim in 9.7; `table add` state-verified ('2 values added').
- **building-blocks**: `zone generate` also enumerates `domain` beyond the four documented `from-*` forms.
- **sketch-workflow**: 3D-side confirmation — 9.7 `sketch` enumerates the 2D six plus `path`/`segment`/`segment-node`.
- **history-workflow**: unified-kernel caveat (history sources from all engines enumerate: ball/clump/wall/block/mpoint…; both `struct` and `structure` accepted).
- **zone-interface / joint-workflow**: 9.7 top-level extras recorded (`create-from-3dec`, `element`, `name`); `zone joint` (10 subcommands), `fracture joint-set`, `zone separate` all confirmed.

With this, **all 45 files under `flac/references/` carry live verdicts** (constitutive-models in Batch 3, plot-items in Batch 2, boundary/initial-conditions in Batches 1/10/11, structural-properties/fish-intrinsics/range-elements in Batch 11, the rest here).

Tests: `test_phase2_tools.py` + `test_tool_contracts.py` pass (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)