### PR TITLE
docs: verify FLAC Python SDK docs against live FLAC3D 9.7 introspection (Batch 14)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/index.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/index.json
@@ -92,7 +92,6 @@
         "set_fluid_timestep",
         "set_thermal_time_total",
         "set_thermal_timestep",
-        "thermal_ratio",
         "thermal_time_total",
         "thermal_timestep",
         "unbal"
@@ -156,7 +155,6 @@
         "set_flow",
         "set_fluid_load",
         "set_fluid_modulus",
-        "set_fluid_tension",
         "set_fluid_unbal",
         "set_force_app",
         "set_force_load",
@@ -307,6 +305,20 @@
       "description": "Functions and classes for working with FLAC interface nodes.",
       "file": "flac/python_sdk_docs/modules/interface/node/module.json",
       "functions": []
+    },
+    "zone.field": {
+      "description": "Spatial interpolation queries at arbitrary model points (Python counterpart of FISH zone.field.*)",
+      "file": "flac/python_sdk_docs/modules/zone/field/module.json",
+      "functions": [
+        "get",
+        "get_extra",
+        "get_prop",
+        "get_prop_fluid",
+        "get_prop_thermal",
+        "get_scalar",
+        "get_tensor",
+        "get_vector"
+      ]
     }
   },
   "objects": {
@@ -1046,5 +1058,6 @@
   "fallback_hints": {
     "model solve": "For solving to equilibrium, use itasca.command('model solve'). Python SDK has itasca.cycle() for fixed cycles only.",
     "automatic timestep": "For automatic timestep calculation, use itasca.command('model auto dt'). Python SDK itasca.set_timestep() sets manual values only."
-  }
+  },
+  "live_verification_flac3d_97": "All 12 module units (181 module functions + 327 class methods) diffed against live FLAC3D 9.7 introspection (2026-08-13). Result: exact match everywhere except 7 upstream-documented names the engine does not expose (flagged available_in_flac3d_97=false in their files): gridpointarray.set_fluid_tension, zone.thermal_ratio, Gridpoint.set_biot_modulus, Gridpoint.set_fluid_modulus, interface Element.join, Zone.fluid_model, Zone.set_fluid_model. itasca.zone.field added from live signatures."
 }

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/gridpoint/Gridpoint.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/gridpoint/Gridpoint.json
@@ -701,7 +701,7 @@
     {
       "name": "set_biot_modulus",
       "signature": "gridpoint.set_biot_modulus(value: float) -> None",
-      "description": "Set the gridpoint fluid Biot modulus.",
+      "description": "Set the gridpoint fluid Biot modulus. NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it. Set Biot modulus via the command layer instead ('zone gridpoint initialize biot').",
       "parameters": [
         {
           "name": "value",
@@ -711,7 +711,8 @@
       ],
       "returns": {
         "type": "None"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "set_disp",
@@ -906,7 +907,7 @@
     {
       "name": "set_fluid_modulus",
       "signature": "gridpoint.set_fluid_modulus(value: float) -> None",
-      "description": "Set the gridpoint gridpoint fluid bulk modulus.",
+      "description": "Set the gridpoint gridpoint fluid bulk modulus. NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it. Use itasca.gridpointarray.set_fluid_modulus() (array level, which DOES exist) or 'zone gridpoint initialize fluid-modulus'.",
       "parameters": [
         {
           "name": "value",
@@ -916,7 +917,8 @@
       ],
       "returns": {
         "type": "None"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "set_fluid_tension",

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/gridpointarray/module.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/gridpointarray/module.json
@@ -414,7 +414,7 @@
     {
       "name": "set_fluid_tension",
       "signature": "itasca.gridpointarray.set_fluid_tension(array double{gridpoint,3}) -> None",
-      "description": "Set the fluid tension at each gridpoint with a NumPy array.",
+      "description": "Set the fluid tension at each gridpoint with a NumPy array. NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it. Per-gridpoint Gridpoint.set_fluid_tension() DOES exist — only the array-level form is missing.",
       "parameters": [
         {
           "name": "array double{gridpoint",
@@ -427,7 +427,8 @@
       ],
       "returns": {
         "type": "None"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "set_fluid_unbal",

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/interface/element/Element.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/interface/element/Element.json
@@ -139,7 +139,7 @@
     {
       "name": "join",
       "signature": "interface.element.join(i: int) -> Interface pointer",
-      "description": "Get the pointer to the adjacent interface element joined across edge i for 3D (i = 1,2,3) pr node i for 2D (i = 1,2).",
+      "description": "Get the pointer to the adjacent interface element joined across edge i for 3D (i = 1,2,3) pr node i for 2D (i = 1,2). NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it.",
       "parameters": [
         {
           "name": "i",
@@ -149,7 +149,8 @@
       ],
       "returns": {
         "type": "Interface pointer"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "node",

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/vertexarray/module.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/vertexarray/module.json
@@ -1,6 +1,6 @@
 {
   "module": "itasca.vertexarray",
-  "description": "Array interface for Itasca wall vertices.",
+  "description": "Array interface for Itasca wall vertices. NOTE (live-verified FLAC3D 9.7, 2026-08-13): the 'wall vertices' wording is the PFC concept — this module is exposed through the unified 9.x kernel and is always EMPTY in FLAC3D (pos() returns shape (0,3) even with interfaces present; FLAC has no walls). Interface element 'vertices' are interface Nodes (interface Element.vertex(i) returns an itasca.interface.Node), not entries in this array.",
   "import_statement": "import itasca",
   "source_url": "https://docs.itascacg.com/itasca900/common/docproject/source/manual/scripting/python/doc/itasca.vertexarray.html",
   "functions": [

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/zone/Zone.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/zone/Zone.json
@@ -466,10 +466,11 @@
     {
       "name": "fluid_model",
       "signature": "zone.fluid_model() -> str",
-      "description": "Get the fluid flow constitituve model for the zone.",
+      "description": "Get the fluid flow constitituve model for the zone. NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it. Query/assign the fluid constitutive model via the command layer ('zone fluid cmodel'); fluid_prop()/set_fluid_prop() DO exist for properties.",
       "returns": {
         "type": "str"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "fluid_prop",
@@ -873,7 +874,7 @@
     {
       "name": "set_fluid_model",
       "signature": "zone.set_fluid_model(model: str) -> None",
-      "description": "Set the fluid flow constitituve model for the zone. The currently available constitutive models are anisotropic, isotropic, and null.",
+      "description": "Set the fluid flow constitituve model for the zone. The currently available constitutive models are anisotropic, isotropic, and null. NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it. Assign via 'zone fluid cmodel assign'; fluid_prop()/set_fluid_prop() DO exist for properties.",
       "parameters": [
         {
           "name": "model",
@@ -883,7 +884,8 @@
       ],
       "returns": {
         "type": "None"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "set_fluid_prop",

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/zone/field/module.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/zone/field/module.json
@@ -1,0 +1,76 @@
+{
+  "module": "itasca.zone.field",
+  "description": "Spatial-interpolation queries over the zone/gridpoint fields: get scalar/vector/tensor values at arbitrary model-space points (not necessarily on gridpoints). This is the Python counterpart of the FISH zone.field.* family, but exposed as pure functions taking the field name and location per call (no persistent zone.field.name state to set). Signatures captured from live FLAC3D 9.7 docstrings (2026-08-13). Common optional kwargs (defaults): method='constant' (interpolation method), hide_null=False, fill_value=0.0, skip_init=False, radius_ratio=0.75, log=False, source='gridpoint', tolerance=1e-7.",
+  "import_statement": "import itasca",
+  "source_url": "https://docs.itascacg.com/itasca900/flac3d/docproject/source/manual/scripting/python/doc/itasca.zone.field.html",
+  "functions": [
+    {
+      "name": "get",
+      "signature": "itasca.zone.field.get(name: str, location: vec, method='constant', hide_null=False, fill_value=0.0, skip_init=False, radius_ratio=0.75, log=False, source='gridpoint', quantity='norm', component='magnitude', tolerance=1e-7) -> float",
+      "description": "Get an interpolated value from the zones. 'name' is a zone field name (see the zone-field-data reference); tensor/vector fields are reduced via 'quantity'/'component'.",
+      "returns": {
+        "type": "float"
+      }
+    },
+    {
+      "name": "get_scalar",
+      "signature": "itasca.zone.field.get_scalar(name: str, location: vec, ..., quantity='norm', component='magnitude', tolerance=1e-7) -> float",
+      "description": "Get an interpolated scalar value from the zones (same argument set as get()).",
+      "returns": {
+        "type": "float"
+      }
+    },
+    {
+      "name": "get_vector",
+      "signature": "itasca.zone.field.get_vector(name: str, location: vec, ..., tolerance=1e-7) -> vec3",
+      "description": "Get an interpolated vector from the zones.",
+      "returns": {
+        "type": "vec3"
+      }
+    },
+    {
+      "name": "get_tensor",
+      "signature": "itasca.zone.field.get_tensor(name: str, location: vec, ..., tolerance=1e-7) -> sten3",
+      "description": "Get an interpolated symmetric tensor from the zones.",
+      "returns": {
+        "type": "sten3"
+      }
+    },
+    {
+      "name": "get_extra",
+      "signature": "itasca.zone.field.get_extra(extra: int, location: vec, ..., tolerance=1e-7) -> float",
+      "description": "Get an interpolated value from the gridpoint or zone extra variable at the given index.",
+      "returns": {
+        "type": "float"
+      }
+    },
+    {
+      "name": "get_prop",
+      "signature": "itasca.zone.field.get_prop(prop: str, location: vec, ..., tolerance=1e-7) -> float",
+      "description": "Get an interpolated value of a mechanical (constitutive-model) property.",
+      "returns": {
+        "type": "float"
+      }
+    },
+    {
+      "name": "get_prop_fluid",
+      "signature": "itasca.zone.field.get_prop_fluid(prop: str, location: vec, ..., tolerance=1e-7) -> float",
+      "description": "Get an interpolated value of a fluid property.",
+      "returns": {
+        "type": "float"
+      }
+    },
+    {
+      "name": "get_prop_thermal",
+      "signature": "itasca.zone.field.get_prop_thermal(prop: str, location: vec, ..., tolerance=1e-7) -> float",
+      "description": "Get an interpolated value of a thermal property.",
+      "returns": {
+        "type": "float"
+      }
+    }
+  ],
+  "notes": [
+    "All eight functions and their signatures verified against live FLAC3D 9.7 (__doc__ introspection).",
+    "The FISH-style stateful API (zone.field.name = ...; zone.field.get(pos)) documented in the fish-intrinsics/field-query reference is the FISH surface; the Python surface is stateless."
+  ]
+}

--- a/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/zone/module.json
+++ b/src/itasca_mcp/knowledge/resources/flac/python_sdk_docs/modules/zone/module.json
@@ -353,10 +353,11 @@
     {
       "name": "thermal_ratio",
       "signature": "itasca.zone.thermal_ratio() -> float",
-      "description": "Get the current thermal convergence ratio for zones. This is defined as the ratio of total unbalanced heat flow to the total heat flow through the zones.",
+      "description": "Get the current thermal convergence ratio for zones. This is defined as the ratio of total unbalanced heat flow to the total heat flow through the zones. NOT AVAILABLE in FLAC3D 9.7: live introspection (dir() + hasattr on real objects, 2026-08-13) shows the engine does not expose this name even though the official 9.x documentation lists it.",
       "returns": {
         "type": "float"
-      }
+      },
+      "available_in_flac3d_97": false
     },
     {
       "name": "thermal_time_total",


### PR DESCRIPTION
Systematic pass over all 12 `python_sdk_docs` module units — every documented name (181 module functions + 327 class methods) diffed against live FLAC3D 9.7 `dir()` dumps, with `hasattr` confirmation on real Zone/Gridpoint objects for the discrepancies.

## Result: corpus is an exact match except 7 fictional names

All flagged `available_in_flac3d_97: false` with working alternatives noted:

| Name | Alternative |
|------|-------------|
| `gridpointarray.set_fluid_tension` | per-gp `Gridpoint.set_fluid_tension()` exists |
| `zone.thermal_ratio` | — |
| `Gridpoint.set_biot_modulus` | `zone gridpoint initialize biot` |
| `Gridpoint.set_fluid_modulus` | `gridpointarray.set_fluid_modulus()` exists |
| interface `Element.join` | — |
| `Zone.fluid_model` / `set_fluid_model` | `zone fluid cmodel` command; `fluid_prop`/`set_fluid_prop` exist |

## New: `itasca.zone.field` module (P2 checklist item)

The 13th official module was missing from the corpus. Documented from live `__doc__` introspection: 8 spatial-interpolation functions (`get`, `get_scalar`, `get_vector`, `get_tensor`, `get_extra`, `get_prop`, `get_prop_fluid`, `get_prop_thermal`) with full signatures and the common kwargs set. Notably the Python surface is **stateless** (name + location per call), unlike the stateful FISH `zone.field.*` family.

## `vertexarray` P3 resolved

Live test: the module is the PFC wall-vertex array exposed through the unified kernel — always empty in FLAC3D (`pos()` shape `(0,3)` even with interfaces present). Interface element 'vertices' are actually interface **Nodes** (`Element.vertex(i)` returns `itasca.interface.Node`). Clarifying note added.

Tests: `test_phase2_tools.py` + `test_tool_contracts.py` pass (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)