### PR TITLE
docs: value-then-probe pass over 3DEC positional/no-enum corpus (Batch 7)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/contact-compute.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/contact-compute.json
@@ -5,7 +5,7 @@
     "contact",
     "compute"
   ],
-  "description": "Compute joint statistics. Various density measures of fractures, filtered by range, can be computed.",
+  "description": "Compute joint statistics. Various density measures of fractures, filtered by range, can be computed. Live 9.7 continuation slot also offers DFN-style fracture statistics (average-trace-length, p10/p20/p21/p30/p32/p33) alongside the documented center-density/mass-density/percolation/trace-* measures.",
   "python_sdk_alternative": {
     "available": false
   },
@@ -73,6 +73,41 @@
           "name": "percolation",
           "syntax": "percolation",
           "description": "Synonym for P33 ."
+        },
+        {
+          "name": "average-trace-length",
+          "syntax": "average-trace-length",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-network statistic computed over subcontacts."
+        },
+        {
+          "name": "p10",
+          "syntax": "p10",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-intensity measure P10 (count per length)."
+        },
+        {
+          "name": "p20",
+          "syntax": "p20",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-intensity measure P20 (count per area)."
+        },
+        {
+          "name": "p21",
+          "syntax": "p21",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-intensity measure P21 (length per area)."
+        },
+        {
+          "name": "p30",
+          "syntax": "p30",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-intensity measure P30 (count per volume)."
+        },
+        {
+          "name": "p32",
+          "syntax": "p32",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-intensity measure P32 (area per volume)."
+        },
+        {
+          "name": "p33",
+          "syntax": "p33",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fracture-intensity measure P33 (volume per volume)."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/contact-group-subcontact.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/contact-group-subcontact.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "block contact group-subcontact",
       "syntax": "block contact group-subcontact <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/contact-group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/contact-group.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "block contact group",
       "syntax": "block contact group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/cut.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/cut.json
@@ -4,7 +4,7 @@
     "block",
     "cut"
   ],
-  "description": "Cut a block. This command generates one set of discontinuities, according to the parameters specified by the following keywords. Blocks are split completely (i.e., no partial cracks are allowed).",
+  "description": "Cut a block. This command generates one set of discontinuities, according to the parameters specified by the following keywords. Blocks are split completely (i.e., no partial cracks are allowed). Live 9.7 first slot: dfn geometry joint-set jointset-id range set tunnel.",
   "python_sdk_alternative": {
     "available": false
   },
@@ -42,6 +42,26 @@
           "name": "x-local",
           "syntax": "x-local <v>",
           "description": "Method 1: Create a tunnel between the two faces defined by the keywords face-1 and face-2 . The shape of the tunnel face is prescribed by an arbitrary number of vertices with coordinates va1 , va2 , va3 , etc. Straight lines between the vertices (in their respective order as listed) connect the two faces to define the tunnel boundary. The same number of vertices must exist on both faces, which may be positioned either inside or outside the model. Method 2: Create a tunnel between the two tables defined by the keywords table-1 and table-2 . The same procedure for creation of the tunnel applies: points in respective order on each table are connected by straight lines that define the tunnel boundary, etc. The orientation of the tables in the third dimension is determined using the axis keyword. Define a tunnel face with three to n vertices. If continuations (&) are used for long input lines of vertices, do not split the values of a v across lines. Define a corresponding tunnel face with the same number of vertices as supplied for face-1 . Cause the cuts used for the tunnel shape to be radial to the center rather than tangential to the tunnel edges. Note: The apparent extra cut through the model occurs because any single cut must pass entirely through a block. Thus the first cut passing through the first vertex cuts through both sides of the tunnel outline. Assign a specific group name (and, optionally, slot) to the blocks within the defined tunnel region. Orient the tunnel to be created using table-1 and table-2 along the axis defined by v1 and v2 . Specify a table to be used as the first tunnel face. Specify a table to be used as the second tunnel face. Specify the local x-axis if faces are defined with tables. The local y-axis will be the cross product of the local x-axis and the tunnel axis."
+        },
+        {
+          "name": "dfn",
+          "syntax": "dfn <name/keyword> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Cut along a discrete fracture network."
+        },
+        {
+          "name": "joint-set",
+          "syntax": "joint-set <keyword> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Cut a joint set (the documented dip/dip-direction/origin/id/spacing/... keywords are sub-keywords of this slot)."
+        },
+        {
+          "name": "set",
+          "syntax": "set",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Alias/related form of joint-set (live-enumerated at the first slot)."
+        },
+        {
+          "name": "tunnel",
+          "syntax": "tunnel",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Tunnel-shaped cut."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/export.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/export.json
@@ -12,7 +12,18 @@
     "9.0": {
       "command": "block export",
       "syntax": "block export filename <s>[binary] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "filename",
+          "syntax": "filename <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Output file name."
+        },
+        {
+          "name": "format",
+          "syntax": "format <keyword>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Output format selector."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/face-group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/face-group.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "block face group",
       "syntax": "block face group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/face-list.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/face-list.json
@@ -53,6 +53,11 @@
           "name": "vertices",
           "syntax": "vertices",
           "description": "List the vertices that make up the faces in the range."
+        },
+        {
+          "name": "rigid",
+          "syntax": "rigid",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. List rigid-face information."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/fluid.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/fluid.json
@@ -4,7 +4,7 @@
     "block",
     "fluid"
   ],
-  "description": "Specify configuration for flow calculations.",
+  "description": "Specify configuration for flow calculations. Live 9.7 first slot: active allow-largestrain bh-heal-ini crack-flow datum fast-flow gas jointflow-substep list matrix-flow property proppant sync-mech tension timestep timestep-multiplier timestep-update - identical with and without 'model configure fluid-flow' (context-free).",
   "python_sdk_alternative": {
     "available": false
   },
@@ -82,6 +82,41 @@
           "name": "timestep-update",
           "syntax": "timestep-update <i>",
           "description": "Specify the interval at which fluid timestep is recalculated. By default, \\(i\\) = 1, so that the timesep is recalculated every fluid step."
+        },
+        {
+          "name": "allow-largestrain",
+          "syntax": "allow-largestrain",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Allow joint fluid flow with large strain."
+        },
+        {
+          "name": "bh-heal-ini",
+          "syntax": "bh-heal-ini",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Borehole heal initialization control."
+        },
+        {
+          "name": "fast-flow",
+          "syntax": "fast-flow",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fast-flow scheme toggle."
+        },
+        {
+          "name": "gas",
+          "syntax": "gas",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Gas-flow settings."
+        },
+        {
+          "name": "property",
+          "syntax": "property <keyword> <value> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fluid property assignment (the documented relaxation/viscosity/density-minimum/permeability-factor keywords are sub-keywords of this slot)."
+        },
+        {
+          "name": "proppant",
+          "syntax": "proppant",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Proppant transport settings."
+        },
+        {
+          "name": "timestep-multiplier",
+          "syntax": "timestep-multiplier <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fluid timestep multiplier."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/generate.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/generate.json
@@ -4,7 +4,7 @@
     "block",
     "generate"
   ],
-  "description": "Generate an assembly of blocks. The method for block creation is determined by the first keyword used.",
+  "description": "Generate an assembly of blocks. The method for block creation is determined by the first keyword used. Live 9.7 first slot: from-geometry from-topography from-vrml voronoi (the documented filename/set/segments keywords are sub-keywords of these forms).",
   "python_sdk_alternative": {
     "available": false
   },
@@ -32,6 +32,26 @@
           "name": "set",
           "syntax": "set <s>",
           "description": "Create Voronoi blocks to fill a closed volume defined by a geometric set (restricted surface). Threshold angle for the capture of surface features. The default value is 45°. Use a larger cut angle smooth over unwanted surface features associated with the coarseness of the triangulation. Use a smaller cut angle if there are intersecting surfaces after surface remeshing. Rate at which, on the restricted surface, distance between two seeds vary (increase or decrease) in size due to local size adaptation Rate at which distance between two seeds will increase in size away from the restricted surface. Specify the maximum distance between two seeds. The actual maximum distance will be close to this, but the result is not guaranteed to be exact. Specify the minimum distance between two seeds. The actual minimum distance will be close to this, but the result is not guaranteed to be exact. Specify the geometry set used to define the restricted surface. By default, the current geometric set will be used."
+        },
+        {
+          "name": "from-geometry",
+          "syntax": "from-geometry <keyword> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Generate blocks from a geometry set."
+        },
+        {
+          "name": "from-topography",
+          "syntax": "from-topography <keyword> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Generate blocks from topography data."
+        },
+        {
+          "name": "from-vrml",
+          "syntax": "from-vrml <keyword> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Generate blocks from a VRML file."
+        },
+        {
+          "name": "voronoi",
+          "syntax": "voronoi <keyword> ...",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Generate a Voronoi block assembly."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/gridpoint-group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/gridpoint-group.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "block gridpoint group",
       "syntax": "block gridpoint group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/import.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/import.json
@@ -12,7 +12,13 @@
     "9.0": {
       "command": "block import",
       "syntax": "block import filename <s>[binary]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "filename",
+          "syntax": "filename <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Input file name."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/list.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/list.json
@@ -207,6 +207,31 @@
           "name": "zone-id",
           "syntax": "zone-id <i>",
           "description": "Specifies the location of the history is at the centroid of zone with ID i ."
+        },
+        {
+          "name": "condition",
+          "syntax": "condition",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. List block condition codes."
+        },
+        {
+          "name": "details",
+          "syntax": "details",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Detailed per-block listing."
+        },
+        {
+          "name": "flaw",
+          "syntax": "flaw",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. List flaws."
+        },
+        {
+          "name": "maxima",
+          "syntax": "maxima",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. List maximum values."
+        },
+        {
+          "name": "profile",
+          "syntax": "profile",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. List a profile of block quantities."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/merge-start.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/merge-start.json
@@ -12,7 +12,18 @@
     "9.0": {
       "command": "block merge-start",
       "syntax": "block merge-start [slot <s>] [exclude <s1>[<s2>[...] ]]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "exclude",
+          "syntax": "exclude",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Exclude entities from the merge session."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Group slot used by the merge session."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/to-flac3d.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/to-flac3d.json
@@ -26,7 +26,17 @@
         {
           "name": "block-id",
           "syntax": "block-id <b>",
-          "description": "Set b to \\(true\\) or \\(on\\) to set zone groups equal to the 3DEC block IDs. If blocks are joined, zone groups will be set to the leader ID of the joined group. The groups will be assigned to slot BlockID . This is \\(off\\) by default."
+          "description": "NOT in the live 9.7.47 enumeration - the live spelling is plural 'block-ids' (see that entry). Set b to \\(true\\) or \\(on\\) to set zone groups equal to the 3DEC block IDs. If blocks are joined, zone groups will be set to the leader ID of the joined group. The groups will be assigned to slot BlockID . This is \\(off\\) by default."
+        },
+        {
+          "name": "block-ids",
+          "syntax": "block-ids",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Live spelling is PLURAL 'block-ids'; the documented singular 'block-id' is not in the live enumeration."
+        },
+        {
+          "name": "offset",
+          "syntax": "offset <v>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Coordinate offset applied on export."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/to-pfc.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/to-pfc.json
@@ -22,6 +22,16 @@
           "name": "by-zone",
           "syntax": "by-zone keyword",
           "description": "Export tetrahedral zones. By default, 3DEC blocks are exported."
+        },
+        {
+          "name": "grid",
+          "syntax": "grid <...>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Grid control for the PFC export."
+        },
+        {
+          "name": "precision",
+          "syntax": "precision <i>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Numeric precision of the export."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/zone-generate-new.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/zone-generate-new.json
@@ -43,6 +43,26 @@
           "name": "number-control-points",
           "syntax": "number-control-points <i>",
           "description": "Specify the number of points on faces to which the specified edge size ( block zone size ) is specified. Increasing the number of control points produces a more uniform mesh. The default value is 5. See Generating Zones for an example."
+        },
+        {
+          "name": "cut-angle",
+          "syntax": "cut-angle <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Cutting-angle control for the new zone generator."
+        },
+        {
+          "name": "fix-gridpoints",
+          "syntax": "fix-gridpoints",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Fix gridpoints during regeneration."
+        },
+        {
+          "name": "maxedge",
+          "syntax": "maxedge <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Alias of maximum-edge (both live-enumerated)."
+        },
+        {
+          "name": "minedge",
+          "syntax": "minedge <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Alias of minimum-edge (both live-enumerated)."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/zone-group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/zone-group.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "block zone group",
       "syntax": "block zone group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/zone-size.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/block/zone-size.json
@@ -38,6 +38,31 @@
           "name": "list",
           "syntax": "list",
           "description": "Prints to the console the coordinates and edge lengths of all isolated points."
+        },
+        {
+          "name": "center",
+          "syntax": "center <v>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Size control about a center point."
+        },
+        {
+          "name": "distance-1",
+          "syntax": "distance-1 <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Size-transition distance control."
+        },
+        {
+          "name": "edgelength-1",
+          "syntax": "edgelength-1 <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Edge-length control (variant 1)."
+        },
+        {
+          "name": "edgelength-2",
+          "syntax": "edgelength-2 <f>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Edge-length control (variant 2)."
+        },
+        {
+          "name": "isolated-point",
+          "syntax": "isolated-point",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Isolated-point size control."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/fblock/group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/fblock/group.json
@@ -12,7 +12,18 @@
     "9.0": {
       "command": "fblock group",
       "syntax": "fblock group keyword [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/fblock/list.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/fblock/list.json
@@ -27,6 +27,11 @@
           "name": "info",
           "syntax": "info",
           "description": "List information about fblocks."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Live 9.7 enumerates ONLY 'information' at this slot; the documented extra/group/info keywords did not enumerate ('info' appears to be the stale short form)."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowknot/group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowknot/group.json
@@ -12,7 +12,18 @@
     "9.0": {
       "command": "flowknot group",
       "syntax": "flowknot group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/area-minimum.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/area-minimum.json
@@ -4,7 +4,7 @@
     "flowplane",
     "area-minimum"
   ],
-  "description": "Set minumum flowplane area. If a potential flowplane has an area less than this, it is not created. This is used to avoid extremely small timesteps. The default is 2(tolerance*tolerance).",
+  "description": "Set minumum flowplane area. If a potential flowplane has an area less than this, it is not created. This is used to avoid extremely small timesteps. The default is 2(tolerance*tolerance). ORDER constraint (live 9.7): flow-plane minimum areas must be given BEFORE zoning ('block zone generate') - issuing it afterwards warns '+++ Flow plane minimum areas must be given before zoning'.",
   "python_sdk_alternative": {
     "available": false
   },

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/group.json
@@ -12,7 +12,18 @@
     "9.0": {
       "command": "flowplane group",
       "syntax": "flowplane group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/list.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/list.json
@@ -32,6 +32,11 @@
           "name": "velocity",
           "syntax": "velocity",
           "description": "List fluid velocities for flow planes."
+        },
+        {
+          "name": "information",
+          "syntax": "information",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Summary information listing."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/vertex-group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/vertex-group.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "flowplane vertex group",
       "syntax": "flowplane vertex group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/zone-group.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/flowplane/zone-group.json
@@ -13,7 +13,18 @@
     "9.0": {
       "command": "flowplane zone group",
       "syntax": "flowplane zone group <s1>[slot <s2>] [range]",
-      "keywords": [],
+      "keywords": [
+        {
+          "name": "remove",
+          "syntax": "remove",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Remove the group name (in the given slot) from entities in the range."
+        },
+        {
+          "name": "slot",
+          "syntax": "slot <s>",
+          "description": "Live-enumerated on 3DEC 9.7.47 (Batch 7 '?' probe); not on the official page. Assign the group name in a named slot."
+        }
+      ],
       "examples": []
     }
   }


### PR DESCRIPTION
Batch 7 closes the last systematic sweep item in the 3DEC 9.7 verification: the 60 corpus files that round 1 classified **positional-arg (25)** or **no-enum (40)**.

The no-enum verdict turns out to have been an artifact: these slots **swallow bogus tokens** (the trap Batch 6 identified on the apply family), but `?` enumerates. A single probe task (`batch7_probe_3dec.py`, sectioned base → destructive → fluid → feblock → risky-last) covered all 60 files — positional commands got a harmless typed value first, then `?` on the continuation slot. 59/60 produced enumerations or explicit terminal/ordering evidence; parsed enums + corpus diff saved as `batch7_enums_3dec.json` in the verification workspace.

## Corpus updates (26 files)
- **Group grammar completed everywhere**: `remove` + `slot` added to all 11 group commands (block contact/contact-subcontact/face/gridpoint/zone, block group already had them, flowknot, flowplane + vertex/zone, fblock).
- **`block contact compute`**: +DFN fracture statistics — `average-trace-length`, `p10/p20/p21/p30/p32/p33`.
- **`block list`**: +`condition/details/flaw/maxima/profile` (26-token live slot); `block face list` +`rigid`.
- **`block fluid`**: 17-token live first slot recorded (+7 undocumented keywords incl. `property` — the documented relaxation/viscosity/... are its sub-keywords); identical with/without fluid configure.
- **`block cut`**: live first slot is `dfn geometry joint-set jointset-id range set tunnel` — the documented dip/dip-direction/origin/id/spacing are joint-set sub-keywords.
- **`block generate`**: +`from-geometry/from-topography/from-vrml/voronoi`.
- **`block zone size` / `zone generate-new`**: +size controls (center/distance-1/edgelength-1/-2/isolated-point), `maxedge`/`minedge` aliases, cut-angle, fix-gridpoints.
- **`block to-flac3d`**: live spelling is plural `block-ids` (documented singular flagged as not live); +`offset`. `to-pfc` +`grid/precision`; `merge-start` +`exclude/slot`; `export/import` +`filename/format`.
- **`flowplane area-minimum`**: ORDER constraint stamped — must be issued BEFORE zoning (live warning captured).
- **`fblock list` / `flowplane list`**: +`information`; documented `info` flagged as stale short form.
- Flow family (flowknot apply/fix/free/list/property, flowplane edge apply/...) enumerated clean and matched the corpus — no edits needed there.

Also verified without edits: `block analyze-stability ?` enumerates exactly the documented six keywords (and does not execute); `skip-join-update`/`join-by-contact`/`block join` boolean forms confirmed.

Tests: `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)