### PR TITLE
docs: structure command family deep pass against live FLAC3D 9.7 (Batch 15)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/beam-history.json
@@ -160,7 +160,8 @@
           "syntax": "position <v>",
           "description": "the particular element is identified by ( v ) coordinates (the nearest element is taken). If this keyword is used, component-id should not be used."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/cable-history.json
@@ -140,7 +140,8 @@
           "syntax": "position <v>",
           "description": "the particular element is identified by ( v ) coordinates (the nearest element is taken). If this keyword is used, component-id should not be used."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/geogrid-history.json
@@ -390,7 +390,8 @@
           "syntax": "surface-x <v>",
           "description": "the surface-x vector whose projection onto the element plane defines the x-direction of the surface coordinate system (see the structure geogrid recover surface command). If this keyword is specified, then the surface coordinate system of the three nodes used by the element will be modified."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/hybrid-history.json
@@ -73,7 +73,7 @@
         {
           "name": "component-id",
           "syntax": "component-id i",
-          "description": "the particular element is identified by the component ID number. This could refer to a \u201ccable\u201d element or a dowel. If this keyword is used, position should not be used."
+          "description": "the particular element is identified by the component ID number. This could refer to a “cable” element or a dowel. If this keyword is used, position should not be used."
         },
         {
           "name": "end",
@@ -82,7 +82,7 @@
         {
           "name": "position",
           "syntax": "position v",
-          "description": "the particular element is identified by (v) coordinates (the nearest element is taken). This could apply to a \u201ccable\u201d element or dowel, depending on what history quantitiy is being queried. If this keyword is used, component-id should not be used."
+          "description": "the particular element is identified by (v) coordinates (the nearest element is taken). This could apply to a “cable” element or dowel, depending on what history quantitiy is being queried. If this keyword is used, component-id should not be used."
         },
         {
           "name": "name",
@@ -167,7 +167,7 @@
         {
           "name": "component-id",
           "syntax": "component-id <i>",
-          "description": "the particular element is identified by the component ID number. This could refer to a \u201ccable\u201d element or a dowel. If this keyword is used, position should not be used."
+          "description": "the particular element is identified by the component ID number. This could refer to a “cable” element or a dowel. If this keyword is used, position should not be used."
         },
         {
           "name": "end",
@@ -177,9 +177,10 @@
         {
           "name": "position",
           "syntax": "position <v>",
-          "description": "the particular element is identified by ( v ) coordinates (the nearest element is taken). This could apply to a \u201ccable\u201d element or dowel, depending on what history quantitiy is being queried. If this keyword is used, component-id should not be used."
+          "description": "the particular element is identified by ( v ) coordinates (the nearest element is taken). This could apply to a “cable” element or dowel, depending on what history quantitiy is being queried. If this keyword is used, component-id should not be used."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/liner-history.json
@@ -420,7 +420,8 @@
           "syntax": "surface-x <v>",
           "description": "the surface-x vector whose projection onto the element plane defines the x-direction of the surface coordinate system (see the structure liner recover surface command). If this keyword is specified, then the surface coordinate system of the three nodes used by the element will be modified."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/link-history.json
@@ -200,7 +200,8 @@
           "syntax": "side <i>",
           "description": "Specify which side of the node indicated in position should be used to find the link. By default, side 1 is used."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-apply.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-apply.json
@@ -131,7 +131,7 @@
         {
           "name": "remove",
           "syntax": "remove keyword",
-          "description": "Remove an existing applied force/moment from nodes in the range. Sub-keywords: force, moment."
+          "description": "Remove an existing applied condition from nodes in the range. Sub-keywords (live-enumerated, FLAC3D 9.7): force, force-edge, moment. TRAP: a bare 'remove' (or one followed by an invalid token) EXECUTES immediately with the default (force) before any error is raised — observed 'Force removed from 13 nodes' on a bogus trailing token."
         },
         {
           "name": "remove-force",
@@ -146,7 +146,7 @@
         {
           "name": "system",
           "syntax": "system keyword",
-          "description": "Set the coordinate system in which the applied force/moment is interpreted. Sub-keywords: local, global."
+          "description": "Set the coordinate system in which the applied force/moment is interpreted. Sub-keywords (live-enumerated, FLAC3D 9.7): global, local. TRAP: a bare 'system' (or one followed by an invalid token) executes and assigns the default before erroring — observed 'System assigned to 13 nodes'."
         },
         {
           "name": "system-local",
@@ -163,7 +163,8 @@
           "syntax": "range ...",
           "description": "Range block selecting which nodes the apply condition is applied to."
         }
-      ]
+      ],
+      "description": "Apply concentrated conditions (force, edge force, moment) at structural nodes. Keyword shapes live-verified against FLAC3D 9.7: first-token enumeration is force / force-edge / moment / remove / system (+ range); add|multiply are position-2 modifiers after the value."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-history.json
@@ -355,7 +355,8 @@
           "syntax": "position <v>",
           "description": "the particular node is identified by ( v ) coordinates (the nearest node is taken). If this keyword is used, component-id should not be used."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-initialize.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/node-initialize.json
@@ -324,7 +324,8 @@
           "syntax": "acceleration-rotational-z <f>",
           "description": "initialize the z-component of rotational acceleration at nodes in the range"
         }
-      ]
+      ],
+      "description": "Modifiers add / multiply / gradient <v> / vary <v> / local are accepted after the value and execute ('velocity-x adjusted in 13 nodes') but are ENUMERATION-INVISIBLE — they never appear in the parser's keyword error listing (same false-positive family as zone gridpoint initialize biot). State-verified against FLAC3D 9.7."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/pile-history.json
@@ -220,7 +220,8 @@
           "syntax": "position <v>",
           "description": "the particular element is identified by ( v ) coordinates (the nearest element is taken). If this keyword is used, component-id should not be used."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-history.json
+++ b/src/itasca_mcp/knowledge/resources/flac/command_docs/commands/structure/shell-history.json
@@ -360,7 +360,8 @@
           "syntax": "surface-x <v>",
           "description": "the surface-x vector whose projection onto the element plane defines the x-direction of the surface coordinate system (see the structure shell recover surface command). If this keyword is specified, then the surface coordinate system of the three nodes used by the element will be modified."
         }
-      ]
+      ],
+      "description": "ELEMENT SPEC REQUIRED: after the quantity keyword, the target must be identified with 'component-id <i>' or 'position <v>' — otherwise the engine rejects with 'Must specify an element, by component-id or position.' Verified live against FLAC3D 9.7 (beam and shell families; both forms created histories)."
     }
   }
 }

--- a/src/itasca_mcp/knowledge/resources/flac/references/plot-items/flac3d-items.json
+++ b/src/itasca_mcp/knowledge/resources/flac/references/plot-items/flac3d-items.json
@@ -7,9 +7,8 @@
     "types": [
       "structure-beam",
       "structure-cable (verified identical)",
-      "structure-pile",
-      "structure-dowel",
-      "structure-hybrid (untested, by family analogy)"
+      "structure-pile (verified identical, 2026-08-13)",
+      "structure-hybrid (verified identical, 2026-08-13)"
     ],
     "keywords": [
       "Bar",
@@ -34,7 +33,8 @@
     ],
     "notes": [
       "'Bar', 'BarScale' and 'FlipBars' are CamelCase keywords leaked from internal property names; 'Bar' takes a boolean. They are real, accepted keywords in 9.7.",
-      "'contour <attribute>' accepts the beam-family attribute set including 3D-only -z / angular / plastic entries (see structure/contour.json)."
+      "'contour <attribute>' accepts the beam-family attribute set including 3D-only -z / angular / plastic entries (see structure/contour.json).",
+      "structure-dowel REMOVED from this family (2026-08-13): live '?' enumeration shows it has its own keyword set (no Bar/BarScale/FlipBars/line; six unique keywords) — see the structure-dowel item entry."
     ]
   },
   "items": {
@@ -362,6 +362,80 @@
         "polygons",
         "text",
         "transparency"
+      ]
+    },
+    "structure-liner": {
+      "keywords": [
+        "active",
+        "clip",
+        "color-list",
+        "contour",
+        "cut",
+        "deformation-factor",
+        "label",
+        "legend",
+        "map",
+        "marker",
+        "polygons",
+        "range",
+        "shrink",
+        "slot",
+        "system",
+        "transparency"
+      ],
+      "notes": [
+        "Shell-flavor set plus 'polygons'. Live '?' enumeration, FLAC3D 9.7 (2026-08-13); previously asserted by family analogy only."
+      ]
+    },
+    "structure-geogrid": {
+      "keywords": [
+        "active",
+        "clip",
+        "color-list",
+        "contour",
+        "cut",
+        "deformation-factor",
+        "label",
+        "legend",
+        "map",
+        "marker",
+        "polygons",
+        "range",
+        "shrink",
+        "slot",
+        "system",
+        "transparency"
+      ],
+      "notes": [
+        "Identical to structure-liner (shell-flavor + polygons). Live '?' enumeration, FLAC3D 9.7 (2026-08-13)."
+      ]
+    },
+    "structure-dowel": {
+      "keywords": [
+        "active",
+        "clip",
+        "color-list",
+        "contour",
+        "cut",
+        "deformation-factor",
+        "doweloffset",
+        "label",
+        "legend",
+        "length-scale",
+        "map",
+        "marker",
+        "minval",
+        "offsetnormal",
+        "range",
+        "shrink",
+        "slot",
+        "system",
+        "transparency",
+        "usesminval",
+        "width-scale"
+      ],
+      "notes": [
+        "UNIQUE set — NOT beam-family despite being a 1D element type: no Bar/BarScale/FlipBars/line; six dowel-specific keywords (doweloffset, length-scale, minval, offsetnormal, usesminval, width-scale — several are leaked internal names, really accepted). Live '?' enumeration, FLAC3D 9.7 (2026-08-13). The prior family-analogy assertion was wrong for this type."
       ]
     }
   },


### PR DESCRIPTION
Closes out the last big not-yet-started checklist block (structure command family, 131 files). The sweep already gave every file a first-token verdict; this batch audits the keyword layer and live-verifies what the sweep could not reach.

Keyword-layer audit: re-diffing the 69 enumerable structure commands against the current corpus leaves zero real keyword gaps (property diffs = no-elements enumeration artifact, already verified in Batch 11; cmodel/create/history = corpus flattening; adummy already fixed).

Live-verified additions:
- History files (9): quantity keyword must be followed by 'component-id <i>' or 'position <v>'; both forms state-verified on beam and shell families; shell 29-token quantity set captured.
- node-apply: remove sub-keywords are force/force-edge/moment; bare remove/system execute with defaults before erroring (trap documented).
- node-initialize: add/multiply/gradient/vary/local execute but are enumeration-invisible.
- Plot follow-up closed: structure-pile/-hybrid identical to beam family; structure-liner/-geogrid captured (shell-flavor + polygons); structure-dowel analogy claim was WRONG - own 21-keyword set. Three new flac3d-items.json entries.

Tests: test_phase2_tools.py + test_tool_contracts.py pass (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)