### PR TITLE
docs: FLAC2D dedicated sweep — verify all 2D claims against a live FLAC2D 9 engine

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/fluid-flow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/fluid-flow.json
@@ -27,7 +27,7 @@
       ]
     },
     {
-      "group": "limited / combined pressure conditions (face apply, FLAC3D 9.x live-verified)",
+      "group": "limited / combined pressure conditions (face apply, live-verified both engines)",
       "keywords": [
         "pore-pressure-maximum",
         "pore-pressure-saturation",
@@ -36,7 +36,8 @@
       "notes": [
         "'pore-pressure-maximum <f>' is a seepage-type limited-pp boundary: face pp stays FREE below f and is drain-clamped at f when flow would exceed it; bare form = f 0 (zero-pressure seepage face). State-verified against FLAC3D 9.7; absent from the official 9.x HTML docs.",
         "'pore-pressure-saturation <v2>' applies pore pressure and saturation together; 'head-saturation <f>' is the head-based companion (needs fluid density + gravity set first). Both absent from the official 9.x HTML docs.",
-        "See the zone face apply command doc for the full verified keyword entries."
+        "See the zone face apply command doc for the full verified keyword entries.",
+        "All three keywords also enumerate in live FLAC2D 9 (2026-08-13) — they are engine-family-wide 9.x features, not FLAC3D-only."
       ]
     },
     {

--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/gridpoint-fixity.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/gridpoint-fixity.json
@@ -56,16 +56,15 @@
         "temperature",
         "saturation",
         "source",
-        "well"
-      ],
-      "keywords_3d_only": [
+        "well",
         "head"
       ],
+      "keywords_3d_only": [],
       "notes": [
         "Fluid and thermal keywords require the corresponding model configuration to EXECUTE (FLAC3D 9.7 rejects with 'Not configured for fluid/thermal calculations'); the keywords still appear in parser enumerations regardless of configuration.",
         "'source' is a heat-source term (thermal); 'well' is a fluid source/sink.",
         "'saturation' fixity holds the value in both fluid-flow (implicit) and fluid-explicit modes; it is also the only way to impose a saturation value in implicit mode (unfixed writes clamp back to 1.0). State-verified against FLAC3D 9.7.",
-        "'head' (hydraulic-head fixity) is accepted by 'zone gridpoint fix' in FLAC3D 9.0 but NOT in FLAC2D 9.0 — use 'pore-pressure' on FLAC2D gridpoints."
+        "CORRECTED (live FLAC2D 9, 2026-08-13): 'head' IS a valid 'zone gridpoint fix' keyword in current FLAC2D 9 — it is semantically gated, not absent ('Must define fluid density before calculating head'). State-verified in 2D: with 'zone water density 1000' + 'model gravity 10', 'fix head 10' at y=0 reads back pp = 100000 = rho*g*h via gp.pp(). The earlier \"rejected by FLAC2D 9.0\" note applied to the older 9.0 binary."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/mechanical-face.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/mechanical-face.json
@@ -19,21 +19,22 @@
         "stress-tensor",
         "stress-xx",
         "stress-yy",
-        "stress-zz",
-        "stress-xy",
-        "stress-xz",
-        "stress-yz"
+        "stress-xy"
       ],
       "keywords_3d_only": [
         "stress-dip",
-        "stress-strike"
+        "stress-strike",
+        "stress-zz",
+        "stress-xz",
+        "stress-yz"
       ],
       "notes": [
         "Use stress-normal for pressure-like loading normal to selected faces.",
         "Use tensor components for global-axis stress loading; 'stress-tensor' accepts a full 6-component tensor.",
-        "Out-of-plane components (stress-zz/-xz/-yz) are accepted by FLAC2D for plane-strain state tracking even though they are 3D-flavored.",
         "stress-dip / stress-strike are dimension-non-obvious 3D-only forms (FLAC2D uses angle-based alternatives). Accepted by FLAC3D 9.0 binary.",
-        "'stress-shear' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (the 3D in-plane forms are stress-dip/-strike)."
+        "'stress-shear' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (the 3D in-plane forms are stress-dip/-strike).",
+        "CORRECTED (live FLAC2D 9, 2026-08-13): 'zone face apply stress-zz/-xz' is REJECTED by FLAC2D ('Bad conversion') — the out-of-plane FACE-apply components are 3D-only. Plane-strain out-of-plane tracking in 2D is done via 'zone initialize stress-zz' instead (state-verified: 'stress-zz modified in 9 zones').",
+        "'stress-shear' live-confirmed in the FLAC2D 9 face-apply enumeration (2D-only; 9.7 3D uses -dip/-strike)."
       ]
     },
     {
@@ -55,7 +56,8 @@
         "Velocity boundary conditions are usually preferred for roller/fixed displacement boundaries.",
         "Local components are interpreted from automatically generated gridpoint local axes.",
         "velocity-dip / velocity-strike are dimension-non-obvious 3D-only forms; rejected by FLAC2D.",
-        "'velocity-tangential' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (use -dip/-strike in 3D)."
+        "'velocity-tangential' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (use -dip/-strike in 3D).",
+        "'velocity-tangential' live-confirmed in the FLAC2D 9 face-apply enumeration (2D-only claim now verified on both engines)."
       ]
     },
     {
@@ -77,7 +79,8 @@
         "Reaction conditions apply forces where the corresponding direction is fixed.",
         "Use after fixity has been established.",
         "reaction-dip / reaction-strike are dimension-non-obvious 3D-only forms; rejected by FLAC2D.",
-        "'reaction-tangential' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (use -dip/-strike in 3D)."
+        "'reaction-tangential' is FLAC2D-only — FLAC3D 9.7 does not enumerate it (use -dip/-strike in 3D).",
+        "'reaction-tangential' live-confirmed in the FLAC2D 9 face-apply enumeration (2D-only claim now verified on both engines)."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/thermal-dynamic.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/boundary-conditions/thermal-dynamic.json
@@ -49,7 +49,8 @@
         "Dynamic keywords require 'model configure dynamic' first to EXECUTE ('The model must be configured for dynamic' otherwise; state-verified against FLAC3D 9.7 — quiet applied and accepted right after configuring). The keywords appear in parser enumerations regardless.",
         "DIMENSION SPLIT for the tangential forms: 'acceleration-tangential' and 'quiet-tangential' are FLAC2D-only — FLAC3D 9.7 does NOT enumerate them (the 3D tangent-plane forms are -dip/-strike). 'acceleration-local' and the -normal forms exist in both.",
         "'acceleration-dip / acceleration-strike / quiet-dip / quiet-strike' accepted by FLAC3D 9.0 binary and enumerated by FLAC3D 9.7.",
-        "CAVEAT: 'zone face apply acceleration-dip <value>' was observed to crash the FLAC3D 9.0 process when applied to all faces without a configured dip axis. Probe with '?' first, or supply an explicit range and dip-axis setup before applying."
+        "CAVEAT: 'zone face apply acceleration-dip <value>' was observed to crash the FLAC3D 9.0 process when applied to all faces without a configured dip axis. Probe with '?' first, or supply an explicit range and dip-axis setup before applying.",
+        "Tangential-form dimension split now verified on BOTH engines (2026-08-13): 'acceleration-tangential'/'quiet-tangential' enumerate in live FLAC2D 9 and are absent from FLAC3D 9.7; '-dip/-strike' enumerate in 9.7 and are absent from FLAC2D 9."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/zone-field-data.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/histories-and-results/zone-field-data.json
@@ -80,11 +80,9 @@
       "names": [
         "pore-pressure",
         "saturation",
-        "saturation-apparent",
         "temperature",
         "density-fluid",
         "fluid-biot-modulus",
-        "fluid-bulk-modulus",
         "fluid-head",
         "permeability-ratio"
       ],
@@ -92,7 +90,8 @@
         "Fluid fields require fluid configuration where applicable.",
         "Thermal fields require thermal configuration where applicable.",
         "'thermal-flux' is NOT a zone field name — use 'property-thermal' for thermal material constants and a thermal-specific FISH query for flux.",
-        "DIMENSION SPLIT (live-verified): 'saturation-apparent' and 'fluid-bulk-modulus' are FLAC2D-only — FLAC3D 9.7 does not enumerate them in 'zone history' (matches the plot-contour finding). FLAC3D 9.7 instead adds fluid names absent in 2D: mobility-coefficient (+ -xx/-xy/-xz/-yy/-yz/-zz), porosity, density-fluid, oob-flow."
+        "REMOVED as field names (live-verified both engines, 2026-08-13): 'saturation-apparent' and 'fluid-bulk-modulus' are rejected by 'zone history' in live FLAC2D 9 ('Bad conversion') and absent from the FLAC3D 9.7 enumeration — they are NOT history/field names in current 9.x engines. They exist only as 2D plot-contour attributes (see the plot-items reference).",
+        "The mobility-coefficient family, porosity, density-fluid, density-wet, and oob-flow enumerate in BOTH current engines (2D lacks only the -xz/-yz tensor components) — they are not 3D-only."
       ]
     }
   ],
@@ -139,8 +138,8 @@
     "notes": [
       "Full 'zone history <bogus>' first-token enumeration captured (76 names). All names documented in this file are present EXCEPT saturation-apparent and fluid-bulk-modulus (FLAC2D-only, see fluid-thermal group note).",
       "'condition' is confirmed present and 'state' confirmed absent in 9.7 — the file's claim holds in 3D too.",
-      "3D names beyond this file's groups: balloon, density-wet, mobility-coefficient family, oob-flow, porosity, name, stress-effective (+ six components), per-component strain-increment/strain-rate/unbalanced-force forms.",
-      "The quantity_names list is an exact match with the live 'quantity' enumeration (plus the six tensor components xx/yy/zz/xy/xz/yz, which the enumeration folds into the same slot)."
+      "The quantity_names list is an exact match with the live 'quantity' enumeration (plus the six tensor components xx/yy/zz/xy/xz/yz, which the enumeration folds into the same slot).",
+      "FLAC2D 9 comparison (live, 2026-08-13): 62-name 2D enumeration differs from the 76-name 3D one only by dimension-mechanical names (-z kinematics, -xz/-yz tensor components, mobility-coefficient-xz) — the scalar name sets otherwise match, including balloon/porosity/density-wet/oob-flow/stress-effective."
     ]
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/range-elements/index.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/range-elements/index.json
@@ -232,18 +232,55 @@
   "live_enumeration_flac3d_97": {
     "description": "Full range-element keyword set enumerated live from FLAC3D 9.7 ('<cmd> range <bogus>' error enumeration, 2026-08-13). All 22 elements documented above are present. The unified 9.x kernel enumerates elements from ALL engines -- acceptance does not imply the element selects anything meaningful for FLAC data (same caveat as plot-items).",
     "flac_relevant_undocumented": [
-      "active", "aspect-ratio", "cmodel", "component-id", "component-id-list",
-      "concave", "deformable", "deselected", "displacement", "edge-length",
-      "excavated", "face-area", "geometry-distance", "geometry-space",
-      "group-intersection", "index-list", "interface", "name", "orientation",
-      "project-range", "region", "remove", "seed", "selected", "set",
-      "sregion", "state", "structure-type", "surface", "use-hidden",
-      "velocity", "volume"
+      "active",
+      "aspect-ratio",
+      "cmodel",
+      "component-id",
+      "component-id-list",
+      "concave",
+      "deformable",
+      "deselected",
+      "displacement",
+      "edge-length",
+      "excavated",
+      "face-area",
+      "geometry-distance",
+      "geometry-space",
+      "group-intersection",
+      "index-list",
+      "interface",
+      "name",
+      "orientation",
+      "project-range",
+      "region",
+      "remove",
+      "seed",
+      "selected",
+      "set",
+      "sregion",
+      "state",
+      "structure-type",
+      "surface",
+      "use-hidden",
+      "velocity",
+      "volume"
     ],
     "other_engine_elements": [
-      "bmaterial", "contact", "dfn", "dfn-3dec", "fid", "fidlist",
-      "fracture-id", "jmaterial", "jmodel", "joint-set", "leader-id",
-      "marker-type", "mintersection", "rintersection", "wall"
+      "bmaterial",
+      "contact",
+      "dfn",
+      "dfn-3dec",
+      "fid",
+      "fidlist",
+      "fracture-id",
+      "jmaterial",
+      "jmodel",
+      "joint-set",
+      "leader-id",
+      "marker-type",
+      "mintersection",
+      "rintersection",
+      "wall"
     ],
     "notes": [
       "dfn/fid/fidlist/fracture-id may still be FLAC-relevant when the DFN module is used; they are grouped by primary origin (DFN/3DEC/PFC), not by hard rejection.",
@@ -255,5 +292,44 @@
     "model range delete",
     "model range list"
   ],
-  "official_documentation": "https://docs.itascacg.com/flac3d900/common/module/doc/manual/range_manual/range_commands/rangephrasereference.html"
+  "official_documentation": "https://docs.itascacg.com/flac3d900/common/module/doc/manual/range_manual/range_commands/rangephrasereference.html",
+  "live_enumeration_flac2d_9": {
+    "description": "Range-element set enumerated live from FLAC2D 9 (2026-08-13): 46 elements.",
+    "flac2d_only": [
+      "circle",
+      "radius"
+    ],
+    "absent_in_2d": [
+      "sphere",
+      "cylinder",
+      "sregion",
+      "region",
+      "aspect-ratio",
+      "concave",
+      "deformable",
+      "edge-length",
+      "excavated",
+      "face-area",
+      "volume",
+      "active",
+      "group-intersection",
+      "index-list",
+      "leader-id",
+      "marker-type",
+      "mintersection",
+      "rintersection",
+      "wall",
+      "bmaterial",
+      "dfn-3dec",
+      "fracture-id",
+      "jmaterial",
+      "jmodel",
+      "joint-set",
+      "position-z"
+    ],
+    "notes": [
+      "'circle' replaces 'sphere' as the 2D radial region ('radius' is its parameter-style companion).",
+      "All 22 elements documented above are present in the 2D enumeration except sphere and cylinder."
+    ]
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/building-blocks.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/building-blocks.json
@@ -38,7 +38,8 @@
     "FLAC3D 9.0 'zone generate ?' valid forms: from-building-blocks, from-geometry, from-sketch, from-topography.",
     "Use sketch-workflow for FLAC2D zone generation.",
     "Sketch can send fully structured FLAC3D sketches to Building Blocks.",
-    "FLAC3D 9.7 live re-check: top-level 'building-blocks' enumerates exactly block / edge / face / point / set (matches the 9.0 validation); 'zone generate' enumerates the four from-* forms PLUS 'domain' (undocumented in the 9.0 note above)."
+    "FLAC3D 9.7 live re-check: top-level 'building-blocks' enumerates exactly block / edge / face / point / set (matches the 9.0 validation); 'zone generate' enumerates the four from-* forms PLUS 'domain' (undocumented in the 9.0 note above).",
+    "Live FLAC2D 9 re-check (2026-08-13): 'building-blocks set create' still rejected verbatim ('Bad conversion of parameter number 1 (building-blocks)')."
   ],
   "binary_validated_subcommands_flac3d": [
     "block",

--- a/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/sketch-workflow.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/sketch-and-building-blocks/sketch-workflow.json
@@ -79,10 +79,11 @@
       ]
     }
   ],
-  "rejected_subcommands_note": "'sketch segment' and 'sketch path' are NOT valid FLAC2D 9.0 subcommands ('Bad conversion of parameter number 2'). Only block / edge / mesh / point / section / set are accepted after 'sketch'.",
+  "rejected_subcommands_note": "'sketch segment' and 'sketch path' are NOT valid FLAC2D 9.0 subcommands ('Bad conversion of parameter number 2'). Only block / edge / mesh / point / section / set are accepted after 'sketch'. UPDATE (live FLAC2D 9, 2026-08-13): the current 2D engine enumerates NINE subcommands — the six above plus fracture, joint-set, and tessellate ('segment'/'path'/'segment-node' remain 3D-only). The 'only six' claim applied to the FLAC2D 9.0 binary.",
   "version_notes": [
     "In FLAC 9.0, sketch replaces the older extrude naming.",
-    "Some legacy documentation and command resources may still use extruder/extrude terminology."
+    "Some legacy documentation and command resources may still use extruder/extrude terminology.",
+    "'zone generate' in live FLAC2D 9 enumerates from-sketch AND from-topography (the from-sketch-only claim applied to the 9.0 binary); 3D adds from-building-blocks, from-geometry, and domain."
   ],
   "official_documentation": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/elements/sketch/sketch.html",
   "flac3d_97_subcommands": {

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/beam-pile.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/beam-pile.json
@@ -112,5 +112,6 @@
       ]
     }
   ],
-  "official_documentation": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/beamtypes/beamtypes.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/beamtypes/beamtypes.html",
+  "live_verification_flac2d_9": "Live FLAC2D 9 re-check (2026-08-13): 'structure beam property' enumerates exactly the 10 keywords in the shared group (young/poisson/density/cross-sectional-area/moi/direction-y/shear-coefficient/spacing/plastic-moment/plastic-shear) with no -y/-z, torsion-constant, or thermal-expansion forms; 'structure pile property' adds exactly the pile-only coupling and rockbolt keywords documented here. 2D beam/pile also expose 'cmodel' (5 models) — see structure-cmodels.json."
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/cable.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/cable.json
@@ -45,7 +45,8 @@
         "spacing is a FLAC2D-only out-of-plane spacing property.",
         "The full FLAC3D 9.7 cable property set was live-enumerated and matches this file exactly (all reinforcement + grout + slide keywords, minus the 2D-only 'spacing').",
         "cable is the one structural type WITHOUT a 9.x constitutive model ('structure cable cmodel' is rejected); see structure-cmodels.json.",
-        "'structure cable apply' takes only 'tension', with sub-keywords 'value' and 'active' (live-enumerated FLAC3D 9.7)."
+        "'structure cable apply' takes only 'tension', with sub-keywords 'value' and 'active' (live-enumerated FLAC3D 9.7).",
+        "Live FLAC2D 9 re-check (2026-08-13): the full 2D cable enumeration matches this file exactly, including 'spacing' AND 'thermal-expansion' (unlike 2D beam, 2D cable does accept thermal-expansion). No cmodel subcommand in 2D either."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/liner.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/liner.json
@@ -158,5 +158,6 @@
       "Geogrids use SHEAR-only coupling (no normal direction): the bare 'coupling-cohesion / -friction / -stiffness' keywords without the '-shear' suffix."
     ]
   },
-  "official_documentation": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/shelltypes/shelltypes.html"
+  "official_documentation": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/shelltypes/shelltypes.html",
+  "live_verification_flac2d_9": "Live FLAC2D 9 re-check (2026-08-13): 'structure liner property' enumerates the full documented 2D set (section props incl. spacing + all 12 coupling-*/-2 keywords + slide/slide-tolerance); 'thickness' and 'thermal-expansion' confirmed absent. shell/geogrid/dowel/hybrid rejections reproduced verbatim. 2D liner also exposes 'cmodel' with the 5 beam-family models — see structure-cmodels.json."
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/link.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/link.json
@@ -22,7 +22,8 @@
       "notes": [
         "'structure link property' is followed by a DOF selector, then per-DOF sub-keywords. FLAC3D 9.7 live enumeration: DOF selectors are x, y, z, rotation-x, rotation-y, rotation-z (no bare 'rotation' in 3D); per-DOF sub-keywords are area, cohesion, for-structure-type, friction, gap, stiffness.",
         "FLAC2D nodes have 3 DOFs: x, y, rotation. FLAC3D uses the 6-DOF selector set above.",
-        "'structure link' subcommands (FLAC3D 9.7 live enumeration): attach, create, delete, dynamic-damping, group, hide, history, list, property, select, slide, tolerance-contact, tolerance-node, tolerance-slide."
+        "'structure link' subcommands (FLAC3D 9.7 live enumeration): attach, create, delete, dynamic-damping, group, hide, history, list, property, select, slide, tolerance-contact, tolerance-node, tolerance-slide.",
+        "Live FLAC2D 9 (2026-08-13): DOF selectors are exactly x / y / rotation; per-DOF sub-keywords are RICHER than 3D: area, cohesion, cohesion-table, confinement-table, for-structure-type, friction, friction-table, gap, incremental-confinement-flag, perimeter, stiffness (11 vs the 6 in FLAC3D 9.7)."
       ]
     }
   ],

--- a/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/structure-cmodels.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/structural-properties/structure-cmodels.json
@@ -1,36 +1,174 @@
 {
   "name": "structure-cmodels",
-  "dimension": "3D",
-  "full_name": "Structural-Element Constitutive Models (FLAC3D 9.x)",
-  "description": "In the 9.x series, structural elements carry their own constitutive models, assigned with 'structure <type> cmodel assign <model>'. The 'structure <type> property' keyword set is MODEL-DEPENDENT: material property names (young, poisson, cohesion, ...) only parse after the corresponding cmodel is assigned, on top of a fixed per-type base set (thickness, density, coupling-*, ...). All facts below were live-verified against FLAC3D 9.7 (error-enumeration probing plus set-and-list readback).",
+  "dimension": "mixed",
+  "full_name": "Structural-Element Constitutive Models (9.x, FLAC3D and FLAC2D)",
+  "description": "In the 9.x series (both FLAC3D and FLAC2D), structural elements carry their own constitutive models, assigned with 'structure <type> cmodel assign <model>'. The 'structure <type> property' keyword set is MODEL-DEPENDENT: material property names (young, poisson, cohesion, ...) only parse after the corresponding cmodel is assigned, on top of a fixed per-type base set (thickness, density, coupling-*, ...). All facts below were live-verified against FLAC3D 9.7 (error-enumeration probing plus set-and-list readback).",
   "cmodel_support_by_type": {
-    "shell": ["anisotropic", "concrete", "elastic", "mohr-coulomb", "orthotropic", "strain-softening", "von-mises"],
-    "liner": ["anisotropic", "concrete", "elastic", "mohr-coulomb", "orthotropic", "strain-softening", "von-mises"],
-    "geogrid": ["anisotropic", "concrete", "elastic", "mohr-coulomb", "orthotropic", "strain-softening", "von-mises"],
-    "beam": ["concrete", "elastic", "mohr-coulomb", "strain-softening", "von-mises"],
-    "pile": ["concrete", "elastic", "mohr-coulomb", "strain-softening", "von-mises"],
+    "shell": [
+      "anisotropic",
+      "concrete",
+      "elastic",
+      "mohr-coulomb",
+      "orthotropic",
+      "strain-softening",
+      "von-mises"
+    ],
+    "liner": [
+      "anisotropic",
+      "concrete",
+      "elastic",
+      "mohr-coulomb",
+      "orthotropic",
+      "strain-softening",
+      "von-mises"
+    ],
+    "geogrid": [
+      "anisotropic",
+      "concrete",
+      "elastic",
+      "mohr-coulomb",
+      "orthotropic",
+      "strain-softening",
+      "von-mises"
+    ],
+    "beam": [
+      "concrete",
+      "elastic",
+      "mohr-coulomb",
+      "strain-softening",
+      "von-mises"
+    ],
+    "pile": [
+      "concrete",
+      "elastic",
+      "mohr-coulomb",
+      "strain-softening",
+      "von-mises"
+    ],
     "cable": [],
     "notes": [
       "beam/pile omit the anisotropic/orthotropic surface models (1D elements).",
       "cable has NO cmodel subcommand at all ('structure cable cmodel' is rejected with 'Unused extra parameter'); cable material behavior is fully driven by its fixed property set.",
-      "'structure <type> cmodel' subcommands: assign, list, plastic-integration."
+      "'structure <type> cmodel' subcommands: assign, list, plastic-integration.",
+      "FLAC2D 9 (live-verified 2026-08-13): beam, pile, AND liner each expose the same 5-model set (concrete/elastic/mohr-coulomb/strain-softening/von-mises) — the 2D liner is beam-formulation, so it gets the 1D model set, not the 7-model surface set. cable has no cmodel in 2D either. shell/geogrid/dowel/hybrid types do not exist in 2D."
     ]
   },
   "assignment_trap": {
-    "description": "Once an elastic-family model (elastic/anisotropic/orthotropic) has been explicitly assigned, reassigning a PLASTIC model (concrete/mohr-coulomb/strain-softening/von-mises) to the same elements is rejected: 'Cannot replace an elastic model with a plastic model'. The reverse direction (plastic -> elastic) IS accepted, as are swaps within the elastic family. Freshly created elements (default state, no explicit assign yet) accept any model.",
+    "description": "On FLAC3D 9.7 shell and liner elements: once an elastic-family model (elastic/anisotropic/orthotropic) has been explicitly assigned, reassigning a PLASTIC model (concrete/mohr-coulomb/strain-softening/von-mises) to the same elements is rejected: 'Cannot replace an elastic model with a plastic model'. The reverse direction (plastic -> elastic) IS accepted, as are swaps within the elastic family. Freshly created elements (default state, no explicit assign yet) accept any model.",
     "workaround": "Assign the plastic model first on fresh elements, or delete and recreate the elements ('structure <type> delete' then create).",
-    "verified": "Reproduced on both shell and liner elements against FLAC3D 9.7."
+    "verified": "Reproduced on FLAC3D 9.7 shell and liner elements. NOT universal: live FLAC2D 9 beam elements ACCEPT elastic -> von-mises reassignment (2026-08-13). Untested combinations: FLAC3D beam/pile, FLAC2D pile/liner — treat the trap as confirmed for 3D surface elements only."
   },
   "property_sets_by_cmodel": {
     "description": "Full 'structure shell property' keyword enumeration per assigned cmodel (FLAC3D 9.7; 'range' omitted). Each set = the type's base set (density, thermal-expansion, thickness for shell) + the model's material properties. liner/geogrid/beam/pile follow the same expansion pattern on top of their own base sets (spot-verified: liner + elastic adds young, poisson).",
-    "shell_base_no_cmodel": ["density", "thermal-expansion", "thickness"],
-    "elastic": ["density", "poisson", "thermal-expansion", "thickness", "young"],
-    "anisotropic": ["aniso-bend-constants", "aniso-bend-thickness", "aniso-memb-constants", "aniso-memb-thickness", "density", "material-x", "thermal-expansion", "thickness"],
-    "orthotropic": ["density", "material-x", "ortho-bend-constants", "ortho-bend-thickness", "ortho-memb-constants", "ortho-memb-thickness", "thermal-expansion", "thickness"],
-    "mohr-coulomb": ["bulk", "cohesion", "density", "dilation", "flag-brittle", "friction", "plastic-strain", "poisson", "shear", "tension", "thermal-expansion", "thickness", "young"],
-    "strain-softening": ["bulk", "cohesion", "density", "dilation", "flag-brittle", "friction", "length-calibration", "plastic-strain", "poisson", "shear", "strain-shear-plastic", "strain-tension-plastic", "table-cohesion", "table-dilation", "table-friction", "table-tension", "tension", "thermal-expansion", "thickness", "young"],
-    "von-mises": ["bulk", "density", "modulus-plastic", "poisson", "shear", "strength-yield", "thermal-expansion", "thickness", "young"],
-    "concrete": ["bulk", "compression", "compression-d", "compression-energy-fracture", "compression-initial", "compression-length-reference", "compression-strength", "damage", "damage-compression", "damage-tension", "density", "dilation", "poisson", "ratio-biaxial", "shear", "strain-plastic-compression", "strain-plastic-tension", "tension", "tension-d", "tension-energy-fracture", "tension-initial", "tension-length-reference", "tension-recovery", "tension-strength", "thermal-expansion", "thickness", "young"]
+    "shell_base_no_cmodel": [
+      "density",
+      "thermal-expansion",
+      "thickness"
+    ],
+    "elastic": [
+      "density",
+      "poisson",
+      "thermal-expansion",
+      "thickness",
+      "young"
+    ],
+    "anisotropic": [
+      "aniso-bend-constants",
+      "aniso-bend-thickness",
+      "aniso-memb-constants",
+      "aniso-memb-thickness",
+      "density",
+      "material-x",
+      "thermal-expansion",
+      "thickness"
+    ],
+    "orthotropic": [
+      "density",
+      "material-x",
+      "ortho-bend-constants",
+      "ortho-bend-thickness",
+      "ortho-memb-constants",
+      "ortho-memb-thickness",
+      "thermal-expansion",
+      "thickness"
+    ],
+    "mohr-coulomb": [
+      "bulk",
+      "cohesion",
+      "density",
+      "dilation",
+      "flag-brittle",
+      "friction",
+      "plastic-strain",
+      "poisson",
+      "shear",
+      "tension",
+      "thermal-expansion",
+      "thickness",
+      "young"
+    ],
+    "strain-softening": [
+      "bulk",
+      "cohesion",
+      "density",
+      "dilation",
+      "flag-brittle",
+      "friction",
+      "length-calibration",
+      "plastic-strain",
+      "poisson",
+      "shear",
+      "strain-shear-plastic",
+      "strain-tension-plastic",
+      "table-cohesion",
+      "table-dilation",
+      "table-friction",
+      "table-tension",
+      "tension",
+      "thermal-expansion",
+      "thickness",
+      "young"
+    ],
+    "von-mises": [
+      "bulk",
+      "density",
+      "modulus-plastic",
+      "poisson",
+      "shear",
+      "strength-yield",
+      "thermal-expansion",
+      "thickness",
+      "young"
+    ],
+    "concrete": [
+      "bulk",
+      "compression",
+      "compression-d",
+      "compression-energy-fracture",
+      "compression-initial",
+      "compression-length-reference",
+      "compression-strength",
+      "damage",
+      "damage-compression",
+      "damage-tension",
+      "density",
+      "dilation",
+      "poisson",
+      "ratio-biaxial",
+      "shear",
+      "strain-plastic-compression",
+      "strain-plastic-tension",
+      "tension",
+      "tension-d",
+      "tension-energy-fracture",
+      "tension-initial",
+      "tension-length-reference",
+      "tension-recovery",
+      "tension-strength",
+      "thermal-expansion",
+      "thickness",
+      "young"
+    ]
   },
   "enumeration_caveats": [
     "The 'structure <type> property' error enumeration only lists properties valid for the CURRENTLY assigned cmodel -- it is not the union across models. Probing with no elements of the type present enumerates nothing but 'range'.",


### PR DESCRIPTION
Batch 13. With the bridge attached to a live **FLAC2D 9** engine, every FLAC2D-side claim in the references corpus now has direct live evidence — previously many rested on the older FLAC2D 9.0 binary validation or on inference from FLAC3D-side absence.

## Corrections (live 2D contradicted the corpus)

- **`head` is real in current FLAC2D 9** — the "rejected by FLAC2D 9.0" note was version-scoped. It's semantically gated ('Must define fluid density before calculating head'), and **state-verified**: with `zone water density 1000` + `model gravity 10`, `fix head 10` at y=0 reads back pp = 100000 = ρgh.
- **`zone face apply stress-zz/-xz` is rejected by 2D** — moved to `keywords_3d_only`; the plane-strain out-of-plane claim belongs to `zone initialize stress-zz` (state-verified: 'modified in 9 zones').
- **`saturation-apparent` / `fluid-bulk-modulus` removed as field names** — rejected by `zone history` in *both* current engines; they exist only as 2D plot-contour attributes.
- **mobility-coefficient family / porosity / density-wet / oob-flow are not 3D-only** — they enumerate in 2D too (corrects a Batch 12 note).
- **The elastic→plastic cmodel trap is not universal** — 2D beam accepts elastic→von-mises; trap re-scoped to its verified domain (FLAC3D shell/liner).
- **Current 2D sketch has nine subcommands** (the documented six + fracture/joint-set/tessellate); `zone generate` 2D also enumerates `from-topography`.

## Direct confirmations (inference → evidence)

- All four `*-tangential` forms + `stress-shear` enumerate in 2D (dimension split now verified from both sides).
- beam (10/10 exact), pile, cable (incl. `spacing` + `thermal-expansion`), liner (25-keyword set) property enumerations match the corpus exactly.
- **structure cmodel mechanism exists in 2D too**: beam/pile/liner expose the same 5-model set (2D liner is beam-formulation → 1D model set); cable has no cmodel in either engine.
- 2D link per-DOF sub-keywords captured — **richer than 3D**: 11 keywords incl. cohesion-table/confinement-table/friction-table/incremental-confinement-flag/perimeter.
- 2D range-element enumeration captured (46 elements; `circle`/`radius` 2D-only; sphere/cylinder absent).
- `pore-pressure-maximum`/`-saturation`/`head-saturation` enumerate in 2D too — engine-family-wide 9.x features.
- shell/geogrid/dowel/hybrid and building-blocks rejections reproduced verbatim.

Tests: `test_phase2_tools.py` + `test_tool_contracts.py` pass (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)