### PR TITLE
docs: verify PFC plot-items + reference boundaries against live PFC3D 9.7 (Batch P1)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/history.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/history.json
@@ -5,7 +5,7 @@
     "track",
     "monitor"
   ],
-  "description": "Add a history of a ball value. A history is a table of floating point values assigned by sampling a model attribute periodically during a simulation. The ball must be specified by either 'id' or 'position' keyword.",
+  "description": "Add a history of a ball value. A history is a table of floating point values assigned by sampling a model attribute periodically during a simulation. The ball must be specified by either 'id' or 'position' keyword. Live 9.7: the quantity slot was fully enumerated (Batch P1); an object selector (id <i> or position <v>) is REQUIRED after the quantity - omitting it fails with 'No object for history specified'.",
   "quantity_categories": {
     "position": [
       "position-x",
@@ -247,22 +247,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are:"
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of ball with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of ball either containing or closest to position v ."
         },
@@ -698,22 +698,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are: Record the \\(x\\) -component of the vector. Record the \\(y\\) -component of the vector. Record the \\(z\\) -component of the vector. Record the vector magnitude."
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of ball with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of ball either containing or closest to position v ."
         },
@@ -726,6 +726,36 @@
           "name": "vector",
           "syntax": "vector",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned. Specify a scalar float type. Specify a tensor type. Specify a vector type."
+        },
+        {
+          "name": "axis-angle-x",
+          "syntax": "axis-angle-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. x-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-y",
+          "syntax": "axis-angle-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. y-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-z",
+          "syntax": "axis-angle-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. z-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "convergence",
+          "syntax": "convergence",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Per-object convergence measure."
+        },
+        {
+          "name": "ratio-local",
+          "syntax": "ratio-local",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Local force-ratio measure."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s>",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Assign a custom name to the history."
         }
       ],
       "examples": [

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/clump/history.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/clump/history.json
@@ -5,7 +5,7 @@
     "track",
     "monitor"
   ],
-  "description": "Add a history of a clump value. A history is a table of floating point values assigned by sampling a model attribute periodically during a simulation. The clump must be specified by either 'id' or 'position' keyword following the quantity keyword. The history can be assigned a name for later reference with the optional name keyword; if not, the history will be given a default name based on its internally assigned id number.",
+  "description": "Add a history of a clump value. A history is a table of floating point values assigned by sampling a model attribute periodically during a simulation. The clump must be specified by either 'id' or 'position' keyword following the quantity keyword. The history can be assigned a name for later reference with the optional name keyword; if not, the history will be given a default name based on its internally assigned id number. Live 9.7: the quantity slot was fully enumerated (Batch P1); an object selector (id <i> or position <v>) is REQUIRED after the quantity - omitting it fails with 'No object for history specified'.",
   "quantity_categories": {
     "position": [
       "position-x",
@@ -252,22 +252,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are:"
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of clump with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of clump either containing or closest to position v ."
         },
@@ -541,22 +541,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are: Record the \\(x\\) -component of the vector. Record the \\(y\\) -component of the vector. Record the \\(z\\) -component of the vector. Record the vector magnitude."
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of clump with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of clump either containing or closest to position v ."
         },
@@ -569,6 +569,36 @@
           "name": "vector",
           "syntax": "vector",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned. Specify a scalar float type. Specify a tensor type. Specify a vector type."
+        },
+        {
+          "name": "axis-angle-x",
+          "syntax": "axis-angle-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. x-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-y",
+          "syntax": "axis-angle-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. y-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-z",
+          "syntax": "axis-angle-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. z-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "convergence",
+          "syntax": "convergence",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Per-object convergence measure."
+        },
+        {
+          "name": "ratio-local",
+          "syntax": "ratio-local",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Local force-ratio measure."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s>",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Assign a custom name to the history."
         }
       ],
       "examples": [

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/contact/history.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/contact/history.json
@@ -3,7 +3,7 @@
   "search_keywords": [
     "history"
   ],
-  "description": "Add a contact history. A history is a floating point variable that can be sampled and stored during a model run. The optional id directly following history creates a history with the specified ID. If not specified, then the next available history ID is used. The s value identifies the contact type (i.e., ball-ball , ball-pebble , ball-facet , or pebble-facet ). Following one of the keywords given below, either 1) a position vector or 2) an additional id keyword must be given to define the specific contact. See the contact history command for details regarding the manipulation of histories.",
+  "description": "Add a contact history. A history is a floating point variable that can be sampled and stored during a model run. The optional id directly following history creates a history with the specified ID. If not specified, then the next available history ID is used. The s value identifies the contact type (i.e., ball-ball , ball-pebble , ball-facet , or pebble-facet ). Following one of the keywords given below, either 1) a position vector or 2) an additional id keyword must be given to define the specific contact. See the contact history command for details regarding the manipulation of histories. Live 9.7 grammar: the FIRST slot is the contact-type pair (ball-ball ball-facet ball-pebble pebble-facet pebble-pebble rblock-rblock), then the quantity (live set: extra force[-x/y/z] force-local-x/y/z force-normal force-shear gap moment-on1/on2 [-x/y/z, -local-x/y/z] position-x/y/z), then a REQUIRED object selector (id/position). Several official spellings are stale - see the per-keyword notes.",
   "notes": [],
   "python_sdk_alternative": {
     "available": false,
@@ -186,97 +186,97 @@
         {
           "name": "localforce-x",
           "syntax": "localforce-x [contacthistoryblock]",
-          "description": "Contact gap. The \\(x\\) -component of the contact force in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'force-local-x'. Contact gap. The \\(x\\) -component of the contact force in the contact coordinate system."
         },
         {
           "name": "localforce-y",
           "syntax": "localforce-y [contacthistoryblock]",
-          "description": "The \\(y\\) -component of the contact force in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'force-local-y'. The \\(y\\) -component of the contact force in the contact coordinate system."
         },
         {
           "name": "localforce-z",
           "syntax": "localforce-z 3D ONLY [contacthistoryblock]",
-          "description": "The \\(z\\) -component of the contact force in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'force-local-z'. The \\(z\\) -component of the contact force in the contact coordinate system."
         },
         {
           "name": "localmomenton1-x",
           "syntax": "localmomenton1-x 3D ONLY [contacthistoryblock]",
-          "description": "The \\(x\\) -component of the contact moment on end 1 in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1-local-x'. The \\(x\\) -component of the contact moment on end 1 in the contact coordinate system."
         },
         {
           "name": "localmomenton1-y",
           "syntax": "localmomenton1-y 3D ONLY [contacthistoryblock]",
-          "description": "The \\(y\\) -component of the contact moment on end 1 in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1-local-y'. The \\(y\\) -component of the contact moment on end 1 in the contact coordinate system."
         },
         {
           "name": "localmomenton1-z",
           "syntax": "localmomenton1-z 3D ONLY [contacthistoryblock]",
-          "description": "The \\(z\\) -component of the contact moment on end 1 in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1-local-z'. The \\(z\\) -component of the contact moment on end 1 in the contact coordinate system."
         },
         {
           "name": "localmomenton2-x",
           "syntax": "localmomenton2-x 3D ONLY [contacthistoryblock]",
-          "description": "The \\(x\\) -component of the contact moment on end 2 in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2-local-x'. The \\(x\\) -component of the contact moment on end 2 in the contact coordinate system."
         },
         {
           "name": "localmomenton2-y",
           "syntax": "localmomenton2-y 3D ONLY [contacthistoryblock]",
-          "description": "The \\(y\\) -component of the contact moment on end 2 in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2-local-y'. The \\(y\\) -component of the contact moment on end 2 in the contact coordinate system."
         },
         {
           "name": "localmomenton2-z",
           "syntax": "localmomenton2-z 3D ONLY [contacthistoryblock]",
-          "description": "The \\(z\\) -component of the contact moment on end 2 in the contact coordinate system."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2-local-z'. The \\(z\\) -component of the contact moment on end 2 in the contact coordinate system."
         },
         {
           "name": "mechanical",
           "syntax": "mechanical [contacthistoryblock]",
-          "description": "Apply to mechanical contacts."
+          "description": "Not in the live 9.7 quantity enumeration (kept from the official page). Apply to mechanical contacts."
         },
         {
           "name": "momenton1",
           "syntax": "momenton1 [contacthistoryblock]",
-          "description": "The {contact moment on end 1 in 2D; magnitude of the contact moment on end 1 in 3D}."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1'. The {contact moment on end 1 in 2D; magnitude of the contact moment on end 1 in 3D}."
         },
         {
           "name": "momenton1-x",
           "syntax": "momenton1-x 3D ONLY [contacthistoryblock]",
-          "description": "The \\(x\\) -component of the contact moment on end 1."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1-x'. The \\(x\\) -component of the contact moment on end 1."
         },
         {
           "name": "momenton1-y",
           "syntax": "momenton1-y 3D ONLY [contacthistoryblock]",
-          "description": "The \\(y\\) -component of the contact moment on end 1."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1-y'. The \\(y\\) -component of the contact moment on end 1."
         },
         {
           "name": "momenton1-z",
           "syntax": "momenton1-z 3D ONLY [contacthistoryblock]",
-          "description": "The \\(z\\) -component of the contact moment on end 1."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on1-z'. The \\(z\\) -component of the contact moment on end 1."
         },
         {
           "name": "momenton2",
           "syntax": "momenton2 [contacthistoryblock]",
-          "description": "The {contact moment on end 2 in 2D; magnitude of the contact moment on end 2 in 3D}."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2'. The {contact moment on end 2 in 2D; magnitude of the contact moment on end 2 in 3D}."
         },
         {
           "name": "momenton2-x",
           "syntax": "momenton2-x 3D ONLY [contacthistoryblock]",
-          "description": "The \\(x\\) -component of the contact moment on end 2."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2-x'. The \\(x\\) -component of the contact moment on end 2."
         },
         {
           "name": "momenton2-y",
           "syntax": "momenton2-y 3D ONLY [contacthistoryblock]",
-          "description": "The \\(y\\) -component of the contact moment on end 2."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2-y'. The \\(y\\) -component of the contact moment on end 2."
         },
         {
           "name": "momenton2-z",
           "syntax": "momenton2-z 3D ONLY [contacthistoryblock]",
-          "description": "The \\(z\\) -component of the contact moment on end 2."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'moment-on2-z'. The \\(z\\) -component of the contact moment on end 2."
         },
         {
           "name": "normalforce",
           "syntax": "normalforce [contacthistoryblock]",
-          "description": "Contact force in the normal direction."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'force-normal'. Contact force in the normal direction."
         },
         {
           "name": "position-x",
@@ -296,12 +296,12 @@
         {
           "name": "shearforce",
           "syntax": "shearforce [contacthistoryblock]",
-          "description": "Magnitude of the shear contact force."
+          "description": "STALE SPELLING - not in the live 9.7 enumeration; the live keyword is 'force-shear'. Magnitude of the shear contact force."
         },
         {
           "name": "thermal",
           "syntax": "thermal [contacthistoryblock]",
-          "description": "Apply to thermal contacts."
+          "description": "Not in the live 9.7 quantity enumeration (kept from the official page). Apply to thermal contacts."
         },
         {
           "name": "magnitude",
@@ -309,22 +309,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are: Record the \\(x\\) -component of the vector. Record the \\(y\\) -component of the vector. Record the \\(z\\) -component of the vector. Record the vector magnitude."
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of the stype contact with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of the stype contact that is nearest to position v ."
         },
@@ -332,6 +332,146 @@
           "name": "vector",
           "syntax": "vector",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned. Specify a scalar float type. Specify a tensor type. Specify a vector type."
+        },
+        {
+          "name": "force-local-x",
+          "syntax": "force-local-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localforce-x'."
+        },
+        {
+          "name": "force-local-y",
+          "syntax": "force-local-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localforce-y'."
+        },
+        {
+          "name": "force-local-z",
+          "syntax": "force-local-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localforce-z'."
+        },
+        {
+          "name": "moment-on1-local-x",
+          "syntax": "moment-on1-local-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localmomenton1-x'."
+        },
+        {
+          "name": "moment-on1-local-y",
+          "syntax": "moment-on1-local-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localmomenton1-y'."
+        },
+        {
+          "name": "moment-on1-local-z",
+          "syntax": "moment-on1-local-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localmomenton1-z'."
+        },
+        {
+          "name": "moment-on2-local-x",
+          "syntax": "moment-on2-local-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localmomenton2-x'."
+        },
+        {
+          "name": "moment-on2-local-y",
+          "syntax": "moment-on2-local-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localmomenton2-y'."
+        },
+        {
+          "name": "moment-on2-local-z",
+          "syntax": "moment-on2-local-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'localmomenton2-z'."
+        },
+        {
+          "name": "moment-on1",
+          "syntax": "moment-on1",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton1'."
+        },
+        {
+          "name": "moment-on1-x",
+          "syntax": "moment-on1-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton1-x'."
+        },
+        {
+          "name": "moment-on1-y",
+          "syntax": "moment-on1-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton1-y'."
+        },
+        {
+          "name": "moment-on1-z",
+          "syntax": "moment-on1-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton1-z'."
+        },
+        {
+          "name": "moment-on2",
+          "syntax": "moment-on2",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton2'."
+        },
+        {
+          "name": "moment-on2-x",
+          "syntax": "moment-on2-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton2-x'."
+        },
+        {
+          "name": "moment-on2-y",
+          "syntax": "moment-on2-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton2-y'."
+        },
+        {
+          "name": "moment-on2-z",
+          "syntax": "moment-on2-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'momenton2-z'."
+        },
+        {
+          "name": "force-normal",
+          "syntax": "force-normal",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'normalforce'."
+        },
+        {
+          "name": "force-shear",
+          "syntax": "force-shear",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Live spelling of the official 'shearforce'."
+        },
+        {
+          "name": "gap",
+          "syntax": "gap",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact gap."
+        },
+        {
+          "name": "extra",
+          "syntax": "extra",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Extra variable at the contact (index <i> selects which)."
+        },
+        {
+          "name": "name",
+          "syntax": "name",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Assign a custom name to the history."
+        },
+        {
+          "name": "ball-ball",
+          "syntax": "ball-ball",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact-type selector - the live 9.7 FIRST slot is the contact type (before the quantity)."
+        },
+        {
+          "name": "ball-facet",
+          "syntax": "ball-facet",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact-type selector - the live 9.7 FIRST slot is the contact type (before the quantity)."
+        },
+        {
+          "name": "ball-pebble",
+          "syntax": "ball-pebble",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact-type selector - the live 9.7 FIRST slot is the contact type (before the quantity)."
+        },
+        {
+          "name": "pebble-facet",
+          "syntax": "pebble-facet",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact-type selector - the live 9.7 FIRST slot is the contact type (before the quantity)."
+        },
+        {
+          "name": "pebble-pebble",
+          "syntax": "pebble-pebble",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact-type selector - the live 9.7 FIRST slot is the contact type (before the quantity)."
+        },
+        {
+          "name": "rblock-rblock",
+          "syntax": "rblock-rblock",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Contact-type selector - the live 9.7 FIRST slot is the contact type (before the quantity)."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/measure/history.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/measure/history.json
@@ -5,7 +5,7 @@
     "track",
     "monitor"
   ],
-  "description": "Add a measurement history. A history is a floating point variable that can be sampled and stored during a model run, allowing tracking of measurement quantities over time. The history records values such as porosity, coordination number, stress, strain rate, position, or radius from a specified measurement object as the simulation progresses.",
+  "description": "Add a measurement history. A history is a floating point variable that can be sampled and stored during a model run, allowing tracking of measurement quantities over time. The history records values such as porosity, coordination number, stress, strain rate, position, or radius from a specified measurement object as the simulation progresses. Live 9.7: the quantity slot was fully enumerated (Batch P1); an object selector (id <i> or position <v>) is REQUIRED after the quantity - omitting it fails with 'No object for history specified'.",
   "notes": [
     "History records floating point values sampled during model run",
     "Allows tracking measurement quantities over time (e.g., porosity evolution)",
@@ -521,22 +521,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are:"
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of measure with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of measure either containing or closest to position v ."
         },
@@ -892,22 +892,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are: Record the \\(x\\) -component of the vector. Record the \\(y\\) -component of the vector. Record the \\(z\\) -component of the vector. Record the vector magnitude."
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of measure with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of measure either containing or closest to position v ."
         },
@@ -920,6 +920,11 @@
           "name": "vector",
           "syntax": "vector",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned. Specify a scalar float type. Specify a tensor type. Specify a vector type."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s>",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Assign a custom name to the history."
         }
       ],
       "examples": [

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/rblock/history.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/rblock/history.json
@@ -1,6 +1,6 @@
 {
   "category": "rblock",
-  "description": "Record rblock properties over time for plotting and post-processing.",
+  "description": "Record rblock properties over time for plotting and post-processing. Live 9.7: the quantity slot was fully enumerated (Batch P1); an object selector (id <i> or position <v>) is REQUIRED after the quantity - omitting it fails with 'No object for history specified'.",
   "search_keywords": [
     "rblock history",
     "record property",
@@ -388,22 +388,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are:"
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of rigid block with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of rigid block either containing or closest to position v ."
         },
@@ -615,22 +615,22 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are: Record the \\(x\\) -component of the vector. Record the \\(y\\) -component of the vector. Record the \\(z\\) -component of the vector. Record the vector magnitude."
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of rigid block with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of rigid block either containing or closest to position v ."
         },
@@ -643,6 +643,36 @@
           "name": "vector",
           "syntax": "vector",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned. Specify a scalar float type. Specify a tensor type. Specify a vector type."
+        },
+        {
+          "name": "axis-angle-x",
+          "syntax": "axis-angle-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. x-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-y",
+          "syntax": "axis-angle-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. y-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-z",
+          "syntax": "axis-angle-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. z-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "convergence",
+          "syntax": "convergence",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Per-object convergence measure."
+        },
+        {
+          "name": "ratio-local",
+          "syntax": "ratio-local",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Local force-ratio measure."
+        },
+        {
+          "name": "name",
+          "syntax": "name <s>",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. Assign a custom name to the history."
         }
       ],
       "examples": []

--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/wall/history.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/wall/history.json
@@ -5,7 +5,7 @@
     "track",
     "monitor"
   ],
-  "description": "Adds a history of a wall value. A history is a table of floating point values assigned by sampling a model attribute periodically during a simulation. The history can be assigned a name for later reference with the optional name keyword, if not the history will be given a default name based on its internally assigned id number. Following one of the keywords given below, either 1) an additional 'id' keyword followed by an integer id, 2) an additional 'name' keyword followed by a string s, or 3) an additional 'position' keyword followed by a position vector v must be given to define the specific wall.",
+  "description": "Adds a history of a wall value. A history is a table of floating point values assigned by sampling a model attribute periodically during a simulation. The history can be assigned a name for later reference with the optional name keyword, if not the history will be given a default name based on its internally assigned id number. Following one of the keywords given below, either 1) an additional 'id' keyword followed by an integer id, 2) an additional 'name' keyword followed by a string s, or 3) an additional 'position' keyword followed by a position vector v must be given to define the specific wall. Live 9.7: the quantity slot was fully enumerated (Batch P1); an object selector (id <i> or position <v>) is REQUIRED after the quantity - omitting it fails with 'No object for history specified'.",
   "python_sdk_alternative": {
     "available": false,
     "workaround": "itasca.command('wall history ...') - Python SDK does not provide history recording. Use history commands for manipulation"
@@ -161,27 +161,27 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are:"
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of wall with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:name",
+          "name": "name",
           "syntax": "name <s>",
           "description": "Record the history of wall with name s ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of wall either containing or closest to position v ."
         },
@@ -548,27 +548,27 @@
           "description": "This keyword selects which scalar to retrieve from a vector type value, such as velocity or displacement. If the value type is not a vector, this setting is ignored. The available options are: Record the \\(x\\) -component of the vector. Record the \\(y\\) -component of the vector. Record the \\(z\\) -component of the vector. Record the vector magnitude."
         },
         {
-          "name": "kwd:id",
+          "name": "id",
           "syntax": "id <i>",
           "description": "Record the history of wall with ID i ."
         },
         {
-          "name": "kwd:index",
+          "name": "index",
           "syntax": "index <i>",
           "description": "For keywords that require it (most notably extra ), this specifies the index that should be used."
         },
         {
-          "name": "kwd:log",
+          "name": "log",
           "syntax": "log <b>",
           "description": "If on , the returned number is the base 10 log of the absolute value of the original value. The default is off ."
         },
         {
-          "name": "kwd:name",
+          "name": "name",
           "syntax": "name <s>",
           "description": "Record the history of wall with name s ."
         },
         {
-          "name": "kwd:position",
+          "name": "position",
           "syntax": "position <v>",
           "description": "Record the history of wall either containing or closest to position v ."
         },
@@ -581,6 +581,21 @@
           "name": "vector",
           "syntax": "vector",
           "description": "In certain cases the type (scalar, vector, or tensor) of the value cannot necessarily be determined ahead of time. Extra variables, for example, can hold values of all three types. This keyword allows one to specify which type it is assumed to be. If the original value type does not match, 0.0 is returned. Specify a scalar float type. Specify a tensor type. Specify a vector type."
+        },
+        {
+          "name": "axis-angle-x",
+          "syntax": "axis-angle-x",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. x-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-y",
+          "syntax": "axis-angle-y",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. y-component of the axis-angle orientation measure."
+        },
+        {
+          "name": "axis-angle-z",
+          "syntax": "axis-angle-z",
+          "description": "Live-enumerated on PFC3D 9.7 (Batch P1); not on the official page. z-component of the axis-angle orientation measure."
         }
       ],
       "examples": [

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/color-by.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/color-by.json
@@ -2,7 +2,6 @@
   "name": "color-by",
   "parent": "ball",
   "description": "Color-by modes for ball plot items. Three modes depending on attribute type: vector, numeric, and text.",
-
   "modes": [
     {
       "keyword": "color-by vector-attribute",
@@ -14,9 +13,16 @@
         "color-by vector-attribute \"force-contact\""
       ],
       "available_attributes": [
-        "position", "velocity", "displacement", "spin",
-        "force-contact", "force-applied", "force-unbalanced",
-        "moment-contact", "moment-applied", "moment-unbalanced"
+        "position",
+        "velocity",
+        "displacement",
+        "spin",
+        "force-contact",
+        "force-applied",
+        "force-unbalanced",
+        "moment-contact",
+        "moment-applied",
+        "moment-unbalanced"
       ],
       "notes": "Defaults to magnitude. Append 'color-options scaled ramp rainbow minimum automatic maximum automatic' for rainbow scale."
     },
@@ -28,7 +34,12 @@
         "color-by numeric-attribute \"radius\"",
         "color-by numeric-attribute \"density\""
       ],
-      "available_attributes": ["radius", "damp", "density", "mass"],
+      "available_attributes": [
+        "radius",
+        "damp",
+        "density",
+        "mass"
+      ],
       "notes": "Append 'color-options scaled ramp rainbow minimum automatic maximum automatic' for rainbow scale"
     },
     {
@@ -39,7 +50,10 @@
         "color-by text-attribute \"id\" color-options named maximum-names 1000000 name-controls true",
         "color-by text-attribute \"group\" 'Any' color-options named maximum-names 1000000 name-controls true"
       ],
-      "available_attributes": ["id", "group"],
+      "available_attributes": [
+        "id",
+        "group"
+      ],
       "notes": "group attribute requires slot name ('Any' for default slot). Use 'color-options named' instead of 'scaled ramp'."
     },
     {
@@ -51,5 +65,8 @@
         "color-by numeric-attribute \"extra\" 3"
       ]
     }
+  ],
+  "notes": [
+    "PFC3D 9.7 behavior change (Batch P1): the attribute-name slot is a free-form String - create accepts ANY name silently (no error at create or export), so typos cannot be caught from the CLI. The attribute lists here are verified on PFC2D 7.00 (which rejected invalid names at create). Live 9.7 mode grammar confirmed: {numeric,tensor,text,vector} x {attribute,property} plus add-* overlay variants."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/cut.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/cut.json
@@ -2,7 +2,6 @@
   "name": "cut",
   "parent": "ball",
   "description": "Cut plane for clipping ball visualization. Shows only material on one side of a defined plane.",
-
   "keywords": [
     {
       "keyword": "cut active on",
@@ -32,18 +31,21 @@
       ]
     }
   ],
-
   "usage_in_creation": "Cut cannot be inlined in 'item create'. First create the item, then use 'item modify' to add the cut plane.",
   "usage_in_modification": "plot \"<name>\" item modify <id> cut active on type plane surface on front off back on origin (0,0,0) normal (0,1,0)",
-
   "legend_settings": {
     "description": "Cut plane legend sub-settings exported in datafile",
-    "keywords": ["title", "origin", "normal", "orientation"],
+    "keywords": [
+      "title",
+      "origin",
+      "normal",
+      "orientation"
+    ],
     "example": "legend ... cut ... title active on size 44 family 'Arial' style normal color 'black' ... origin active off ... normal active off ... orientation active off"
   },
-
   "notes": [
     "Cut plane syntax is identical across ball, contact, and wall item types.",
-    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut."
+    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut.",
+    "Live PFC3D 9.7 (Batch P1): cut keywords DO parse inline at create time - 'plot item create <type> cut ?' enumerates active/back/front/surface/type, with type = none/octant/plane/wedge and front/surface booleans. The 'must use plot item modify' rule above was verified on PFC2D 7.00; on 9.7 both routes parse."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/index.json
@@ -1,10 +1,18 @@
 {
   "name": "ball",
   "item_type": "ball",
-  "search_keywords": ["ball", "particle", "sphere", "arrow", "color", "velocity", "displacement", "force"],
+  "search_keywords": [
+    "ball",
+    "particle",
+    "sphere",
+    "arrow",
+    "color",
+    "velocity",
+    "displacement",
+    "force"
+  ],
   "description": "Configuration keywords for 'plot item create ball'. Controls ball rendering, coloring by attributes, arrow shape for vector fields, cut planes, and legend display.",
   "base_syntax": "plot item create ball <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "active on",
@@ -29,7 +37,6 @@
       "notes": "Appended after color-by for continuous color mapping"
     }
   ],
-
   "sub_items": [
     {
       "name": "color-by",
@@ -47,7 +54,6 @@
       "description": "Arrow shape for vector field visualization"
     }
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Default ball visualization",
@@ -64,5 +70,8 @@
       "command": "plot item create ball active on color-by text-attribute \"group\" 'Any' color-options named maximum-names 1000000 name-controls true legend active on",
       "description": "Different color per group name"
     }
+  ],
+  "notes": [
+    "Live PFC3D 9.7 first-slot enumeration (Batch P1): active both-directions clip color-by color-options cut ghosts legend map orientation range scale-by-magnitude selected-only shape transparency."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/shape.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/ball/shape.json
@@ -2,7 +2,6 @@
   "name": "shape",
   "parent": "ball",
   "description": "Arrow shape rendering for vector field visualization on ball items.",
-
   "keywords": [
     {
       "keyword": "shape arrow",
@@ -17,11 +16,13 @@
       "notes": "Use 'off' for uniform arrow size with color-only encoding"
     }
   ],
-
   "examples": [
     {
       "command": "plot item create ball active on shape arrow arrow-quality 8 color-by vector-attribute \"velocity\" color-options scaled ramp rainbow minimum automatic maximum automatic scale-by-magnitude off legend active on",
       "description": "Velocity arrow field with uniform size, colored by magnitude"
     }
+  ],
+  "notes": [
+    "Live 9.7 'shape' slot: arrow | ball, plus sizing/quality keywords cell-extent minimum-extent pixel-size quality shrink-factor tolerance-extent sketch. 'shape arrow' continuation: arrow-body arrow-head arrow-quality arrow-size point-to-base scale."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/color-by.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/color-by.json
@@ -2,7 +2,6 @@
   "name": "color-by",
   "parent": "clump",
   "description": "Color-by modes for clump plot items. Three modes depending on attribute type: vector, numeric, and text.",
-
   "modes": [
     {
       "keyword": "color-by vector-attribute",
@@ -14,9 +13,16 @@
         "color-by vector-attribute \"force-contact\""
       ],
       "available_attributes": [
-        "position", "velocity", "displacement", "spin",
-        "force-contact", "force-applied", "force-unbalanced",
-        "moment-contact", "moment-applied", "moment-unbalanced"
+        "position",
+        "velocity",
+        "displacement",
+        "spin",
+        "force-contact",
+        "force-applied",
+        "force-unbalanced",
+        "moment-contact",
+        "moment-applied",
+        "moment-unbalanced"
       ],
       "notes": "Defaults to magnitude. Append 'color-options scaled ramp rainbow minimum automatic maximum automatic' for rainbow scale."
     },
@@ -29,7 +35,14 @@
         "color-by numeric-attribute \"mass\"",
         "color-by numeric-attribute \"density\""
       ],
-      "available_attributes": ["volume", "mass", "density", "damp", "moi-principal-real", "moi-real"],
+      "available_attributes": [
+        "volume",
+        "mass",
+        "density",
+        "damp",
+        "moi-principal-real",
+        "moi-real"
+      ],
       "notes": "Append 'color-options scaled ramp rainbow minimum automatic maximum automatic' for rainbow scale"
     },
     {
@@ -40,7 +53,10 @@
         "color-by text-attribute \"id\" color-options named maximum-names 1000000 name-controls true",
         "color-by text-attribute \"group\" 'Any' color-options named maximum-names 1000000 name-controls true"
       ],
-      "available_attributes": ["id", "group"],
+      "available_attributes": [
+        "id",
+        "group"
+      ],
       "notes": "group attribute requires slot name ('Any' for default slot). Use 'color-options named' instead of 'scaled ramp'."
     },
     {
@@ -52,5 +68,8 @@
         "color-by numeric-attribute \"extra\" 3"
       ]
     }
+  ],
+  "notes": [
+    "PFC3D 9.7 behavior change (Batch P1): the attribute-name slot is a free-form String - create accepts ANY name silently (no error at create or export), so typos cannot be caught from the CLI. The attribute lists here are verified on PFC2D 7.00 (which rejected invalid names at create). Live 9.7 mode grammar confirmed: {numeric,tensor,text,vector} x {attribute,property} plus add-* overlay variants."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/cut.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/cut.json
@@ -2,7 +2,6 @@
   "name": "cut",
   "parent": "clump",
   "description": "Cut plane for clipping clump visualization. Shows only material on one side of a defined plane.",
-
   "keywords": [
     {
       "keyword": "cut active on",
@@ -32,12 +31,11 @@
       ]
     }
   ],
-
   "usage_in_creation": "Cut cannot be inlined in 'item create'. First create the item, then use 'item modify' to add the cut plane.",
   "usage_in_modification": "plot \"<name>\" item modify <id> cut active on type plane surface on front off back on origin (0,0,0) normal (0,1,0)",
-
   "notes": [
     "Cut plane syntax is identical across ball, clump, contact, and wall item types.",
-    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut."
+    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut.",
+    "Live PFC3D 9.7 (Batch P1): cut keywords DO parse inline at create time - 'plot item create <type> cut ?' enumerates active/back/front/surface/type, with type = none/octant/plane/wedge and front/surface booleans. The 'must use plot item modify' rule above was verified on PFC2D 7.00; on 9.7 both routes parse."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/index.json
@@ -1,10 +1,20 @@
 {
   "name": "clump",
   "item_type": "clump",
-  "search_keywords": ["clump", "cluster", "pebble", "rigid", "arrow", "color", "velocity", "displacement", "force", "volume"],
+  "search_keywords": [
+    "clump",
+    "cluster",
+    "pebble",
+    "rigid",
+    "arrow",
+    "color",
+    "velocity",
+    "displacement",
+    "force",
+    "volume"
+  ],
   "description": "Configuration keywords for 'plot item create clump'. Controls clump rendering, coloring by attributes, arrow shape for vector fields, transparency, cut planes, and legend display.",
   "base_syntax": "plot item create clump <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "active on",
@@ -35,7 +45,6 @@
       "notes": "Appended after color-by for continuous color mapping"
     }
   ],
-
   "sub_items": [
     {
       "name": "color-by",
@@ -53,7 +62,6 @@
       "description": "Arrow shape for vector field visualization"
     }
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Default clump visualization",
@@ -80,5 +88,9 @@
       "command": "plot item create clump active on color-by numeric-attribute \"volume\" color-options scaled ramp rainbow minimum automatic maximum automatic legend active on",
       "description": "Rainbow color scale by clump volume"
     }
+  ],
+  "notes": [
+    "Live PFC3D 9.7 first-slot enumeration (Batch P1): active both-directions clip color-by color-options cut ghosts legend map orientation range scale-by-magnitude selected-only shape template transparency.",
+    "clump 'shape' drill-down (live 9.7): arrow pebble surface + cell-extent/minimum-extent/pixel-size/quality/shrink-factor/tolerance-extent."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/shape.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/clump/shape.json
@@ -2,7 +2,6 @@
   "name": "shape",
   "parent": "clump",
   "description": "Arrow shape rendering for vector field visualization on clump items.",
-
   "keywords": [
     {
       "keyword": "shape arrow",
@@ -17,11 +16,13 @@
       "notes": "Use 'off' for uniform arrow size with color-only encoding"
     }
   ],
-
   "examples": [
     {
       "command": "plot item create clump active on shape arrow arrow-quality 8 color-by vector-attribute \"velocity\" color-options scaled ramp rainbow minimum automatic maximum automatic scale-by-magnitude off legend active on",
       "description": "Velocity arrow field with uniform size, colored by magnitude"
     }
+  ],
+  "notes": [
+    "Live 9.7 'shape' slot for clump: arrow | pebble | surface, plus cell-extent minimum-extent pixel-size quality shrink-factor tolerance-extent."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/color-by.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/color-by.json
@@ -2,7 +2,6 @@
   "name": "color-by",
   "parent": "contact",
   "description": "Color-by modes for contact plot items. Supports vector attributes, numeric model properties, and text attributes.",
-
   "modes": [
     {
       "keyword": "color-by vector-attribute",
@@ -11,7 +10,9 @@
       "examples": [
         "color-by vector-attribute \"force\""
       ],
-      "available_attributes": ["force"]
+      "available_attributes": [
+        "force"
+      ]
     },
     {
       "keyword": "color-by numeric-property",
@@ -23,10 +24,16 @@
         "color-by numeric-property \"ks\""
       ],
       "available_properties": [
-        "fric", "kn", "ks",
-        "dp_nratio", "dp_sratio",
-        "emod", "kratio",
-        "rr_fric", "rr_kr", "rr_slip"
+        "fric",
+        "kn",
+        "ks",
+        "dp_nratio",
+        "dp_sratio",
+        "emod",
+        "kratio",
+        "rr_fric",
+        "rr_kr",
+        "rr_slip"
       ],
       "notes": "Property must exist in the assigned contact model. See itasca_browse_reference('contact-models') for properties per model."
     },
@@ -40,7 +47,12 @@
         "color-by text-attribute \"model name\" color-options named maximum-names 1000000 name-controls true",
         "color-by text-attribute \"group\" 'Any' color-options named maximum-names 1000000 name-controls true"
       ],
-      "available_attributes": ["id", "contact-type", "model-name", "group"],
+      "available_attributes": [
+        "id",
+        "contact-type",
+        "model-name",
+        "group"
+      ],
       "notes": "Text attributes contact-type and model-name use space-separated names in the command (e.g., 'contact type', not 'contact-type')"
     },
     {
@@ -51,5 +63,8 @@
         "color-by numeric-attribute \"extra\" 1"
       ]
     }
+  ],
+  "notes": [
+    "PFC3D 9.7 behavior change (Batch P1): the attribute-name slot is a free-form String - create accepts ANY name silently (no error at create or export), so typos cannot be caught from the CLI. The attribute lists here are verified on PFC2D 7.00 (which rejected invalid names at create). Live 9.7 mode grammar confirmed: {numeric,tensor,text,vector} x {attribute,property} plus add-* overlay variants."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/cut.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/cut.json
@@ -2,7 +2,6 @@
   "name": "cut",
   "parent": "contact",
   "description": "Cut plane for clipping contact visualization. Shows only contacts on one side of a defined plane.",
-
   "keywords": [
     {
       "keyword": "cut active on",
@@ -32,18 +31,21 @@
       ]
     }
   ],
-
   "usage_in_creation": "Cut cannot be inlined in 'item create'. First create the item, then use 'item modify' to add the cut plane.",
   "usage_in_modification": "plot \"<name>\" item modify <id> cut active on type plane surface on front off back on origin (0,0,0) normal (0,1,0)",
-
   "legend_settings": {
     "description": "Cut plane legend sub-settings exported in datafile",
-    "keywords": ["title", "origin", "normal", "orientation"],
+    "keywords": [
+      "title",
+      "origin",
+      "normal",
+      "orientation"
+    ],
     "example": "legend ... cut ... title active on size 44 family 'Arial' style normal color 'black' ... origin active off ... normal active off ... orientation active off"
   },
-
   "notes": [
     "Cut plane syntax is identical across ball, contact, and wall item types.",
-    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut."
+    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut.",
+    "Live PFC3D 9.7 (Batch P1): cut keywords DO parse inline at create time - 'plot item create <type> cut ?' enumerates active/back/front/surface/type, with type = none/octant/plane/wedge and front/surface booleans. The 'must use plot item modify' rule above was verified on PFC2D 7.00; on 9.7 both routes parse."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/contact/index.json
@@ -1,10 +1,16 @@
 {
   "name": "contact",
   "item_type": "contact",
-  "search_keywords": ["contact", "force", "bond", "friction", "stiffness", "color"],
+  "search_keywords": [
+    "contact",
+    "force",
+    "bond",
+    "friction",
+    "stiffness",
+    "color"
+  ],
   "description": "Configuration keywords for 'plot item create contact'. Controls contact rendering, force scaling, coloring by properties or attributes, cut planes, and legend display.",
   "base_syntax": "plot item create contact <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "active on",
@@ -33,7 +39,6 @@
       "syntax": "color-options scaled ramp rainbow minimum automatic maximum automatic"
     }
   ],
-
   "sub_items": [
     {
       "name": "color-by",
@@ -46,12 +51,12 @@
       "description": "Clip visualization with a cutting plane"
     }
   ],
-
   "notes": [
     "'radius-factor' and a bare 'automatic'/'automatic off' are NOT contact-item keywords - they fail with 'Unused extra parameter' (verified PFC2D 7.00). Force-chain thickness comes from 'scale-by-force'; the word 'automatic' is only valid inside 'color-options ... minimum automatic maximum automatic'.",
-    "The force-chain pattern below is verified working on PFC2D 7.00."
+    "The force-chain pattern below is verified working on PFC2D 7.00.",
+    "Live PFC3D 9.7 first-slot enumeration (Batch P1): active all-contacts both-directions clip cm-normal color-by color-options cut directed display ghosts legend map orientation range scale-by-force scale-by-magnitude selected-only shape transparency.",
+    "contact 'shape' drill-down (live 9.7): arrow cylinder disk joint sphere."
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Contact force network",

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/dfn.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/dfn.json
@@ -1,10 +1,14 @@
 {
   "name": "dfn",
   "item_type": "dfn",
-  "search_keywords": ["dfn", "fracture contour", "discrete fracture network", "contour"],
+  "search_keywords": [
+    "dfn",
+    "fracture contour",
+    "discrete fracture network",
+    "contour"
+  ],
   "description": "Configuration keywords for 'plot item create dfn' - the 'DFN Fracture Contour' item, which contours mechanical contact data on DFN fractures. NOT the item for drawing the fractures themselves; use the 'fracture' item for that. Verified against PFC2D 7.00.",
   "base_syntax": "plot item create dfn contour <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "contour",
@@ -17,7 +21,6 @@
       "syntax": "active on"
     }
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Contour contact data on DFN fractures",
@@ -25,10 +28,10 @@
       "description": "Creates the DFN Fracture Contour item with default contour settings"
     }
   ],
-
   "notes": [
     "Official label: 'DFN Fracture Contour - Contour mechanical contact data on DFN fractures' (PFC 7.0 Program Guide, Plot Items in PFC).",
     "For visualizing cracks/fractures as line segments or disks (the common bonded-material use case), use the 'fracture' plot item instead - see itasca_browse_reference('plot-items fracture').",
-    "Further contour configuration keywords are sparsely documented; discover them by issuing an incomplete 'plot item modify <i> ...' command and reading the expected-token list in the engine error."
+    "Further contour configuration keywords are sparsely documented; discover them by issuing an incomplete 'plot item modify <i> ...' command and reading the expected-token list in the engine error.",
+    "Live PFC3D 9.7 (Batch P1): first slot enumerates ONLY 'contour' (confirming creation requires it); 'contour' continuation: active all both-directions caption clip cmnormal color-by color-options cut directed ghosts icontype interpolate legend map orientation outline radius range rendering scale-by-magnitude selected-only transparency."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/fracture.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/fracture.json
@@ -1,10 +1,17 @@
 {
   "name": "fracture",
   "item_type": "fracture",
-  "search_keywords": ["fracture", "dfn", "crack", "discrete fracture network", "color", "group", "bond break"],
+  "search_keywords": [
+    "fracture",
+    "dfn",
+    "crack",
+    "discrete fracture network",
+    "color",
+    "group",
+    "bond break"
+  ],
   "description": "Configuration keywords for 'plot item create fracture'. Draws the fractures of the Discrete Fracture Network (DFN) system - including cracks recorded during bond breakage - with coloring and range filtering. Verified against PFC2D 7.00.",
   "base_syntax": "plot item create fracture <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "active on|off",
@@ -38,7 +45,6 @@
       "syntax": "legend active on"
     }
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Cracks colored by family (tension vs shear)",
@@ -56,11 +62,13 @@
       "description": "Contour fractures by trace length (2D; use 'area' in 3D)"
     }
   ],
-
   "notes": [
     "There is NO color-by attribute for the parent DFN: text-attribute 'dfn', 'dfn-group', 'name' etc. are rejected as invalid attributes (verified PFC2D 7.00). Coloring or filtering by DFN membership must go through groups.",
     "Per-DFN recipe: assign a group to each DFN's fractures, then color by group. Scope the assignment with 'fracture group <name> range fish <fn>' (official pattern, filter on dfn.fracture.dfn(frac)), or simplest: tag each crack's group right when it is created in the bond-break callback.",
     "'range dfn <name>' does NOT select by DFN membership - the dfn range element selects by DISTANCE from a named DFN (geometric proximity) and is not accepted by fracture-scoped commands in PFC 7.",
-    "Plot legend groups fractures under 'Fracture group <slot>' when coloring by group; a plain fracture item shows a single 'fractures' entry regardless of how many DFNs exist."
+    "Plot legend groups fractures under 'Fracture group <slot>' when coloring by group; a plain fracture item shows a single 'fractures' entry regardless of how many DFNs exist.",
+    "Live PFC3D 9.7 first-slot enumeration (Batch P1): active both-directions clip color-by color-options cut display ghosts intersections legend map orientation range rosette scale-by-magnitude selected-only shape stereonet transparency.",
+    "'rosette' continuation (live 9.7): active bins border colors display grid legend plane-normal position range size transparency. 'stereonet' continuation: active border contours density display grid hemisphere legend points position projection range resolution size transparency. 'intersections' takes the entity core set.",
+    "9.7 attribute-name trap: color-by names are NOT validated at create time on 9.7 (any string accepted silently) - the attribute verdicts above are from PFC2D 7.00, which did reject invalid names."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/index.json
@@ -1,9 +1,7 @@
 {
   "type": "plot_item_keywords",
   "description": "Configuration keywords for plot item types created via 'plot item create <type>'. These keywords are appended after the item type to control appearance, coloring, clipping, and legend.",
-
   "usage_context": "plot item create <type> <keyword> <keyword> ...",
-
   "items": [
     {
       "name": "ball",
@@ -54,15 +52,32 @@
       "common_use": "Plot recorded histories over cycling: convergence ratio, energy, ball/wall/measure quantities"
     }
   ],
-
   "shared_keywords": {
-    "description": "Keywords common to most plot item types",
-    "list": ["active", "color-by", "color-options", "cut", "legend"]
+    "description": "Live PFC3D 9.7 common first-slot core shared by the entity item types (ball/wall/clump/contact/rblock/fracture and the thermal/cfd twins)",
+    "list": [
+      "active",
+      "both-directions",
+      "clip",
+      "color-by",
+      "color-options",
+      "cut",
+      "ghosts",
+      "legend",
+      "map",
+      "orientation",
+      "range",
+      "scale-by-magnitude",
+      "selected-only",
+      "shape",
+      "transparency"
+    ]
   },
-
   "notes": [
     "Keywords are appended directly after 'plot item create <type>'",
     "Multiple keywords can be combined in a single command",
-    "These keywords are not officially documented; derived from working patterns"
+    "Live-verified against PFC3D 9.7 (Batch P1): every documented type's first-slot keyword set was enumerated with '?'; per-type sets recorded in each type's file/notes.",
+    "Live 9.7 type registry = 87 types, UNIFIED KERNEL: PFC types are mixed with other engines' (block*/bzone/zone*/flowplane/mpoint/structure-* ...). Cross-engine types parse but render no PFC data. PFC-relevant types beyond the documented eight, with live first-slot sets captured (Batch P1 workspace): ballthermal/clumpthermal/rblockthermal/cfdball/cfdclump/cfdelement/measure (= entity core set), contactthermal/wallthermal (+display), inlet (core minus shape), domain (active clip color-list cut-line legend polygons transparency), fracture-zone (contour-style: above/below/interval/maximum/minimum/ramp/log/value/...), particle-trace (active contour legend line skip trace-name transparency), geometry (edge/node/polygon/sets/import/view/...), chart-table (axis-x axis-y chart labels legend marks swap table title transparency), plus shared infrastructure items (axes scalebox data-* history-locations stereonet).",
+    "ATTRIBUTE-NAME TRAP (9.7): 'color-by <mode> <name>' accepts ANY string at create time - a bogus attribute is accepted silently and even 'plot export' raises no error (verified Batch P1). Attribute typos produce a wrong plot, not an error message. The attribute lists in the per-type files are verified on PFC2D 7.00, where create-time validation still rejected invalid names.",
+    "plot command family on PFC3D 9.7 matches the FLAC/3DEC re-stamp: 22 'plot' subcommands; export formats bitmap/csv/datafile/dxf/pdf/postscript/print/svg (bitmap: dpi/dpm/filename/size); 'plot view' = 13 3D-navigation keywords."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/rblock/color-by.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/rblock/color-by.json
@@ -2,7 +2,6 @@
   "name": "color-by",
   "parent": "rblock",
   "description": "Color-by modes for rblock plot items. Three modes depending on attribute type: vector, numeric, and text.",
-
   "modes": [
     {
       "keyword": "color-by vector-attribute",
@@ -14,9 +13,16 @@
         "color-by vector-attribute \"force-contact\""
       ],
       "available_attributes": [
-        "position", "velocity", "displacement", "spin",
-        "force-contact", "force-applied", "force-unbalanced",
-        "moment-contact", "moment-applied", "moment-unbalanced"
+        "position",
+        "velocity",
+        "displacement",
+        "spin",
+        "force-contact",
+        "force-applied",
+        "force-unbalanced",
+        "moment-contact",
+        "moment-applied",
+        "moment-unbalanced"
       ],
       "notes": "Defaults to magnitude. Append 'color-options scaled ramp rainbow minimum automatic maximum automatic' for rainbow scale."
     },
@@ -28,7 +34,12 @@
         "color-by numeric-attribute \"volume\"",
         "color-by numeric-attribute \"density\""
       ],
-      "available_attributes": ["volume", "damp", "density", "mass"],
+      "available_attributes": [
+        "volume",
+        "damp",
+        "density",
+        "mass"
+      ],
       "notes": "Append 'color-options scaled ramp rainbow minimum automatic maximum automatic' for rainbow scale"
     },
     {
@@ -39,7 +50,10 @@
         "color-by text-attribute \"id\" color-options named maximum-names 1000000 name-controls true",
         "color-by text-attribute \"group\" 'Any' color-options named maximum-names 1000000 name-controls true"
       ],
-      "available_attributes": ["id", "group"],
+      "available_attributes": [
+        "id",
+        "group"
+      ],
       "notes": "group attribute requires slot name ('Any' for default slot). Use 'color-options named' instead of 'scaled ramp'."
     },
     {
@@ -51,5 +65,8 @@
         "color-by numeric-attribute \"extra\" 3"
       ]
     }
+  ],
+  "notes": [
+    "PFC3D 9.7 behavior change (Batch P1): the attribute-name slot is a free-form String - create accepts ANY name silently (no error at create or export), so typos cannot be caught from the CLI. The attribute lists here are verified on PFC2D 7.00 (which rejected invalid names at create). Live 9.7 mode grammar confirmed: {numeric,tensor,text,vector} x {attribute,property} plus add-* overlay variants."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/rblock/cut.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/rblock/cut.json
@@ -2,7 +2,6 @@
   "name": "cut",
   "parent": "rblock",
   "description": "Cut plane for clipping rblock visualization. Shows only material on one side of a defined plane.",
-
   "keywords": [
     {
       "keyword": "cut active on",
@@ -32,12 +31,11 @@
       ]
     }
   ],
-
   "usage_in_creation": "Cut cannot be inlined in 'item create'. First create the item, then use 'item modify' to add the cut plane.",
   "usage_in_modification": "plot \"<name>\" item modify <id> cut active on type plane surface on front off back on origin (0,0,0) normal (0,1,0)",
-
   "notes": [
     "Cut plane syntax is identical across ball, clump, contact, rblock, and wall item types.",
-    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut."
+    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut.",
+    "Live PFC3D 9.7 (Batch P1): cut keywords DO parse inline at create time - 'plot item create <type> cut ?' enumerates active/back/front/surface/type, with type = none/octant/plane/wedge and front/surface booleans. The 'must use plot item modify' rule above was verified on PFC2D 7.00; on 9.7 both routes parse."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/rblock/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/rblock/index.json
@@ -1,10 +1,18 @@
 {
   "name": "rblock",
   "item_type": "rblock",
-  "search_keywords": ["rblock", "rigid-block", "rb", "color", "velocity", "displacement", "force", "volume"],
+  "search_keywords": [
+    "rblock",
+    "rigid-block",
+    "rb",
+    "color",
+    "velocity",
+    "displacement",
+    "force",
+    "volume"
+  ],
   "description": "Configuration keywords for 'plot item create rblock'. Controls rigid block rendering, coloring by attributes, cut planes, and legend display.",
   "base_syntax": "plot item create rblock <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "active on",
@@ -29,7 +37,6 @@
       "notes": "Appended after color-by for continuous color mapping"
     }
   ],
-
   "sub_items": [
     {
       "name": "color-by",
@@ -42,7 +49,6 @@
       "description": "Clip visualization with a cutting plane"
     }
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Default rblock visualization",
@@ -59,5 +65,9 @@
       "command": "plot item create rblock active on color-by text-attribute \"group\" 'Any' color-options named maximum-names 1000000 name-controls true legend active on",
       "description": "Different color per group name"
     }
+  ],
+  "notes": [
+    "Live PFC3D 9.7 first-slot enumeration (Batch P1): active both-directions clip color-by color-options cut ghosts legend map orientation range scale-by-magnitude selected-only shape template transparency.",
+    "rblock 'shape' drill-down (live 9.7): arrow ball core facet rblock + cell-extent/minimum-extent/shrink-factor sizing keywords."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/wall/color-by.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/wall/color-by.json
@@ -2,7 +2,6 @@
   "name": "color-by",
   "parent": "wall",
   "description": "Color-by modes for wall plot items.",
-
   "modes": [
     {
       "keyword": "color-by vector-attribute",
@@ -12,7 +11,12 @@
         "color-by vector-attribute \"velocity\"",
         "color-by vector-attribute \"force-contact\""
       ],
-      "available_attributes": ["position", "velocity", "displacement", "force-contact"]
+      "available_attributes": [
+        "position",
+        "velocity",
+        "displacement",
+        "force-contact"
+      ]
     },
     {
       "keyword": "color-by text-attribute",
@@ -22,7 +26,10 @@
         "color-by text-attribute \"name\" color-options named maximum-names 1000000 name-controls true",
         "color-by text-attribute \"group\" 'Any' piece off color-options named maximum-names 1000000 name-controls true"
       ],
-      "available_attributes": ["name", "group"],
+      "available_attributes": [
+        "name",
+        "group"
+      ],
       "notes": "group attribute requires slot name and 'piece off' for wall facets"
     },
     {
@@ -33,5 +40,8 @@
         "color-by numeric-attribute \"extra\" 1"
       ]
     }
+  ],
+  "notes": [
+    "PFC3D 9.7 behavior change (Batch P1): the attribute-name slot is a free-form String - create accepts ANY name silently (no error at create or export), so typos cannot be caught from the CLI. The attribute lists here are verified on PFC2D 7.00 (which rejected invalid names at create). Live 9.7 mode grammar confirmed: {numeric,tensor,text,vector} x {attribute,property} plus add-* overlay variants."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/wall/cut.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/wall/cut.json
@@ -2,7 +2,6 @@
   "name": "cut",
   "parent": "wall",
   "description": "Cut plane for clipping wall visualization. Shows only wall facets on one side of a defined plane.",
-
   "keywords": [
     {
       "keyword": "cut active on",
@@ -32,18 +31,21 @@
       ]
     }
   ],
-
   "usage_in_creation": "Cut cannot be inlined in 'item create'. First create the item, then use 'item modify' to add the cut plane.",
   "usage_in_modification": "plot \"<name>\" item modify <id> cut active on type plane surface on front off back on origin (0,0,0) normal (0,0,1)",
-
   "legend_settings": {
     "description": "Cut plane legend sub-settings exported in datafile",
-    "keywords": ["title", "origin", "normal", "orientation"],
+    "keywords": [
+      "title",
+      "origin",
+      "normal",
+      "orientation"
+    ],
     "example": "legend ... cut ... title active on size 44 family 'Arial' style normal color 'black' ... origin active off ... normal active off ... orientation active off"
   },
-
   "notes": [
     "Cut plane syntax is identical across ball, contact, and wall item types.",
-    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut."
+    "IMPORTANT: cut parameters must be set via 'plot item modify', not inline in 'plot item create'. Create the item first, then modify to add the cut.",
+    "Live PFC3D 9.7 (Batch P1): cut keywords DO parse inline at create time - 'plot item create <type> cut ?' enumerates active/back/front/surface/type, with type = none/octant/plane/wedge and front/surface booleans. The 'must use plot item modify' rule above was verified on PFC2D 7.00; on 9.7 both routes parse."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/wall/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/plot-items/wall/index.json
@@ -1,10 +1,15 @@
 {
   "name": "wall",
   "item_type": "wall",
-  "search_keywords": ["wall", "boundary", "transparency", "color", "force"],
+  "search_keywords": [
+    "wall",
+    "boundary",
+    "transparency",
+    "color",
+    "force"
+  ],
   "description": "Configuration keywords for 'plot item create wall'. Controls wall rendering, transparency, coloring by attributes, cut planes, and legend display.",
   "base_syntax": "plot item create wall <keywords...>",
-
   "basic_keywords": [
     {
       "keyword": "active on",
@@ -33,7 +38,6 @@
       "syntax": "color-options scaled ramp rainbow minimum automatic maximum automatic"
     }
   ],
-
   "sub_items": [
     {
       "name": "color-by",
@@ -46,7 +50,6 @@
       "description": "Clip visualization with a cutting plane"
     }
   ],
-
   "common_usage_patterns": [
     {
       "use_case": "Semi-transparent walls",
@@ -58,5 +61,8 @@
       "command": "plot item create wall active on color-by vector-attribute \"force-contact\" color-options scaled ramp rainbow minimum automatic maximum automatic transparency 50 legend active on",
       "description": "Force distribution on walls with moderate transparency"
     }
+  ],
+  "notes": [
+    "Live PFC3D 9.7 first-slot enumeration (Batch P1): active both-directions clip color-by color-options cut display ghosts legend map orientation range scale-by-magnitude selected-only shape transparency."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/range-elements/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/range-elements/index.json
@@ -252,7 +252,9 @@
   "notes": [
     "Multiple range elements create intersection (AND) by default",
     "Use 'union' keyword for OR logic",
-    "Unspecified range affects all objects of target type"
+    "Unspecified range affects all objects of target type",
+    "Live PFC3D 9.7 enumeration (Batch P1) = 66 tokens: annulus aspect-ratio bmaterial by cmodel component-id component-id-list concave contact cylinder deformable deselected dfn dfn-3dec displacement edge-length ellipse excavated extent extra extra-list face-area fid fidlist fish fracture-id geometry-distance geometry-space group group-intersection id id-list index-list interface jmaterial jmodel joint-set leader-id mintersection name named-range not orientation plane polygon position position-x position-y position-z project-range radius rectangle region remove rintersection seed selected set sphere sregion state structure-type surface union use-hidden velocity volume wall.",
+    "UNIFIED-KERNEL caveat (same as FLAC): the 9.x parser enumerates other engines' range elements too (bmaterial/cmodel/deformable/excavated/jmaterial/jmodel/joint-set/interface/structure-type/dfn-3dec/...) - accepted by the parser but meaningless for PFC data. PFC-relevant tokens missing from this index include: aspect-ratio displacement edge-length face-area fid/fidlist/fracture-id geometry-distance geometry-space group-intersection index-list name named-range orientation project-range radius region remove seed selected/deselected set state surface use-hidden velocity volume wall."
   ],
   "related_commands": [
     "model range create",


### PR DESCRIPTION
First formal unified-standard verification batch for the PFC corpus — the same discipline as FLAC (0.6.6) and 3DEC (0.6.7). New checklist `pfc.md` in the verification workspace; 27 corpus JSONs touched.

## plot-items (the user-reported gap)
Previously authored from working patterns (the index's own notes said so); now live-verified on PFC3D 9.7:
- **Type registry = 87 types, UNIFIED KERNEL** (unlike 3DEC's engine-scoped 48) — cross-engine types parse but render no PFC data.
- Per-type first-slot keyword sets for all 8 documented types; shared-keyword core corrected from 5 to 15 live keywords; 14 undocumented PFC-relevant types captured in the index with their live sets.
- **cut parses inline at create on 9.7** (the documented "must use `plot item modify`" rule was 7.00-era); `cut type` = none/octant/plane/wedge; shape drill-downs (ball arrow params, clump pebble/surface, rblock core/facet, contact cylinder/disk/sphere/joint); fracture `rosette`/`stereonet` parameter sets; dfn `contour` continuation.
- **Attribute-name trap (9.7 behavior change)**: `color-by <mode> <name>` accepts ANY string silently — create and even `plot export` raise no error (bogus controls all passed). Attribute typos produce a wrong plot, not an error. The per-type attribute lists stay verified-on-PFC2D-7.00 (which did reject invalid names) and are now labeled as such.

## Similar boundaries checked (统一标准边界)
- **range-elements**: live 66-token enumeration recorded (corpus documented 24); unified-kernel caveat + PFC-relevant missing tokens listed.
- **histories** (ball/clump/rblock/wall/contact/measure): `kwd:` crawler artifacts stripped from both version blocks (same bug class as 3DEC Batch 1); live 9.7 additions (`axis-angle-*`, `convergence`, `ratio-local`, `name`); **contact history grammar rebuilt** — the contact-type pair (ball-ball/ball-facet/…/rblock-rblock) is the REQUIRED first slot, live spellings adopted (`force-local-*`, `moment-on1/2*`, `force-normal`, `force-shear`, `gap`) with the official stale spellings (`localforce-*`, `normalforce`, …) flagged in place; the required object selector documented.
- **fish-intrinsics**: PFC has NO fish-intrinsics reference family (FLAC and 3DEC both do). Full live dump captured (3754 names, ~1290 PFC-family) to scope the authoring batch — tracked as the next open item in `pfc.md`.

Tests: `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)