### PR TITLE
docs: author PFC fish-intrinsics reference family from live 9.7 dump (Batch P2)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/ball.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/ball.json
@@ -1,0 +1,438 @@
+{
+  "name": "ball",
+  "dimension": "3D",
+  "full_name": "Ball FISH Intrinsics",
+  "description": "Pointer-based FISH access to balls - iteration, kinematics, forces, attributes, plus the ball.thermal.* / ball.fluid.* / ball.cfd.* process twins and ball.zone.* coupling namespaces.",
+  "intrinsic_families": [
+    {
+      "family": "iteration & lookup",
+      "examples": [
+        {
+          "name": "ball.list",
+          "signature": "ball_list_pnt := ball.list()"
+        },
+        {
+          "name": "ball.find",
+          "signature": "bal_pnt := ball.find(int)"
+        },
+        {
+          "name": "ball.near",
+          "signature": "bal_pnt := ball.near(vec3+,<flt>)"
+        },
+        {
+          "name": "ball.num",
+          "signature": "int := ball.num()"
+        },
+        {
+          "name": "ball.maxid",
+          "signature": "int := ball.maxid()"
+        },
+        {
+          "name": "ball.inbox",
+          "signature": "list := ball.inbox(vec3+,vec3+,<bool>)"
+        },
+        {
+          "name": "ball.containing",
+          "signature": "ball_pnt := ball.containing(vec3+,<index>)"
+        },
+        {
+          "name": "ball.inside",
+          "signature": "bool := ball.inside(ball_pnt,vec3)"
+        }
+      ]
+    },
+    {
+      "family": "kinematics",
+      "examples": [
+        {
+          "name": "ball.pos",
+          "signature": "vec3/flt := ball.pos(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.vel",
+          "signature": "vec3/flt := ball.vel(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.disp",
+          "signature": "vec3/flt := ball.disp(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.spin",
+          "signature": "vec3/flt := ball.spin(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.euler",
+          "signature": "vec3/flt := ball.euler(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.axis.angle",
+          "signature": "vec3/flt := ball.axis.angle(ball_pnt,<int>) := vec3/flt"
+        }
+      ],
+      "notes": [
+        "Vector intrinsics carry .x/.y/.z component variants throughout."
+      ]
+    },
+    {
+      "family": "forces & moments",
+      "examples": [
+        {
+          "name": "ball.force.app",
+          "signature": "vec3/flt := ball.force.app(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.force.contact",
+          "signature": "vec3/flt := ball.force.contact(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.force.unbal",
+          "signature": "vec3/flt := ball.force.unbal(ball_pnt,<int>)"
+        },
+        {
+          "name": "ball.moment.contact",
+          "signature": "vec3/flt := ball.moment.contact(ball_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "ball.moment.unbal",
+          "signature": "vec3/flt := ball.moment.unbal(ball_pnt,<int>)"
+        }
+      ]
+    },
+    {
+      "family": "attributes & properties",
+      "examples": [
+        {
+          "name": "ball.radius",
+          "signature": "flt := ball.radius(ball_pnt) := flt"
+        },
+        {
+          "name": "ball.density",
+          "signature": "flt := ball.density(ball_pnt) := flt"
+        },
+        {
+          "name": "ball.mass",
+          "signature": "flt := ball.mass(ball_pnt)"
+        },
+        {
+          "name": "ball.mass.real",
+          "signature": "flt := ball.mass.real(ball_pnt)"
+        },
+        {
+          "name": "ball.moi",
+          "signature": "flt := ball.moi(ball_pnt)"
+        },
+        {
+          "name": "ball.damp",
+          "signature": "flt := ball.damp(ball_pnt) := flt"
+        },
+        {
+          "name": "ball.prop",
+          "signature": "any := ball.prop(ball_pnt,str) := any"
+        },
+        {
+          "name": "ball.isprop",
+          "signature": "bool := ball.isprop(ball_pnt,str)"
+        },
+        {
+          "name": "ball.stress",
+          "signature": "ten/flt := ball.stress(ball_pnt,<int>,<int>)"
+        },
+        {
+          "name": "ball.fix",
+          "signature": "bool := ball.fix(ball_pnt,int) := bool"
+        },
+        {
+          "name": "ball.extra",
+          "signature": "any := ball.extra(ball_pnt,<int>) := any"
+        },
+        {
+          "name": "ball.group",
+          "signature": "str := ball.group(ball_pnt,<str/index>) := str/index"
+        },
+        {
+          "name": "ball.id",
+          "signature": "int := ball.id(ball_pnt)"
+        },
+        {
+          "name": "ball.isbonded",
+          "signature": "bool := ball.isbonded(ball_pnt,<pnt/int>)"
+        },
+        {
+          "name": "ball.energy",
+          "signature": "flt := ball.energy(str)"
+        },
+        {
+          "name": "ball.fragment",
+          "signature": "int := ball.fragment(ball_pnt) := int"
+        }
+      ]
+    },
+    {
+      "family": "creation & deletion",
+      "examples": [
+        {
+          "name": "ball.create",
+          "signature": "ball_pnt := ball.create(ball_pnt,vec3+,<int>)"
+        },
+        {
+          "name": "ball.delete",
+          "signature": "bool = ball.delete(ball_pnt)"
+        }
+      ]
+    },
+    {
+      "family": "convergence & ratios",
+      "examples": [
+        {
+          "name": "ball.convergence",
+          "signature": "flt := ball.convergence(ball_pnt)"
+        },
+        {
+          "name": "ball.ratio",
+          "signature": "flt := ball.ratio(ball_pnt)"
+        },
+        {
+          "name": "ball.ratio.target",
+          "signature": "flt := ball.ratio.target(ball_pnt) := flt"
+        },
+        {
+          "name": "ball.mech.ratio.avg",
+          "signature": "flt := ball.mech.ratio.avg()"
+        },
+        {
+          "name": "ball.mech.ratio.max",
+          "signature": "flt := ball.mech.ratio.max()"
+        },
+        {
+          "name": "ball.mech.unbal.max",
+          "signature": "flt := ball.mech.unbal.max()"
+        }
+      ]
+    },
+    {
+      "family": "contact topology",
+      "examples": [
+        {
+          "name": "ball.contact.list",
+          "signature": "list := ball.contact.list(ball_pnt,<int>,<pce_pnt>)"
+        },
+        {
+          "name": "ball.contactmap",
+          "signature": "map := ball.contactmap(ball_pnt,<int>,<pce_pnt>)"
+        },
+        {
+          "name": "ball.contactnum",
+          "signature": "int := ball.contactnum(ball_pnt,<int>)"
+        }
+      ],
+      "notes": [
+        ".all variants include inactive contacts."
+      ]
+    },
+    {
+      "family": "process sub-namespaces",
+      "examples": [
+        {
+          "name": "ball.thermal.temp",
+          "signature": "flt = ball.thermal.temp(tball_pnt) = flt"
+        },
+        {
+          "name": "ball.thermal.power.unbal",
+          "signature": "flt = ball.thermal.power.unbal(tball_pnt)"
+        },
+        {
+          "name": "ball.fluid.pressure.head",
+          "signature": "flt := ball.fluid.pressure.head(fball_pnt)"
+        },
+        {
+          "name": "ball.cfd.force",
+          "signature": "vec3/flt = ball.cfd.force(cfdball_pnt,<int>) = vec3/flt"
+        },
+        {
+          "name": "ball.zone.ball.mass.factor",
+          "signature": "flt = ball.zone.ball.mass.factor(cball_pnt) = flt"
+        }
+      ],
+      "notes": [
+        "ball.thermal.* (36 names) mirrors the mechanical bookkeeping for the thermal process; ball.fluid.* (11) and ball.cfd.* (22) likewise; ball.zone.* couples balls to FLAC3D-style zones."
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 171,
+    "names": [
+      "ball.axis.angle",
+      "ball.axis.angle.x",
+      "ball.axis.angle.y",
+      "ball.axis.angle.z",
+      "ball.cfd.ball",
+      "ball.cfd.elementlist",
+      "ball.cfd.elementmap",
+      "ball.cfd.extra",
+      "ball.cfd.find",
+      "ball.cfd.force",
+      "ball.cfd.force.x",
+      "ball.cfd.force.y",
+      "ball.cfd.force.z",
+      "ball.cfd.group",
+      "ball.cfd.group.remove",
+      "ball.cfd.id",
+      "ball.cfd.inbox",
+      "ball.cfd.isgroup",
+      "ball.cfd.list",
+      "ball.cfd.near",
+      "ball.cfd.num",
+      "ball.cfd.pos",
+      "ball.cfd.pos.x",
+      "ball.cfd.pos.y",
+      "ball.cfd.pos.z",
+      "ball.cfd.typeid",
+      "ball.contact.list",
+      "ball.contact.list.all",
+      "ball.contactmap",
+      "ball.contactmap.all",
+      "ball.contactnum",
+      "ball.contactnum.all",
+      "ball.containing",
+      "ball.convergence",
+      "ball.create",
+      "ball.damp",
+      "ball.delete",
+      "ball.density",
+      "ball.disp",
+      "ball.disp.x",
+      "ball.disp.y",
+      "ball.disp.z",
+      "ball.energy",
+      "ball.euler",
+      "ball.euler.x",
+      "ball.euler.y",
+      "ball.euler.z",
+      "ball.extra",
+      "ball.find",
+      "ball.fix",
+      "ball.fluid.ball.mech",
+      "ball.fluid.contact.list",
+      "ball.fluid.contactmap",
+      "ball.fluid.contactnum",
+      "ball.fluid.find",
+      "ball.fluid.id",
+      "ball.fluid.list",
+      "ball.fluid.near",
+      "ball.fluid.num",
+      "ball.fluid.pressure.head",
+      "ball.force.app",
+      "ball.force.app.x",
+      "ball.force.app.y",
+      "ball.force.app.z",
+      "ball.force.contact",
+      "ball.force.contact.x",
+      "ball.force.contact.y",
+      "ball.force.contact.z",
+      "ball.force.unbal",
+      "ball.force.unbal.x",
+      "ball.force.unbal.y",
+      "ball.force.unbal.z",
+      "ball.fragment",
+      "ball.group",
+      "ball.group.list",
+      "ball.group.remove",
+      "ball.groupmap",
+      "ball.id",
+      "ball.inbox",
+      "ball.inside",
+      "ball.isbonded",
+      "ball.isgroup",
+      "ball.isprop",
+      "ball.list",
+      "ball.mass",
+      "ball.mass.real",
+      "ball.maxid",
+      "ball.mech.convergence",
+      "ball.mech.ratio.avg",
+      "ball.mech.ratio.local",
+      "ball.mech.ratio.max",
+      "ball.mech.unbal.max",
+      "ball.moi",
+      "ball.moi.real",
+      "ball.moment.app",
+      "ball.moment.app.x",
+      "ball.moment.app.y",
+      "ball.moment.app.z",
+      "ball.moment.contact",
+      "ball.moment.contact.x",
+      "ball.moment.contact.y",
+      "ball.moment.contact.z",
+      "ball.moment.unbal",
+      "ball.moment.unbal.x",
+      "ball.moment.unbal.y",
+      "ball.moment.unbal.z",
+      "ball.near",
+      "ball.num",
+      "ball.pos",
+      "ball.pos.x",
+      "ball.pos.y",
+      "ball.pos.z",
+      "ball.prop",
+      "ball.radius",
+      "ball.ratio",
+      "ball.ratio.target",
+      "ball.spin",
+      "ball.spin.x",
+      "ball.spin.y",
+      "ball.spin.z",
+      "ball.stress",
+      "ball.stress.full",
+      "ball.stress.xx",
+      "ball.stress.xy",
+      "ball.stress.xz",
+      "ball.stress.yy",
+      "ball.stress.yz",
+      "ball.stress.zz",
+      "ball.thermal.ball",
+      "ball.thermal.contact.list",
+      "ball.thermal.contact.list.all",
+      "ball.thermal.contactmap",
+      "ball.thermal.contactmap.all",
+      "ball.thermal.contactnum",
+      "ball.thermal.contactnum.all",
+      "ball.thermal.expansion",
+      "ball.thermal.extra",
+      "ball.thermal.find",
+      "ball.thermal.fix",
+      "ball.thermal.group",
+      "ball.thermal.group.list",
+      "ball.thermal.group.remove",
+      "ball.thermal.groupmap",
+      "ball.thermal.id",
+      "ball.thermal.inbox",
+      "ball.thermal.isgroup",
+      "ball.thermal.isprop",
+      "ball.thermal.list",
+      "ball.thermal.near",
+      "ball.thermal.num",
+      "ball.thermal.power.app",
+      "ball.thermal.power.unbal",
+      "ball.thermal.prop",
+      "ball.thermal.specific.heat",
+      "ball.thermal.temp",
+      "ball.thermal.temp.increment",
+      "ball.thermal.typeid",
+      "ball.typeid",
+      "ball.vel",
+      "ball.vel.x",
+      "ball.vel.y",
+      "ball.vel.z",
+      "ball.vol",
+      "ball.zone.ball.ball",
+      "ball.zone.ball.list",
+      "ball.zone.ball.mass.factor",
+      "ball.zone.ball.typeid",
+      "ball.zone.gp.gp",
+      "ball.zone.gp.list",
+      "ball.zone.gp.mass.factor",
+      "ball.zone.gp.typeid"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/clump.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/clump.json
@@ -1,0 +1,466 @@
+{
+  "name": "clump",
+  "dimension": "3D",
+  "full_name": "Clump / Pebble / Clump-Template FISH Intrinsics",
+  "description": "FISH access to clumps (rigid pebble clusters): the clump body, its pebbles (clump.pebble.*), reusable clump templates (clump.template.*), and thermal/cfd twins.",
+  "intrinsic_families": [
+    {
+      "family": "clump body",
+      "examples": [
+        {
+          "name": "clump.list",
+          "signature": "clump_list_pnt = clump.list()"
+        },
+        {
+          "name": "clump.find",
+          "signature": "clump_pnt = clump.find(int)"
+        },
+        {
+          "name": "clump.pos",
+          "signature": "vec3/flt := clump.pos(clump_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "clump.vel",
+          "signature": "vec3/flt := clump.vel(clump_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "clump.spin",
+          "signature": "vec3/flt := clump.spin(clump_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "clump.mass",
+          "signature": "flt := clump.mass(clump_pnt)"
+        },
+        {
+          "name": "clump.vol",
+          "signature": "flt := clump.vol(clump_pnt)"
+        },
+        {
+          "name": "clump.moi.prin",
+          "signature": "vec3/flt := clump.moi.prin(clump_pnt,<int>)"
+        },
+        {
+          "name": "clump.inglobal",
+          "signature": "vec3/flt := clump.inglobal(clump_pnt,vec3/flt)"
+        },
+        {
+          "name": "clump.inprin",
+          "signature": "vec3/flt := clump.inprin(clump_pnt,vec3/flt)"
+        },
+        {
+          "name": "clump.rotate",
+          "signature": "int := clump.rotate(clump_pnt,vec3/flt)"
+        },
+        {
+          "name": "clump.scalesphere",
+          "signature": "int := clump.scalesphere(clump_pnt,flt)"
+        },
+        {
+          "name": "clump.scalevol",
+          "signature": "int := clump.scalevol(clump_pnt,flt)"
+        },
+        {
+          "name": "clump.calculate",
+          "signature": "bool := clump.calculate(clump_pnt,<int>)"
+        }
+      ],
+      "notes": [
+        "clump.inglobal/clump.inprin convert between global and principal-axis frames; moi has .real (deformable-mass) variants."
+      ]
+    },
+    {
+      "family": "pebbles",
+      "examples": [
+        {
+          "name": "clump.pebblelist",
+          "signature": "pebble_list_pnt := clump.pebblelist(clump_pnt)"
+        },
+        {
+          "name": "clump.pebble.list",
+          "signature": "pebble_list_pnt = clump.pebble.list()"
+        },
+        {
+          "name": "clump.pebble.find",
+          "signature": "pebble_pnt = clump.pebble.find(int)"
+        },
+        {
+          "name": "clump.pebble.clump",
+          "signature": "clump_pnt := clump.pebble.clump(pebble_pnt)"
+        },
+        {
+          "name": "clump.pebble.pos",
+          "signature": "vec3/flt := clump.pebble.pos(pebble_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "clump.pebble.radius",
+          "signature": "flt := clump.pebble.radius(pebble_pnt) := flt"
+        },
+        {
+          "name": "clump.addpebble",
+          "signature": "clump_pnt := clump.addpebble(clump_pnt,flt,vec3,<int>)"
+        },
+        {
+          "name": "clump.deletepebble",
+          "signature": "bool = clump.deletepebble(clump_pnt,pebble_pnt)"
+        }
+      ]
+    },
+    {
+      "family": "templates",
+      "examples": [
+        {
+          "name": "clump.template.list",
+          "signature": "template_list_pnt = clump.template.list()"
+        },
+        {
+          "name": "clump.template.find",
+          "signature": "template_pnt = clump.template.find(str)"
+        },
+        {
+          "name": "clump.template.make",
+          "signature": "template_pnt = clump.template.make(template_pnt,str)"
+        },
+        {
+          "name": "clump.template.clone",
+          "signature": "template_pnt = clump.template.clone(template_pnt,str)"
+        },
+        {
+          "name": "clump.template.name",
+          "signature": "str = clump.template.name(template_pnt)"
+        },
+        {
+          "name": "clump.template.pebblelist",
+          "signature": "pebble_list_pnt = clump.template.pebblelist(template_pnt)"
+        },
+        {
+          "name": "clump.template.vol",
+          "signature": "flt = clump.template.vol(template_pnt) = flt"
+        }
+      ],
+      "notes": [
+        "Templates are the reusable shape library behind 'clump template create' / 'clump generate'."
+      ]
+    },
+    {
+      "family": "process sub-namespaces",
+      "examples": [
+        {
+          "name": "clump.thermal.temp",
+          "signature": "flt = clump.thermal.temp(tclump_pnt) = flt"
+        },
+        {
+          "name": "clump.thermal.pebble.list",
+          "signature": "pebblet_list_pnt = clump.thermal.pebble.list()"
+        },
+        {
+          "name": "clump.cfd.force",
+          "signature": "vec3/flt = clump.cfd.force(cfdclump_pnt,<int>) = vec3/flt"
+        }
+      ],
+      "notes": [
+        "clump.thermal.* (55 names incl. thermal pebbles) and clump.cfd.* (39 incl. cfd pebbles) mirror the mechanical namespaces."
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 295,
+    "names": [
+      "clump.addpebble",
+      "clump.axis.angle",
+      "clump.axis.angle.x",
+      "clump.axis.angle.y",
+      "clump.axis.angle.z",
+      "clump.calculate",
+      "clump.cfd.clump",
+      "clump.cfd.element.list",
+      "clump.cfd.elementmap",
+      "clump.cfd.extra",
+      "clump.cfd.find",
+      "clump.cfd.force",
+      "clump.cfd.force.x",
+      "clump.cfd.force.y",
+      "clump.cfd.force.z",
+      "clump.cfd.group",
+      "clump.cfd.group.remove",
+      "clump.cfd.id",
+      "clump.cfd.inbox",
+      "clump.cfd.isgroup",
+      "clump.cfd.list",
+      "clump.cfd.near",
+      "clump.cfd.num",
+      "clump.cfd.pebble.clump",
+      "clump.cfd.pebble.find",
+      "clump.cfd.pebble.group",
+      "clump.cfd.pebble.group.remove",
+      "clump.cfd.pebble.id",
+      "clump.cfd.pebble.inbox",
+      "clump.cfd.pebble.isgroup",
+      "clump.cfd.pebble.list",
+      "clump.cfd.pebble.near",
+      "clump.cfd.pebble.num",
+      "clump.cfd.pebble.pebble",
+      "clump.cfd.pebble.pos",
+      "clump.cfd.pebble.pos.x",
+      "clump.cfd.pebble.pos.y",
+      "clump.cfd.pebble.pos.z",
+      "clump.cfd.pebble.typeid",
+      "clump.cfd.pebblelist",
+      "clump.cfd.pos",
+      "clump.cfd.pos.x",
+      "clump.cfd.pos.y",
+      "clump.cfd.pos.z",
+      "clump.cfd.typeid",
+      "clump.contact.list",
+      "clump.contact.list.all",
+      "clump.contactmap",
+      "clump.contactmap.all",
+      "clump.contactnum",
+      "clump.contactnum.all",
+      "clump.containing",
+      "clump.convergence",
+      "clump.damp",
+      "clump.delete",
+      "clump.deletepebble",
+      "clump.density",
+      "clump.disp",
+      "clump.disp.x",
+      "clump.disp.y",
+      "clump.disp.z",
+      "clump.energy",
+      "clump.euler",
+      "clump.euler.x",
+      "clump.euler.y",
+      "clump.euler.z",
+      "clump.extra",
+      "clump.find",
+      "clump.fix",
+      "clump.force.app",
+      "clump.force.app.x",
+      "clump.force.app.y",
+      "clump.force.app.z",
+      "clump.force.contact",
+      "clump.force.contact.x",
+      "clump.force.contact.y",
+      "clump.force.contact.z",
+      "clump.force.unbal",
+      "clump.force.unbal.x",
+      "clump.force.unbal.y",
+      "clump.force.unbal.z",
+      "clump.fragment",
+      "clump.group",
+      "clump.group.list",
+      "clump.group.remove",
+      "clump.groupmap",
+      "clump.id",
+      "clump.inbox",
+      "clump.inglobal",
+      "clump.inprin",
+      "clump.inside",
+      "clump.isbonded",
+      "clump.isgroup",
+      "clump.list",
+      "clump.mass",
+      "clump.mass.real",
+      "clump.maxid",
+      "clump.mech.convergence",
+      "clump.mech.ratio.avg",
+      "clump.mech.ratio.local",
+      "clump.mech.ratio.max",
+      "clump.mech.unbal.max",
+      "clump.moi",
+      "clump.moi.fix",
+      "clump.moi.prin",
+      "clump.moi.prin.real",
+      "clump.moi.prin.real.x",
+      "clump.moi.prin.real.y",
+      "clump.moi.prin.real.z",
+      "clump.moi.prin.x",
+      "clump.moi.prin.y",
+      "clump.moi.prin.z",
+      "clump.moi.real",
+      "clump.moi.real.xx",
+      "clump.moi.real.xy",
+      "clump.moi.real.xz",
+      "clump.moi.real.yy",
+      "clump.moi.real.yz",
+      "clump.moi.real.zz",
+      "clump.moi.xx",
+      "clump.moi.xy",
+      "clump.moi.xz",
+      "clump.moi.yy",
+      "clump.moi.yz",
+      "clump.moi.zz",
+      "clump.moment.app",
+      "clump.moment.app.x",
+      "clump.moment.app.y",
+      "clump.moment.app.z",
+      "clump.moment.contact",
+      "clump.moment.contact.x",
+      "clump.moment.contact.y",
+      "clump.moment.contact.z",
+      "clump.moment.unbal",
+      "clump.moment.unbal.x",
+      "clump.moment.unbal.y",
+      "clump.moment.unbal.z",
+      "clump.near",
+      "clump.num",
+      "clump.pebble.clump",
+      "clump.pebble.contact.list",
+      "clump.pebble.contact.list.all",
+      "clump.pebble.contactmap",
+      "clump.pebble.contactmap.all",
+      "clump.pebble.contactnum",
+      "clump.pebble.contactnum.all",
+      "clump.pebble.delete",
+      "clump.pebble.extra",
+      "clump.pebble.find",
+      "clump.pebble.group",
+      "clump.pebble.group.list",
+      "clump.pebble.group.remove",
+      "clump.pebble.groupmap",
+      "clump.pebble.id",
+      "clump.pebble.inbox",
+      "clump.pebble.isbonded",
+      "clump.pebble.isgroup",
+      "clump.pebble.isprop",
+      "clump.pebble.list",
+      "clump.pebble.maxid",
+      "clump.pebble.near",
+      "clump.pebble.num",
+      "clump.pebble.pos",
+      "clump.pebble.pos.x",
+      "clump.pebble.pos.y",
+      "clump.pebble.pos.z",
+      "clump.pebble.prop",
+      "clump.pebble.radius",
+      "clump.pebble.typeid",
+      "clump.pebble.vel",
+      "clump.pebble.vel.x",
+      "clump.pebble.vel.y",
+      "clump.pebble.vel.z",
+      "clump.pebblelist",
+      "clump.pos",
+      "clump.pos.x",
+      "clump.pos.y",
+      "clump.pos.z",
+      "clump.prop",
+      "clump.ratio",
+      "clump.ratio.target",
+      "clump.rotate",
+      "clump.scalesphere",
+      "clump.scalevol",
+      "clump.spin",
+      "clump.spin.x",
+      "clump.spin.y",
+      "clump.spin.z",
+      "clump.stress",
+      "clump.stress.xx",
+      "clump.stress.xy",
+      "clump.stress.xz",
+      "clump.stress.yy",
+      "clump.stress.yz",
+      "clump.stress.zz",
+      "clump.template",
+      "clump.template.aangle",
+      "clump.template.aangle.x",
+      "clump.template.aangle.y",
+      "clump.template.aangle.z",
+      "clump.template.addpebble",
+      "clump.template.clone",
+      "clump.template.delete",
+      "clump.template.deletepebble",
+      "clump.template.euler",
+      "clump.template.euler.x",
+      "clump.template.euler.y",
+      "clump.template.euler.z",
+      "clump.template.find",
+      "clump.template.findpebble",
+      "clump.template.list",
+      "clump.template.make",
+      "clump.template.maxid",
+      "clump.template.moi",
+      "clump.template.moi.prin",
+      "clump.template.moi.prin.x",
+      "clump.template.moi.prin.y",
+      "clump.template.moi.prin.z",
+      "clump.template.moi.xx",
+      "clump.template.moi.xy",
+      "clump.template.moi.xz",
+      "clump.template.moi.yy",
+      "clump.template.moi.yz",
+      "clump.template.moi.zz",
+      "clump.template.name",
+      "clump.template.num",
+      "clump.template.origpos",
+      "clump.template.origpos.x",
+      "clump.template.origpos.y",
+      "clump.template.origpos.z",
+      "clump.template.pebblelist",
+      "clump.template.scale",
+      "clump.template.typeid",
+      "clump.template.vol",
+      "clump.thermal.clump",
+      "clump.thermal.contact.list",
+      "clump.thermal.contact.list.all",
+      "clump.thermal.contactmap",
+      "clump.thermal.contactmap.all",
+      "clump.thermal.contactnum",
+      "clump.thermal.contactnum.all",
+      "clump.thermal.expansion",
+      "clump.thermal.extra",
+      "clump.thermal.find",
+      "clump.thermal.fix",
+      "clump.thermal.group",
+      "clump.thermal.group.list",
+      "clump.thermal.group.remove",
+      "clump.thermal.groupmap",
+      "clump.thermal.id",
+      "clump.thermal.inbox",
+      "clump.thermal.isgroup",
+      "clump.thermal.list",
+      "clump.thermal.near",
+      "clump.thermal.num",
+      "clump.thermal.pebble.clump",
+      "clump.thermal.pebble.contact.list",
+      "clump.thermal.pebble.contact.list.all",
+      "clump.thermal.pebble.contactmap",
+      "clump.thermal.pebble.contactmap.all",
+      "clump.thermal.pebble.contactnum",
+      "clump.thermal.pebble.contactnum.all",
+      "clump.thermal.pebble.find",
+      "clump.thermal.pebble.group",
+      "clump.thermal.pebble.group.list",
+      "clump.thermal.pebble.group.remove",
+      "clump.thermal.pebble.groupmap",
+      "clump.thermal.pebble.id",
+      "clump.thermal.pebble.inbox",
+      "clump.thermal.pebble.isgroup",
+      "clump.thermal.pebble.isprop",
+      "clump.thermal.pebble.list",
+      "clump.thermal.pebble.near",
+      "clump.thermal.pebble.num",
+      "clump.thermal.pebble.pebble",
+      "clump.thermal.pebble.pos",
+      "clump.thermal.pebble.pos.x",
+      "clump.thermal.pebble.pos.y",
+      "clump.thermal.pebble.pos.z",
+      "clump.thermal.pebble.prop",
+      "clump.thermal.pebble.typeid",
+      "clump.thermal.pebblelist",
+      "clump.thermal.power.app",
+      "clump.thermal.power.unbal",
+      "clump.thermal.prop",
+      "clump.thermal.specific.heat",
+      "clump.thermal.temp",
+      "clump.thermal.temp.increment",
+      "clump.thermal.typeid",
+      "clump.typeid",
+      "clump.vel",
+      "clump.vel.x",
+      "clump.vel.y",
+      "clump.vel.z",
+      "clump.vol"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/contact.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/contact.json
@@ -1,0 +1,329 @@
+{
+  "name": "contact",
+  "dimension": "3D",
+  "full_name": "Contact FISH Intrinsics",
+  "description": "FISH access to contacts (all pair types): forces in global/local frames, gap, contact-model properties, end bodies, activity/bond state, and the contact.fluid.* fluid-pipe namespace.",
+  "intrinsic_families": [
+    {
+      "family": "iteration & topology",
+      "examples": [
+        {
+          "name": "contact.list",
+          "signature": "contact_list_pnt := contact.list(<str>)"
+        },
+        {
+          "name": "contact.find",
+          "signature": "contact_pnt := contact.find(int/str,int,<int>)"
+        },
+        {
+          "name": "contact.num",
+          "signature": "int := contact.num(<str>)"
+        },
+        {
+          "name": "contact.end1",
+          "signature": "piece_pnt := contact.end1(contact_pnt)"
+        },
+        {
+          "name": "contact.end2",
+          "signature": "piece_pnt := contact.end2(contact_pnt)"
+        },
+        {
+          "name": "contact.otherend",
+          "signature": "flt := contact.otherend(contact_pnt,any)"
+        },
+        {
+          "name": "contact.pos",
+          "signature": "vec3/flt := contact.pos(contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.gps",
+          "signature": "gp_list_pnt = contact.gps(con_pnt)"
+        }
+      ],
+      "notes": [
+        "contact.list.all / contact.num.all include inactive contacts; contact.list takes an optional type-name filter."
+      ]
+    },
+    {
+      "family": "forces & moments",
+      "examples": [
+        {
+          "name": "contact.force.global",
+          "signature": "vec3/flt := contact.force.global(mech_contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.force.local",
+          "signature": "vec3/flt := contact.force.local(mech_contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.force.normal",
+          "signature": "flt := contact.force.normal(mech_contact_pnt)"
+        },
+        {
+          "name": "contact.force.shear",
+          "signature": "flt := contact.force.shear(mech_contact_pnt)"
+        },
+        {
+          "name": "contact.force.set",
+          "signature": "contact.force.set(mech_contact_pnt) := vec3"
+        },
+        {
+          "name": "contact.moment.on1.global",
+          "signature": "vec3/flt := contact.moment.on1.global(mech_contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.moment.on2.global",
+          "signature": "vec3/flt := contact.moment.on2.global(mech_contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.gap",
+          "signature": "flt := contact.gap(contact_pnt)"
+        },
+        {
+          "name": "contact.normal",
+          "signature": "vec3/flt := contact.normal(contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.branch",
+          "signature": "vec3/flt := contact.branch(mech_contact_pnt,<int>)"
+        },
+        {
+          "name": "contact.offset",
+          "signature": "vec3/flt := contact.offset(contact_pnt,<int>)"
+        }
+      ],
+      "notes": [
+        "Frame conversion via contact.to.global / contact.to.local."
+      ]
+    },
+    {
+      "family": "model & properties",
+      "examples": [
+        {
+          "name": "contact.model",
+          "signature": "str := contact.model(contact_pnt) := str"
+        },
+        {
+          "name": "contact.prop",
+          "signature": "any := contact.prop(contact_pnt,str,<int>) := any"
+        },
+        {
+          "name": "contact.prop.index",
+          "signature": "int := contact.prop.index(contact_pnt,str)"
+        },
+        {
+          "name": "contact.model.prop.index",
+          "signature": "int := contact.model.prop.index(str,str)"
+        },
+        {
+          "name": "contact.isprop",
+          "signature": "bool := contact.isprop(contact_pnt,str,<int>)"
+        },
+        {
+          "name": "contact.method",
+          "signature": "bool := contact.method(contact_pnt,str,<arr>)"
+        }
+      ],
+      "notes": [
+        "contact.prop reads/writes contact-model properties by name; contact.method invokes model methods (e.g. bond/unbond on bonded models)."
+      ]
+    },
+    {
+      "family": "state & lifecycle",
+      "examples": [
+        {
+          "name": "contact.active",
+          "signature": "bool := contact.active(contact_pnt)"
+        },
+        {
+          "name": "contact.activate",
+          "signature": "bool := contact.activate(contact_pnt) := bool"
+        },
+        {
+          "name": "contact.inhibit",
+          "signature": "bool := contact.inhibit(contact_pnt) := bool"
+        },
+        {
+          "name": "contact.isbonded",
+          "signature": "bool := contact.isbonded(mech_contact_pnt)"
+        },
+        {
+          "name": "contact.unbond",
+          "signature": "bool := contact.unbond(mech_contact_pnt)"
+        },
+        {
+          "name": "contact.persist",
+          "signature": "bool := contact.persist(contact_pnt) := bool"
+        },
+        {
+          "name": "contact.energy",
+          "signature": "flt := contact.energy(contact_pnt,str)"
+        },
+        {
+          "name": "contact.fid",
+          "signature": "int := contact.fid(contact_pnt)"
+        },
+        {
+          "name": "contact.group",
+          "signature": "str := contact.group(contact_pnt,<str/index>) := str/index"
+        }
+      ]
+    },
+    {
+      "family": "fluid pipe namespace",
+      "examples": [
+        {
+          "name": "contact.fluid.flow.rate",
+          "signature": "flt := contact.fluid.flow.rate(fcon_pnt,int)"
+        },
+        {
+          "name": "contact.fluid.pressure.pore",
+          "signature": "flt := contact.fluid.pressure.pore(fcon_pnt) := flt"
+        },
+        {
+          "name": "contact.fluid.pipe.area",
+          "signature": "flt := contact.fluid.pipe.area(fcon_pnt) := flt"
+        },
+        {
+          "name": "contact.fluid.open",
+          "signature": "bool := contact.fluid.open(fcon_pnt) := bool"
+        }
+      ],
+      "notes": [
+        "contact.fluid.* (27 names) serves the fluid-pipe network riding on the contact fabric."
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 126,
+    "names": [
+      "contact.activate",
+      "contact.active",
+      "contact.area",
+      "contact.branch",
+      "contact.branch.x",
+      "contact.branch.y",
+      "contact.branch.z",
+      "contact.end1",
+      "contact.end2",
+      "contact.energy",
+      "contact.energy.sum",
+      "contact.extra",
+      "contact.fid",
+      "contact.find",
+      "contact.fluid.contact.mech",
+      "contact.fluid.flow.rate",
+      "contact.fluid.flow.rate.reservoir",
+      "contact.fluid.flow.rate.source",
+      "contact.fluid.force.effective.global",
+      "contact.fluid.force.effective.global.x",
+      "contact.fluid.force.effective.global.y",
+      "contact.fluid.force.effective.global.z",
+      "contact.fluid.force.pressure",
+      "contact.fluid.force.total.global",
+      "contact.fluid.force.total.global.x",
+      "contact.fluid.force.total.global.y",
+      "contact.fluid.force.total.global.z",
+      "contact.fluid.id",
+      "contact.fluid.internal",
+      "contact.fluid.model",
+      "contact.fluid.open",
+      "contact.fluid.pipe.area",
+      "contact.fluid.pipe.length",
+      "contact.fluid.pressure.fixed",
+      "contact.fluid.pressure.head",
+      "contact.fluid.pressure.hydrostatic",
+      "contact.fluid.pressure.pore",
+      "contact.fluid.type.name",
+      "contact.fluid.volume.external",
+      "contact.fluid.volume.material",
+      "contact.fluid.volume.total",
+      "contact.force.from.stress",
+      "contact.force.global",
+      "contact.force.global.x",
+      "contact.force.global.y",
+      "contact.force.global.z",
+      "contact.force.local",
+      "contact.force.local.x",
+      "contact.force.local.y",
+      "contact.force.local.z",
+      "contact.force.normal",
+      "contact.force.set",
+      "contact.force.shear",
+      "contact.fullupdate",
+      "contact.gap",
+      "contact.gps",
+      "contact.group",
+      "contact.group.list",
+      "contact.group.list.all",
+      "contact.group.remove",
+      "contact.groupmap",
+      "contact.groupmap.all",
+      "contact.id",
+      "contact.inherit",
+      "contact.inhibit",
+      "contact.isbonded",
+      "contact.isenergy",
+      "contact.isgroup",
+      "contact.isprop",
+      "contact.joint",
+      "contact.list",
+      "contact.list.all",
+      "contact.method",
+      "contact.model",
+      "contact.model.prop.index",
+      "contact.moment.on1.global",
+      "contact.moment.on1.global.x",
+      "contact.moment.on1.global.y",
+      "contact.moment.on1.global.z",
+      "contact.moment.on1.local",
+      "contact.moment.on1.local.x",
+      "contact.moment.on1.local.y",
+      "contact.moment.on1.local.z",
+      "contact.moment.on2.global",
+      "contact.moment.on2.global.x",
+      "contact.moment.on2.global.y",
+      "contact.moment.on2.global.z",
+      "contact.moment.on2.local",
+      "contact.moment.on2.local.x",
+      "contact.moment.on2.local.y",
+      "contact.moment.on2.local.z",
+      "contact.normal",
+      "contact.normal.x",
+      "contact.normal.y",
+      "contact.normal.z",
+      "contact.num",
+      "contact.num.all",
+      "contact.offset",
+      "contact.offset.x",
+      "contact.offset.y",
+      "contact.offset.z",
+      "contact.otherend",
+      "contact.persist",
+      "contact.pos",
+      "contact.pos.x",
+      "contact.pos.y",
+      "contact.pos.z",
+      "contact.prop",
+      "contact.prop.index",
+      "contact.shear",
+      "contact.shear.x",
+      "contact.shear.y",
+      "contact.shear.z",
+      "contact.spin",
+      "contact.spin.x",
+      "contact.spin.y",
+      "contact.spin.z",
+      "contact.thermal.power",
+      "contact.to.global",
+      "contact.to.local",
+      "contact.typeid",
+      "contact.unbond",
+      "contact.vel",
+      "contact.vel.x",
+      "contact.vel.y",
+      "contact.vel.z"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/fracture-dfn.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/fracture-dfn.json
@@ -1,0 +1,342 @@
+{
+  "name": "fracture-dfn",
+  "dimension": "3D",
+  "full_name": "Fracture / DFN FISH Intrinsics",
+  "description": "FISH access to the Discrete Fracture Network: fractures (geometry, statistics, per-fracture properties), fracture intersections and intersection sets, fracture templates and vertices, and the DFN containers (dfn.*).",
+  "intrinsic_families": [
+    {
+      "family": "fracture geometry & attributes",
+      "examples": [
+        {
+          "name": "fracture.list",
+          "signature": "frac_network_list_pnt := fracture.list()"
+        },
+        {
+          "name": "fracture.find",
+          "signature": "frac_pnt := fracture.find(int)"
+        },
+        {
+          "name": "fracture.pos",
+          "signature": "vec3/flt := fracture.pos(frac_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "fracture.dip",
+          "signature": "flt := fracture.dip(frac_pnt) := flt"
+        },
+        {
+          "name": "fracture.ddir",
+          "signature": "flt := fracture.ddir(frac_pnt) := flt"
+        },
+        {
+          "name": "fracture.normal",
+          "signature": "vec3/flt := fracture.normal(frac_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "fracture.area",
+          "signature": "flt := fracture.area(frac_pnt) := flt"
+        },
+        {
+          "name": "fracture.diameter",
+          "signature": "flt := fracture.diameter(frac_pnt) := flt"
+        },
+        {
+          "name": "fracture.aperture",
+          "signature": "flt := fracture.aperture(frac_pnt) := flt"
+        },
+        {
+          "name": "fracture.isdisk",
+          "signature": "bool := fracture.isdisk(frac_pnt)"
+        },
+        {
+          "name": "fracture.dfn",
+          "signature": "frac_network_pnt := fracture.dfn(frac_pnt)"
+        },
+        {
+          "name": "fracture.from.contact",
+          "signature": "frac_pnt = fracture.from.contact(frac_network_pnt,contact_pnt)"
+        },
+        {
+          "name": "fracture.create",
+          "signature": "frac_pnt = fracture.create(frac_network_pnt,arr)"
+        },
+        {
+          "name": "fracture.delete",
+          "signature": "bool = fracture.delete(frac_pnt)"
+        }
+      ]
+    },
+    {
+      "family": "network statistics",
+      "examples": [
+        {
+          "name": "fracture.p10",
+          "signature": "flt := fracture.p10(vec3,vec3,<frac_network_pnt>)"
+        },
+        {
+          "name": "fracture.geomp10",
+          "signature": "flt := fracture.geomp10(geom_set_pnt,<frac_network_pnt>)"
+        },
+        {
+          "name": "fracture.geomp21",
+          "signature": "flt := fracture.geomp21(geom_set_pnt,<frac_network_pnt>)"
+        },
+        {
+          "name": "fracture.centerdensity",
+          "signature": "flt := fracture.centerdensity(<vec3>,<vec3>,<frac_network_pnt>)"
+        },
+        {
+          "name": "fracture.density",
+          "signature": "flt := fracture.density(<vec3>,<vec3>,<frac_network_pnt>)"
+        },
+        {
+          "name": "fracture.percolation",
+          "signature": "flt := fracture.percolation(<vec3>,<vec3>,<int>,<frac_network_pnt>)"
+        }
+      ],
+      "notes": [
+        "Same Pxy fracture-intensity vocabulary as the plot/compute commands."
+      ]
+    },
+    {
+      "family": "intersections",
+      "examples": [
+        {
+          "name": "fracture.intersect.list",
+          "signature": "intersect_list_pnt := fracture.intersect.list()"
+        },
+        {
+          "name": "fracture.intersect.find",
+          "signature": "intersect_pnt := fracture.intersect.find(int)"
+        },
+        {
+          "name": "fracture.intersect.end1",
+          "signature": "frac_pnt := fracture.intersect.end1(intersect_pnt)"
+        },
+        {
+          "name": "fracture.intersect.len",
+          "signature": "vec3/flt := fracture.intersect.len(intersect_pnt)"
+        },
+        {
+          "name": "fracture.intersect.set.list",
+          "signature": "intersection_set_list_pnt := fracture.intersect.set.list()"
+        },
+        {
+          "name": "fracture.intersect.set.name",
+          "signature": "str := fracture.intersect.set.name(intersect_set_pnt)"
+        }
+      ],
+      "notes": [
+        "Intersections live in named intersection sets (fracture.intersect.set.*)."
+      ]
+    },
+    {
+      "family": "templates & vertices",
+      "examples": [
+        {
+          "name": "fracture.template.list",
+          "signature": "dfn_template_list_pnt := fracture.template.list()"
+        },
+        {
+          "name": "fracture.template.name",
+          "signature": "str := fracture.template.name(dfn_template_pnt)"
+        },
+        {
+          "name": "fracture.template.sizemin",
+          "signature": "flt := fracture.template.sizemin(dfn_template_pnt) := flt"
+        },
+        {
+          "name": "fracture.vertexlist",
+          "signature": "list := fracture.vertexlist(frac_pnt)"
+        },
+        {
+          "name": "fracture.vertex.pos",
+          "signature": "vec3/flt := fracture.vertex.pos(dfn_vertex_pnt,<int>)"
+        }
+      ]
+    },
+    {
+      "family": "DFN containers",
+      "examples": [
+        {
+          "name": "dfn.list",
+          "signature": "list := dfn.list()"
+        },
+        {
+          "name": "dfn.find",
+          "signature": "frac_network_pnt := dfn.find(int/str)"
+        },
+        {
+          "name": "dfn.name",
+          "signature": "str := dfn.name(frac_network_pnt)"
+        },
+        {
+          "name": "dfn.fracturelist",
+          "signature": "frac_network_list_pnt := dfn.fracturelist(frac_network_pnt)"
+        },
+        {
+          "name": "dfn.fracturenum",
+          "signature": "int := dfn.fracturenum(frac_network_pnt)"
+        },
+        {
+          "name": "dfn.dominance",
+          "signature": "int := dfn.dominance(frac_network_pnt) := int"
+        },
+        {
+          "name": "dfn.create",
+          "signature": "frac_network_pnt := dfn.create(<str>)"
+        },
+        {
+          "name": "dfn.delete",
+          "signature": "bool := dfn.delete(frac_network_pnt)"
+        }
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 141,
+    "names": [
+      "dfn.contact.list",
+      "dfn.contact.list.all",
+      "dfn.contactmap",
+      "dfn.contactmap.all",
+      "dfn.create",
+      "dfn.delete",
+      "dfn.dominance",
+      "dfn.extra",
+      "dfn.find",
+      "dfn.fracturelist",
+      "dfn.fracturenum",
+      "dfn.group",
+      "dfn.group.remove",
+      "dfn.id",
+      "dfn.isgroup",
+      "dfn.list",
+      "dfn.maxid",
+      "dfn.name",
+      "dfn.num",
+      "dfn.prop",
+      "dfn.template",
+      "dfn.typeid",
+      "fracture.aperture",
+      "fracture.area",
+      "fracture.centerdensity",
+      "fracture.contact.list",
+      "fracture.contact.list.all",
+      "fracture.contactmap",
+      "fracture.contactmap.all",
+      "fracture.copy",
+      "fracture.create",
+      "fracture.ddir",
+      "fracture.decimate",
+      "fracture.delete",
+      "fracture.density",
+      "fracture.dfn",
+      "fracture.diameter",
+      "fracture.dip",
+      "fracture.extra",
+      "fracture.find",
+      "fracture.from.contact",
+      "fracture.genpos",
+      "fracture.genpos.x",
+      "fracture.genpos.y",
+      "fracture.genpos.z",
+      "fracture.gensize",
+      "fracture.geomp10",
+      "fracture.geomp20",
+      "fracture.geomp21",
+      "fracture.geomtrace",
+      "fracture.gintersect",
+      "fracture.group",
+      "fracture.group.remove",
+      "fracture.id",
+      "fracture.inbox",
+      "fracture.interarray",
+      "fracture.intersect",
+      "fracture.intersect.end1",
+      "fracture.intersect.end2",
+      "fracture.intersect.find",
+      "fracture.intersect.id",
+      "fracture.intersect.len",
+      "fracture.intersect.list",
+      "fracture.intersect.maxid",
+      "fracture.intersect.npolylinept",
+      "fracture.intersect.num",
+      "fracture.intersect.polylinept",
+      "fracture.intersect.pos1",
+      "fracture.intersect.pos1.x",
+      "fracture.intersect.pos1.y",
+      "fracture.intersect.pos1.z",
+      "fracture.intersect.pos2",
+      "fracture.intersect.pos2.x",
+      "fracture.intersect.pos2.y",
+      "fracture.intersect.pos2.z",
+      "fracture.intersect.set",
+      "fracture.intersect.set.delete",
+      "fracture.intersect.set.find",
+      "fracture.intersect.set.id",
+      "fracture.intersect.set.interlist",
+      "fracture.intersect.set.internum",
+      "fracture.intersect.set.list",
+      "fracture.intersect.set.maxid",
+      "fracture.intersect.set.name",
+      "fracture.intersect.set.num",
+      "fracture.intersect.set.path",
+      "fracture.intersect.set.typeid",
+      "fracture.intersect.typeid",
+      "fracture.isdisk",
+      "fracture.isgroup",
+      "fracture.isprop",
+      "fracture.list",
+      "fracture.maxid",
+      "fracture.near",
+      "fracture.normal",
+      "fracture.normal.x",
+      "fracture.normal.y",
+      "fracture.normal.z",
+      "fracture.num",
+      "fracture.p10",
+      "fracture.percolation",
+      "fracture.pointnear",
+      "fracture.pos",
+      "fracture.pos.x",
+      "fracture.pos.y",
+      "fracture.pos.z",
+      "fracture.prop",
+      "fracture.template.ddirmax",
+      "fracture.template.ddirmin",
+      "fracture.template.dipmax",
+      "fracture.template.dipmin",
+      "fracture.template.find",
+      "fracture.template.id",
+      "fracture.template.list",
+      "fracture.template.maxid",
+      "fracture.template.name",
+      "fracture.template.norientparam",
+      "fracture.template.nposparam",
+      "fracture.template.nsizeparam",
+      "fracture.template.num",
+      "fracture.template.orientparam",
+      "fracture.template.orienttype",
+      "fracture.template.posparam",
+      "fracture.template.postype",
+      "fracture.template.sizemax",
+      "fracture.template.sizemin",
+      "fracture.template.sizeparam",
+      "fracture.template.sizetype",
+      "fracture.template.typeid",
+      "fracture.typeid",
+      "fracture.vertex.find",
+      "fracture.vertex.list",
+      "fracture.vertex.maxid",
+      "fracture.vertex.num",
+      "fracture.vertex.pos",
+      "fracture.vertex.pos.x",
+      "fracture.vertex.pos.y",
+      "fracture.vertex.pos.z",
+      "fracture.vertex.typeid",
+      "fracture.vertexarray",
+      "fracture.vertexlist"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/index.json
@@ -1,0 +1,52 @@
+{
+  "type": "fish_intrinsics",
+  "description": "PFC FISH intrinsic families for scripted model inspection, validation, and control - balls, clumps (pebbles/templates), walls (facets/servo), rigid blocks, contacts, the fracture/DFN system, and model-level utilities (measure/inlet/fragment/domain/cfd).",
+  "items": [
+    {
+      "name": "ball",
+      "file": "ball.json",
+      "full_name": "Ball FISH Intrinsics",
+      "intrinsic_count": 171
+    },
+    {
+      "name": "clump",
+      "file": "clump.json",
+      "full_name": "Clump / Pebble / Clump-Template FISH Intrinsics",
+      "intrinsic_count": 295
+    },
+    {
+      "name": "wall",
+      "file": "wall.json",
+      "full_name": "Wall / Facet / Vertex FISH Intrinsics",
+      "intrinsic_count": 236
+    },
+    {
+      "name": "rblock",
+      "file": "rblock.json",
+      "full_name": "Rigid-Block (rblock) FISH Intrinsics",
+      "intrinsic_count": 225
+    },
+    {
+      "name": "contact",
+      "file": "contact.json",
+      "full_name": "Contact FISH Intrinsics",
+      "intrinsic_count": 126
+    },
+    {
+      "name": "fracture-dfn",
+      "file": "fracture-dfn.json",
+      "full_name": "Fracture / DFN FISH Intrinsics",
+      "intrinsic_count": 141
+    },
+    {
+      "name": "model-utilities",
+      "file": "model-utilities.json",
+      "full_name": "Measurement, Inlet, Fragment, Domain & CFD FISH Intrinsics",
+      "intrinsic_count": 115
+    }
+  ],
+  "official_sources": [
+    "https://docs.itascacg.com/itasca900/pfc/docproject/source/manual/fish_beta/fish_instances/fish_instances.html"
+  ],
+  "verification": "Authored 2026-08-15 from the complete live 'fish list intrinsics' table of PFC3D 9.7 (3754 names dumped; the seven family files carry the full per-family inventories - 1290 PFC-family names - plus curated examples with verbatim live signatures). The dump is a UNIFIED-KERNEL table: it also lists other engines' families (block.*, zone.*, struct.*, ...) which are omitted here."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/model-utilities.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/model-utilities.json
@@ -1,0 +1,287 @@
+{
+  "name": "model-utilities",
+  "dimension": "3D",
+  "full_name": "Measurement, Inlet, Fragment, Domain & CFD FISH Intrinsics",
+  "description": "PFC model-level helper namespaces: measurement spheres (measure.*), particle inlets (inlet.*), fragment analysis (fragment.*), the model domain (domain.*), and global CFD state (cfd.*).",
+  "intrinsic_families": [
+    {
+      "family": "measurement spheres",
+      "examples": [
+        {
+          "name": "measure.list",
+          "signature": "measure_list_pnt = measure.list()"
+        },
+        {
+          "name": "measure.find",
+          "signature": "measure_pnt = measure.find(int)"
+        },
+        {
+          "name": "measure.pos",
+          "signature": "vec3/flt = measure.pos(measure_pnt,<int>) = vec3/flt"
+        },
+        {
+          "name": "measure.radius",
+          "signature": "flt = measure.radius(measure_pnt) = flt"
+        },
+        {
+          "name": "measure.porosity",
+          "signature": "flt = measure.porosity(measure_pnt)"
+        },
+        {
+          "name": "measure.coordination",
+          "signature": "flt = measure.coordination(measure_pnt)"
+        },
+        {
+          "name": "measure.stress",
+          "signature": "mat/flt = measure.stress(measure_pnt,<int>,<int>)"
+        },
+        {
+          "name": "measure.strain.rate",
+          "signature": "mat/flt = measure.strain.rate(measure_pnt,<int>,<int>)"
+        }
+      ],
+      "notes": [
+        "stress/strain.rate carry full 9-component .xx...zz variants."
+      ]
+    },
+    {
+      "family": "inlets",
+      "examples": [
+        {
+          "name": "inlet.list",
+          "signature": "inlet_list_pnt := inlet.list()"
+        },
+        {
+          "name": "inlet.find",
+          "signature": "inlet_pnt := inlet.find(int)"
+        },
+        {
+          "name": "inlet.active",
+          "signature": "bool := inlet.active(inlet_pnt) := bool"
+        },
+        {
+          "name": "inlet.pos",
+          "signature": "vec3/flt := inlet.pos(inlet_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "inlet.vel",
+          "signature": "vec3/flt := inlet.vel(inlet_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "inlet.flow.vel",
+          "signature": "vec3/flt := inlet.flow.vel(inlet_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "inlet.brick",
+          "signature": "brick_pnt := inlet.brick(inlet_pnt) := int"
+        }
+      ]
+    },
+    {
+      "family": "fragments",
+      "examples": [
+        {
+          "name": "fragment.list",
+          "signature": "list := fragment.list(<int>)"
+        },
+        {
+          "name": "fragment.find",
+          "signature": "fragment_pnt := fragment.find(int)"
+        },
+        {
+          "name": "fragment.bodylist",
+          "signature": "list := fragment.bodylist(fragment_pnt,<int>)"
+        },
+        {
+          "name": "fragment.childlist",
+          "signature": "list := fragment.childlist(fragment_pnt)"
+        },
+        {
+          "name": "fragment.parent",
+          "signature": "int := fragment.parent(fragment_pnt)"
+        },
+        {
+          "name": "fragment.vol",
+          "signature": "flt := fragment.vol(fragment_pnt,<int>)"
+        },
+        {
+          "name": "fragment.catalog",
+          "signature": "map := fragment.catalog()"
+        },
+        {
+          "name": "fragment.history",
+          "signature": "map := fragment.history(body_pnt)"
+        }
+      ],
+      "notes": [
+        "Requires fragment tracking to be enabled (fragment compute workflow)."
+      ]
+    },
+    {
+      "family": "domain",
+      "examples": [
+        {
+          "name": "domain.min",
+          "signature": "vec3/flt := domain.min(<int>) := vec3/flt"
+        },
+        {
+          "name": "domain.max",
+          "signature": "vec3/flt := domain.max(<int>) := vec3/flt"
+        },
+        {
+          "name": "domain.condition",
+          "signature": "str := domain.condition(int) := str"
+        },
+        {
+          "name": "domain.strain.rate",
+          "signature": "mat/flt := domain.strain.rate(<int>,<int>) := mat/flt"
+        }
+      ],
+      "notes": [
+        "domain.condition reads the model-domain boundary condition."
+      ]
+    },
+    {
+      "family": "global CFD state",
+      "examples": [
+        {
+          "name": "cfd.age",
+          "signature": "flt = cfd.age()"
+        },
+        {
+          "name": "cfd.cycle",
+          "signature": "int = cfd.cycle()"
+        },
+        {
+          "name": "cfd.energy",
+          "signature": "flt = cfd.energy(str)"
+        },
+        {
+          "name": "cfd.step",
+          "signature": "int = cfd.step()"
+        }
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 115,
+    "names": [
+      "cfd.age",
+      "cfd.cycle",
+      "cfd.energy",
+      "cfd.step",
+      "domain.condition",
+      "domain.max",
+      "domain.max.x",
+      "domain.max.y",
+      "domain.max.z",
+      "domain.min",
+      "domain.min.x",
+      "domain.min.y",
+      "domain.min.z",
+      "domain.strain.rate",
+      "domain.strain.rate.xx",
+      "domain.strain.rate.xy",
+      "domain.strain.rate.xz",
+      "domain.strain.rate.yx",
+      "domain.strain.rate.yy",
+      "domain.strain.rate.yz",
+      "domain.strain.rate.zx",
+      "domain.strain.rate.zy",
+      "domain.strain.rate.zz",
+      "fragment.bodylist",
+      "fragment.bodymap",
+      "fragment.bodynum",
+      "fragment.catalog",
+      "fragment.catalog.num",
+      "fragment.childlist",
+      "fragment.childmap",
+      "fragment.find",
+      "fragment.history",
+      "fragment.id",
+      "fragment.index",
+      "fragment.list",
+      "fragment.map",
+      "fragment.num",
+      "fragment.parent",
+      "fragment.pos",
+      "fragment.pos.catalog",
+      "fragment.pos.catalog.x",
+      "fragment.pos.catalog.y",
+      "fragment.pos.catalog.z",
+      "fragment.pos.x",
+      "fragment.pos.y",
+      "fragment.pos.z",
+      "fragment.vol",
+      "inlet.active",
+      "inlet.brick",
+      "inlet.delete",
+      "inlet.find",
+      "inlet.flow.vel",
+      "inlet.flow.vel.x",
+      "inlet.flow.vel.y",
+      "inlet.flow.vel.z",
+      "inlet.id",
+      "inlet.list",
+      "inlet.maxid",
+      "inlet.num",
+      "inlet.orientation",
+      "inlet.orientation.x",
+      "inlet.orientation.y",
+      "inlet.orientation.z",
+      "inlet.pos",
+      "inlet.pos.x",
+      "inlet.pos.y",
+      "inlet.pos.z",
+      "inlet.rotation.center",
+      "inlet.rotation.center.x",
+      "inlet.rotation.center.y",
+      "inlet.rotation.center.z",
+      "inlet.spin",
+      "inlet.spin.x",
+      "inlet.spin.y",
+      "inlet.spin.z",
+      "inlet.typeid",
+      "inlet.vel",
+      "inlet.vel.x",
+      "inlet.vel.y",
+      "inlet.vel.z",
+      "measure.coordination",
+      "measure.delete",
+      "measure.find",
+      "measure.id",
+      "measure.list",
+      "measure.maxid",
+      "measure.num",
+      "measure.porosity",
+      "measure.pos",
+      "measure.pos.x",
+      "measure.pos.y",
+      "measure.pos.z",
+      "measure.radius",
+      "measure.size",
+      "measure.strain.rate",
+      "measure.strain.rate.xx",
+      "measure.strain.rate.xy",
+      "measure.strain.rate.xz",
+      "measure.strain.rate.yx",
+      "measure.strain.rate.yy",
+      "measure.strain.rate.yz",
+      "measure.strain.rate.zx",
+      "measure.strain.rate.zy",
+      "measure.strain.rate.zz",
+      "measure.stress",
+      "measure.stress.xx",
+      "measure.stress.xy",
+      "measure.stress.xz",
+      "measure.stress.yx",
+      "measure.stress.yy",
+      "measure.stress.yz",
+      "measure.stress.zx",
+      "measure.stress.zy",
+      "measure.stress.zz",
+      "measure.typeid"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/rblock.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/rblock.json
@@ -1,0 +1,414 @@
+{
+  "name": "rblock",
+  "dimension": "3D",
+  "full_name": "Rigid-Block (rblock) FISH Intrinsics",
+  "description": "FISH access to rigid blocks: body kinematics/dynamics, geometry queries (facets, vertices, aspect ratio, rounding), templates, and the thermal twin.",
+  "intrinsic_families": [
+    {
+      "family": "body",
+      "examples": [
+        {
+          "name": "rblock.list",
+          "signature": "rblock_list_pnt := rblock.list()"
+        },
+        {
+          "name": "rblock.find",
+          "signature": "rblock_pnt := rblock.find(int)"
+        },
+        {
+          "name": "rblock.pos",
+          "signature": "vec3/flt := rblock.pos(rblock_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "rblock.vel",
+          "signature": "vec3/flt := rblock.vel(rblock_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "rblock.spin",
+          "signature": "vec3/flt := rblock.spin(rblock_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "rblock.mass",
+          "signature": "flt := rblock.mass(rblock_pnt)"
+        },
+        {
+          "name": "rblock.vol",
+          "signature": "flt := rblock.vol(rblock_pnt) := flt"
+        },
+        {
+          "name": "rblock.moi.prin",
+          "signature": "vec3/flt := rblock.moi.prin(rblock_pnt,<int>)"
+        },
+        {
+          "name": "rblock.stress",
+          "signature": "ten/flt := rblock.stress(rblock_pnt,<int>,<int>)"
+        },
+        {
+          "name": "rblock.copy",
+          "signature": "rblock_pnt = rblock.copy(rblock_pnt)"
+        },
+        {
+          "name": "rblock.rotate",
+          "signature": "int := rblock.rotate(rblock_pnt,vec3+/flt)"
+        },
+        {
+          "name": "rblock.scalesphere",
+          "signature": "int := rblock.scalesphere(rblock_pnt,flt)"
+        },
+        {
+          "name": "rblock.scalevol",
+          "signature": "int := rblock.scalevol(rblock_pnt,flt)"
+        },
+        {
+          "name": "rblock.unbond",
+          "signature": "bool := rblock.unbond(rblock_pnt)"
+        }
+      ]
+    },
+    {
+      "family": "geometry queries",
+      "examples": [
+        {
+          "name": "rblock.aspect.ratio",
+          "signature": "flt := rblock.aspect.ratio(rblock_pnt)"
+        },
+        {
+          "name": "rblock.axis.long",
+          "signature": "vec3 := rblock.axis.long(rblock_pnt)"
+        },
+        {
+          "name": "rblock.rounding",
+          "signature": "flt := rblock.rounding(rblock_pnt)"
+        },
+        {
+          "name": "rblock.length.max",
+          "signature": "flt := rblock.length.max(rblock_pnt)"
+        },
+        {
+          "name": "rblock.length.min",
+          "signature": "flt := rblock.length.min(rblock_pnt)"
+        },
+        {
+          "name": "rblock.intersect",
+          "signature": "bool := rblock.intersect(rblock_pnt,rblock_pnt)"
+        },
+        {
+          "name": "rblock.ball.pos",
+          "signature": "vec3/flt := rblock.ball.pos(rblock_pnt,<int>)"
+        },
+        {
+          "name": "rblock.ball.radius",
+          "signature": "flt := rblock.ball.radius(rblock_pnt)"
+        }
+      ],
+      "notes": [
+        "rblock.ball.* exposes the bounding/inscribed-ball approximation."
+      ]
+    },
+    {
+      "family": "facets & vertices",
+      "examples": [
+        {
+          "name": "rblock.facet.list",
+          "signature": "list := rblock.facet.list(rblock_pnt)"
+        },
+        {
+          "name": "rblock.facet.area",
+          "signature": "int := rblock.facet.area(rblock_pnt,int)"
+        },
+        {
+          "name": "rblock.facet.centroid",
+          "signature": "vec3/flt := rblock.facet.centroid(rblock_pnt,int,<int>)"
+        },
+        {
+          "name": "rblock.facet.normal",
+          "signature": "vec3/flt := rblock.facet.normal(rblock_pnt,int,<int>)"
+        },
+        {
+          "name": "rblock.facet.closest",
+          "signature": "vec3/flt := rblock.facet.closest(rblock_pnt,int,vec3/flt,<int>)"
+        },
+        {
+          "name": "rblock.vertex.list",
+          "signature": "list := rblock.vertex.list(rblock_pnt)"
+        },
+        {
+          "name": "rblock.vertex.pos",
+          "signature": "vec3/flt := rblock.vertex.pos(rblock_pnt,int,<int>)"
+        },
+        {
+          "name": "rblock.vertex.near",
+          "signature": "rblock_pnt := rblock.vertex.near(rblock_pnt,vec3)"
+        }
+      ]
+    },
+    {
+      "family": "templates",
+      "examples": [
+        {
+          "name": "rblock.template.list",
+          "signature": "rblock_temp_list_pnt = rblock.template.list()"
+        },
+        {
+          "name": "rblock.template.find",
+          "signature": "rblock_temp_pnt = rblock.template.find(str)"
+        },
+        {
+          "name": "rblock.template.name",
+          "signature": "str = rblock.template.name(rblock_temp_pnt)"
+        },
+        {
+          "name": "rblock.template.vol",
+          "signature": "flt = rblock.template.vol(rblock_temp_pnt) = flt"
+        }
+      ]
+    },
+    {
+      "family": "thermal twin",
+      "examples": [
+        {
+          "name": "rblock.thermal.temp",
+          "signature": "flt = rblock.thermal.temp(trblock_pnt) = flt"
+        },
+        {
+          "name": "rblock.thermal.power.unbal",
+          "signature": "flt = rblock.thermal.power.unbal(trblock_pnt)"
+        }
+      ],
+      "notes": [
+        "rblock.thermal.* (24 names) mirrors the mechanical bookkeeping."
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 225,
+    "names": [
+      "rblock.aspect.ratio",
+      "rblock.axis.angle",
+      "rblock.axis.angle.x",
+      "rblock.axis.angle.y",
+      "rblock.axis.angle.z",
+      "rblock.axis.long",
+      "rblock.ball.pos",
+      "rblock.ball.pos.x",
+      "rblock.ball.pos.y",
+      "rblock.ball.pos.z",
+      "rblock.ball.radius",
+      "rblock.contact.list",
+      "rblock.contact.list.all",
+      "rblock.contactmap",
+      "rblock.contactmap.all",
+      "rblock.contactnum",
+      "rblock.contactnum.all",
+      "rblock.containing",
+      "rblock.convergence",
+      "rblock.copy",
+      "rblock.damp",
+      "rblock.delete",
+      "rblock.density",
+      "rblock.disp",
+      "rblock.disp.x",
+      "rblock.disp.y",
+      "rblock.disp.z",
+      "rblock.energy",
+      "rblock.euler",
+      "rblock.euler.x",
+      "rblock.euler.y",
+      "rblock.euler.z",
+      "rblock.extra",
+      "rblock.facet.area",
+      "rblock.facet.centroid",
+      "rblock.facet.centroid.x",
+      "rblock.facet.centroid.y",
+      "rblock.facet.centroid.z",
+      "rblock.facet.closest",
+      "rblock.facet.closest.x",
+      "rblock.facet.closest.y",
+      "rblock.facet.closest.z",
+      "rblock.facet.group",
+      "rblock.facet.group.remove",
+      "rblock.facet.isgroup",
+      "rblock.facet.list",
+      "rblock.facet.map",
+      "rblock.facet.normal",
+      "rblock.facet.normal.x",
+      "rblock.facet.normal.y",
+      "rblock.facet.normal.z",
+      "rblock.facet.num",
+      "rblock.facet.vertex.pos",
+      "rblock.facet.vertex.pos.x",
+      "rblock.facet.vertex.pos.y",
+      "rblock.facet.vertex.pos.z",
+      "rblock.find",
+      "rblock.fix",
+      "rblock.force.app",
+      "rblock.force.app.x",
+      "rblock.force.app.y",
+      "rblock.force.app.z",
+      "rblock.force.contact",
+      "rblock.force.contact.x",
+      "rblock.force.contact.y",
+      "rblock.force.contact.z",
+      "rblock.force.unbal",
+      "rblock.force.unbal.x",
+      "rblock.force.unbal.y",
+      "rblock.force.unbal.z",
+      "rblock.fragment",
+      "rblock.group",
+      "rblock.group.list",
+      "rblock.group.remove",
+      "rblock.groupmap",
+      "rblock.id",
+      "rblock.inbox",
+      "rblock.inglobal",
+      "rblock.inprin",
+      "rblock.inside",
+      "rblock.intersect",
+      "rblock.isbonded",
+      "rblock.isgroup",
+      "rblock.isprop",
+      "rblock.length.max",
+      "rblock.length.min",
+      "rblock.list",
+      "rblock.mass",
+      "rblock.mass.real",
+      "rblock.maxid",
+      "rblock.mech.convergence",
+      "rblock.mech.ratio.avg",
+      "rblock.mech.ratio.local",
+      "rblock.mech.ratio.max",
+      "rblock.mech.unbal.max",
+      "rblock.moi",
+      "rblock.moi.fix",
+      "rblock.moi.prin",
+      "rblock.moi.prin.real",
+      "rblock.moi.prin.real.x",
+      "rblock.moi.prin.real.y",
+      "rblock.moi.prin.real.z",
+      "rblock.moi.prin.x",
+      "rblock.moi.prin.y",
+      "rblock.moi.prin.z",
+      "rblock.moi.real",
+      "rblock.moi.real.xx",
+      "rblock.moi.real.xy",
+      "rblock.moi.real.xz",
+      "rblock.moi.real.yy",
+      "rblock.moi.real.yz",
+      "rblock.moi.real.zz",
+      "rblock.moi.xx",
+      "rblock.moi.xy",
+      "rblock.moi.xz",
+      "rblock.moi.yy",
+      "rblock.moi.yz",
+      "rblock.moi.zz",
+      "rblock.moment.app",
+      "rblock.moment.app.x",
+      "rblock.moment.app.y",
+      "rblock.moment.app.z",
+      "rblock.moment.contact",
+      "rblock.moment.contact.x",
+      "rblock.moment.contact.y",
+      "rblock.moment.contact.z",
+      "rblock.moment.unbal",
+      "rblock.moment.unbal.x",
+      "rblock.moment.unbal.y",
+      "rblock.moment.unbal.z",
+      "rblock.near",
+      "rblock.num",
+      "rblock.pos",
+      "rblock.pos.x",
+      "rblock.pos.y",
+      "rblock.pos.z",
+      "rblock.prin.axis.angle",
+      "rblock.prin.axis.angle.x",
+      "rblock.prin.axis.angle.y",
+      "rblock.prin.axis.angle.z",
+      "rblock.prin.euler",
+      "rblock.prin.euler.x",
+      "rblock.prin.euler.y",
+      "rblock.prin.euler.z",
+      "rblock.prop",
+      "rblock.ratio",
+      "rblock.ratio.target",
+      "rblock.rotate",
+      "rblock.rounding",
+      "rblock.scalesphere",
+      "rblock.scalevol",
+      "rblock.spin",
+      "rblock.spin.x",
+      "rblock.spin.y",
+      "rblock.spin.z",
+      "rblock.stress",
+      "rblock.stress.xx",
+      "rblock.stress.xy",
+      "rblock.stress.xz",
+      "rblock.stress.yy",
+      "rblock.stress.yz",
+      "rblock.stress.zz",
+      "rblock.template.delete",
+      "rblock.template.find",
+      "rblock.template.list",
+      "rblock.template.maxid",
+      "rblock.template.moi",
+      "rblock.template.moi.prin",
+      "rblock.template.moi.prin.x",
+      "rblock.template.moi.prin.y",
+      "rblock.template.moi.prin.z",
+      "rblock.template.moi.xx",
+      "rblock.template.moi.xy",
+      "rblock.template.moi.xz",
+      "rblock.template.moi.yy",
+      "rblock.template.moi.yz",
+      "rblock.template.moi.zz",
+      "rblock.template.name",
+      "rblock.template.num",
+      "rblock.template.typeid",
+      "rblock.template.vol",
+      "rblock.thermal.contact.list",
+      "rblock.thermal.contact.list.all",
+      "rblock.thermal.contactmap",
+      "rblock.thermal.contactmap.all",
+      "rblock.thermal.contactnum",
+      "rblock.thermal.contactnum.all",
+      "rblock.thermal.expansion",
+      "rblock.thermal.extra",
+      "rblock.thermal.find",
+      "rblock.thermal.fix",
+      "rblock.thermal.group",
+      "rblock.thermal.group.list",
+      "rblock.thermal.group.remove",
+      "rblock.thermal.groupmap",
+      "rblock.thermal.id",
+      "rblock.thermal.inbox",
+      "rblock.thermal.isgroup",
+      "rblock.thermal.isprop",
+      "rblock.thermal.list",
+      "rblock.thermal.near",
+      "rblock.thermal.num",
+      "rblock.thermal.power.app",
+      "rblock.thermal.power.unbal",
+      "rblock.thermal.prop",
+      "rblock.thermal.rblock",
+      "rblock.thermal.specific.heat",
+      "rblock.thermal.temp",
+      "rblock.thermal.temp.increment",
+      "rblock.thermal.typeid",
+      "rblock.typeid",
+      "rblock.unbond",
+      "rblock.vel",
+      "rblock.vel.x",
+      "rblock.vel.y",
+      "rblock.vel.z",
+      "rblock.vertex.list",
+      "rblock.vertex.map",
+      "rblock.vertex.near",
+      "rblock.vertex.num",
+      "rblock.vertex.pos",
+      "rblock.vertex.pos.x",
+      "rblock.vertex.pos.y",
+      "rblock.vertex.pos.z",
+      "rblock.vol"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/wall.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/fish-intrinsics/wall.json
@@ -1,0 +1,440 @@
+{
+  "name": "wall",
+  "dimension": "3D",
+  "full_name": "Wall / Facet / Vertex FISH Intrinsics",
+  "description": "FISH access to walls and their facets/vertices, including the wall servo controls used for stress-controlled boundaries and facet conveyor velocities.",
+  "intrinsic_families": [
+    {
+      "family": "wall body",
+      "examples": [
+        {
+          "name": "wall.list",
+          "signature": "wall_list_pnt = wall.list()"
+        },
+        {
+          "name": "wall.find",
+          "signature": "wall_pnt = wall.find(int/str)"
+        },
+        {
+          "name": "wall.name",
+          "signature": "str := wall.name(wall_pnt) := str"
+        },
+        {
+          "name": "wall.pos",
+          "signature": "vec3/flt := wall.pos(wall_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.vel",
+          "signature": "vec3/flt := wall.vel(wall_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.disp",
+          "signature": "vec3/flt := wall.disp(wall_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.spin",
+          "signature": "vec3/flt := wall.spin(wall_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.force.contact",
+          "signature": "vec3/flt := wall.force.contact(wall_pnt,<int>)"
+        },
+        {
+          "name": "wall.moment.contact",
+          "signature": "vec3/flt := wall.moment.contact(wall_pnt,<int>)"
+        },
+        {
+          "name": "wall.rotation.center",
+          "signature": "vec3/flt := wall.rotation.center(wall_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.delete",
+          "signature": "bool = wall.delete(wall_pnt)"
+        },
+        {
+          "name": "wall.closed",
+          "signature": "bool := wall.closed(wall_pnt)"
+        },
+        {
+          "name": "wall.convex",
+          "signature": "bool := wall.convex(wall_pnt)"
+        }
+      ]
+    },
+    {
+      "family": "servo control",
+      "examples": [
+        {
+          "name": "wall.servo.active",
+          "signature": "bool := wall.servo.active(wall_pnt) := bool"
+        },
+        {
+          "name": "wall.servo.force",
+          "signature": "vec3/flt := wall.servo.force(wall_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.servo.gain",
+          "signature": "flt := wall.servo.gain(wall_pnt)"
+        },
+        {
+          "name": "wall.servo.gainfactor",
+          "signature": "flt := wall.servo.gainfactor(wall_pnt) := flt"
+        },
+        {
+          "name": "wall.servo.gainupdate",
+          "signature": "int := wall.servo.gainupdate(wall_pnt) := int"
+        },
+        {
+          "name": "wall.servo.vmax",
+          "signature": "flt := wall.servo.vmax(wall_pnt) := flt"
+        }
+      ],
+      "notes": [
+        "The FISH handle for 'wall servo' stress-controlled boundaries - read/set the target force, gain, and activation per wall."
+      ]
+    },
+    {
+      "family": "facets",
+      "examples": [
+        {
+          "name": "wall.facetlist",
+          "signature": "facet_list_pnt := wall.facetlist(wall_pnt)"
+        },
+        {
+          "name": "wall.facet.list",
+          "signature": "facet_list_pnt := wall.facet.list()"
+        },
+        {
+          "name": "wall.facet.find",
+          "signature": "facet_pnt := wall.facet.find(int)"
+        },
+        {
+          "name": "wall.facet.wall",
+          "signature": "wall_pnt := wall.facet.wall(facet_pnt)"
+        },
+        {
+          "name": "wall.facet.normal",
+          "signature": "vec3/flt := wall.facet.normal(facet_pnt,<int>)"
+        },
+        {
+          "name": "wall.facet.pos",
+          "signature": "vec3/flt := wall.facet.pos(facet_pnt,<int>)"
+        },
+        {
+          "name": "wall.facet.conveyor",
+          "signature": "vec3/flt := wall.facet.conveyor(facet_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.facet.active",
+          "signature": "int := wall.facet.active(facet_pnt) := int"
+        },
+        {
+          "name": "wall.facet.pair",
+          "signature": "facet_pnt := wall.facet.pair(facet_pnt,int)"
+        },
+        {
+          "name": "wall.facet.pointnear",
+          "signature": "vec3/flt := wall.facet.pointnear(facet_pnt,vec3+,<int>)"
+        },
+        {
+          "name": "wall.addfacet",
+          "signature": "facet_pnt = wall.addfacet(wall_pnt,vec3+,<vertex_pnt>)"
+        },
+        {
+          "name": "wall.facet.delete",
+          "signature": "bool = wall.facet.delete(facet_pnt)"
+        }
+      ],
+      "notes": [
+        "wall.facet.conveyor(.x/y/z) is the conveyor-belt surface velocity."
+      ]
+    },
+    {
+      "family": "vertices",
+      "examples": [
+        {
+          "name": "wall.vertexlist",
+          "signature": "vertex_list_pnt := wall.vertexlist(wall_pnt)"
+        },
+        {
+          "name": "wall.vertex.list",
+          "signature": "vertex_list_pnt = wall.vertex.list()"
+        },
+        {
+          "name": "wall.vertex.find",
+          "signature": "vertex_pnt = wall.vertex.find(int,<wall_pnt>)"
+        },
+        {
+          "name": "wall.vertex.pos",
+          "signature": "vec3/flt := wall.vertex.pos(vertex_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.vertex.vel",
+          "signature": "vec3/flt := wall.vertex.vel(vertex_pnt,<int>) := vec3/flt"
+        },
+        {
+          "name": "wall.vertex.facetarray",
+          "signature": "arr := wall.vertex.facetarray(vertex_pnt)"
+        }
+      ]
+    },
+    {
+      "family": "process sub-namespaces",
+      "examples": [
+        {
+          "name": "wall.thermal.list",
+          "signature": "fwallt_list_pnt = wall.thermal.list()"
+        },
+        {
+          "name": "wall.fluid.list",
+          "signature": "fwallt_list_pnt = wall.fluid.list()"
+        }
+      ],
+      "notes": [
+        "wall.thermal.* (48 names incl. thermal facets) and wall.fluid.* (49) mirror the mechanical wall/facet namespaces."
+      ]
+    }
+  ],
+  "live_inventory": {
+    "count": 236,
+    "names": [
+      "wall.addfacet",
+      "wall.axis.angle",
+      "wall.axis.angle.x",
+      "wall.axis.angle.y",
+      "wall.axis.angle.z",
+      "wall.closed",
+      "wall.contact.list",
+      "wall.contact.list.all",
+      "wall.contactmap",
+      "wall.contactmap.all",
+      "wall.contactnum",
+      "wall.contactnum.all",
+      "wall.convex",
+      "wall.cutoff",
+      "wall.delete",
+      "wall.disp",
+      "wall.disp.x",
+      "wall.disp.y",
+      "wall.disp.z",
+      "wall.energy",
+      "wall.euler",
+      "wall.euler.x",
+      "wall.euler.y",
+      "wall.euler.z",
+      "wall.extra",
+      "wall.facet.active",
+      "wall.facet.contact.list",
+      "wall.facet.contact.list.all",
+      "wall.facet.contactmap",
+      "wall.facet.contactmap.all",
+      "wall.facet.contactnum",
+      "wall.facet.contactnum.all",
+      "wall.facet.conveyor",
+      "wall.facet.conveyor.x",
+      "wall.facet.conveyor.y",
+      "wall.facet.conveyor.z",
+      "wall.facet.delete",
+      "wall.facet.extra",
+      "wall.facet.find",
+      "wall.facet.group",
+      "wall.facet.group.list",
+      "wall.facet.group.remove",
+      "wall.facet.groupmap",
+      "wall.facet.id",
+      "wall.facet.inbox",
+      "wall.facet.isbonded",
+      "wall.facet.isgroup",
+      "wall.facet.isprop",
+      "wall.facet.list",
+      "wall.facet.maxid",
+      "wall.facet.near",
+      "wall.facet.normal",
+      "wall.facet.normal.x",
+      "wall.facet.normal.y",
+      "wall.facet.normal.z",
+      "wall.facet.num",
+      "wall.facet.pair",
+      "wall.facet.pointnear",
+      "wall.facet.pointnear.x",
+      "wall.facet.pointnear.y",
+      "wall.facet.pointnear.z",
+      "wall.facet.pos",
+      "wall.facet.pos.x",
+      "wall.facet.pos.y",
+      "wall.facet.pos.z",
+      "wall.facet.prop",
+      "wall.facet.typeid",
+      "wall.facet.vertex",
+      "wall.facet.wall",
+      "wall.facetlist",
+      "wall.find",
+      "wall.fluid.contact.list",
+      "wall.fluid.contact.list.all",
+      "wall.fluid.contactmap",
+      "wall.fluid.contactmap.all",
+      "wall.fluid.extra",
+      "wall.fluid.facet.contact.list",
+      "wall.fluid.facet.contact.list.all",
+      "wall.fluid.facet.contactmap",
+      "wall.fluid.facet.contactmap.all",
+      "wall.fluid.facet.facet",
+      "wall.fluid.facet.find",
+      "wall.fluid.facet.group",
+      "wall.fluid.facet.group.list",
+      "wall.fluid.facet.group.remove",
+      "wall.fluid.facet.groupmap",
+      "wall.fluid.facet.id",
+      "wall.fluid.facet.inbox",
+      "wall.fluid.facet.isgroup",
+      "wall.fluid.facet.isprop",
+      "wall.fluid.facet.list",
+      "wall.fluid.facet.near",
+      "wall.fluid.facet.num",
+      "wall.fluid.facet.pos",
+      "wall.fluid.facet.pos.x",
+      "wall.fluid.facet.pos.y",
+      "wall.fluid.facet.pos.z",
+      "wall.fluid.facet.prop",
+      "wall.fluid.facet.typeid",
+      "wall.fluid.facet.wall",
+      "wall.fluid.facetlist",
+      "wall.fluid.find",
+      "wall.fluid.group",
+      "wall.fluid.group.list",
+      "wall.fluid.group.remove",
+      "wall.fluid.groupmap",
+      "wall.fluid.id",
+      "wall.fluid.inbox",
+      "wall.fluid.isgroup",
+      "wall.fluid.list",
+      "wall.fluid.near",
+      "wall.fluid.num",
+      "wall.fluid.pos",
+      "wall.fluid.pos.x",
+      "wall.fluid.pos.y",
+      "wall.fluid.pos.z",
+      "wall.fluid.prop",
+      "wall.fluid.typeid",
+      "wall.fluid.wall",
+      "wall.force.contact",
+      "wall.force.contact.x",
+      "wall.force.contact.y",
+      "wall.force.contact.z",
+      "wall.fragment",
+      "wall.group",
+      "wall.group.list",
+      "wall.group.remove",
+      "wall.groupmap",
+      "wall.id",
+      "wall.inbox",
+      "wall.inside",
+      "wall.isbonded",
+      "wall.isgroup",
+      "wall.list",
+      "wall.maxid",
+      "wall.moment.contact",
+      "wall.moment.contact.x",
+      "wall.moment.contact.y",
+      "wall.moment.contact.z",
+      "wall.name",
+      "wall.near",
+      "wall.num",
+      "wall.pos",
+      "wall.pos.x",
+      "wall.pos.y",
+      "wall.pos.z",
+      "wall.prop",
+      "wall.rotation.center",
+      "wall.rotation.center.x",
+      "wall.rotation.center.y",
+      "wall.rotation.center.z",
+      "wall.servo.active",
+      "wall.servo.force",
+      "wall.servo.force.x",
+      "wall.servo.force.y",
+      "wall.servo.force.z",
+      "wall.servo.gain",
+      "wall.servo.gainfactor",
+      "wall.servo.gainupdate",
+      "wall.servo.vmax",
+      "wall.spin",
+      "wall.spin.x",
+      "wall.spin.y",
+      "wall.spin.z",
+      "wall.thermal.contact.list",
+      "wall.thermal.contact.list.all",
+      "wall.thermal.contactmap",
+      "wall.thermal.contactmap.all",
+      "wall.thermal.extra",
+      "wall.thermal.facet.contact.list",
+      "wall.thermal.facet.contact.list.all",
+      "wall.thermal.facet.contactmap",
+      "wall.thermal.facet.contactmap.all",
+      "wall.thermal.facet.facet",
+      "wall.thermal.facet.find",
+      "wall.thermal.facet.group",
+      "wall.thermal.facet.group.list",
+      "wall.thermal.facet.group.remove",
+      "wall.thermal.facet.groupmap",
+      "wall.thermal.facet.id",
+      "wall.thermal.facet.inbox",
+      "wall.thermal.facet.isgroup",
+      "wall.thermal.facet.isprop",
+      "wall.thermal.facet.list",
+      "wall.thermal.facet.near",
+      "wall.thermal.facet.num",
+      "wall.thermal.facet.pos",
+      "wall.thermal.facet.pos.x",
+      "wall.thermal.facet.pos.y",
+      "wall.thermal.facet.pos.z",
+      "wall.thermal.facet.prop",
+      "wall.thermal.facet.typeid",
+      "wall.thermal.facet.wall",
+      "wall.thermal.facetlist",
+      "wall.thermal.find",
+      "wall.thermal.group",
+      "wall.thermal.group.list",
+      "wall.thermal.group.remove",
+      "wall.thermal.groupmap",
+      "wall.thermal.id",
+      "wall.thermal.inbox",
+      "wall.thermal.isgroup",
+      "wall.thermal.list",
+      "wall.thermal.near",
+      "wall.thermal.num",
+      "wall.thermal.pos",
+      "wall.thermal.pos.x",
+      "wall.thermal.pos.y",
+      "wall.thermal.pos.z",
+      "wall.thermal.prop",
+      "wall.thermal.typeid",
+      "wall.thermal.wall",
+      "wall.typeid",
+      "wall.vel",
+      "wall.vel.x",
+      "wall.vel.y",
+      "wall.vel.z",
+      "wall.vertex.delete",
+      "wall.vertex.facetarray",
+      "wall.vertex.find",
+      "wall.vertex.id",
+      "wall.vertex.inbox",
+      "wall.vertex.list",
+      "wall.vertex.maxid",
+      "wall.vertex.near",
+      "wall.vertex.num",
+      "wall.vertex.pos",
+      "wall.vertex.pos.x",
+      "wall.vertex.pos.y",
+      "wall.vertex.pos.z",
+      "wall.vertex.typeid",
+      "wall.vertex.vel",
+      "wall.vertex.vel.x",
+      "wall.vertex.vel.y",
+      "wall.vertex.vel.z",
+      "wall.vertexlist"
+    ]
+  },
+  "verification": "Authored 2026-08-15 from the full live 'fish list intrinsics' dump of PFC3D 9.7 (3754 names total; every name and signature below is verbatim from the live table). Signatures use FISH type notation (flt/int/bool/str/vec/ptr/any)."
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/index.json
@@ -25,6 +25,14 @@
       "index_file": "plot-items/index.json",
       "summary": "Keywords for 'plot item create <type>' — color-by, cut, transparency, legend, etc.",
       "usage": "plot item create <type> <keyword> <keyword> ..."
+    },
+    "fish-intrinsics": {
+      "name": "FISH Intrinsics",
+      "description": "PFC FISH intrinsic families for scripted inspection and control - ball, clump, wall (incl. servo), rblock, contact, fracture/DFN, and model utilities (measure/inlet/fragment/domain/cfd).",
+      "directory": "fish-intrinsics",
+      "index_file": "fish-intrinsics/index.json",
+      "summary": "7 family files carrying the complete live PFC3D 9.7 inventory (1290 names) plus curated examples with live signatures",
+      "usage": "fish define <name>; loop foreach local b ball.list; ...; ball.vel(b); endloop; end"
     }
   },
   "navigation": {


### PR DESCRIPTION
PFC was the only engine without a `fish-intrinsics` reference family (FLAC and 3DEC both have one — the boundary gap identified in Batch P1). This batch authors it from the **complete live `fish list intrinsics` dump of PFC3D 9.7** captured in P1 (3754 names; unified-kernel table — other engines' families omitted here).

## Structure (follows the menu-vs-content sizing rule from the references-size discussion)
- Category listing = a 7-entry menu with `intrinsic_count` per family (~2KB).
- Seven leaf files (8–14KB each, fetched on demand), each carrying:
  - curated example intrinsics grouped by purpose, every one with its **verbatim live signature** (`vec3/flt := contact.force.global(mech_contact_pnt,<int>)` style), and
  - the **complete per-family live inventory** (1309 names total) for membership checking.

| family | names | highlights |
|--------|-------|-----------|
| ball | 171 | kinematics/forces/props + thermal/fluid/cfd/zone coupling twins |
| clump | 295 | body + pebbles + reusable templates + thermal/cfd |
| wall | 236 | body + facets (conveyor velocity) + vertices + **servo controls** |
| rblock | 225 | body + geometry queries (aspect ratio, rounding) + templates |
| contact | 126 | global/local forces, `contact.prop`/`contact.method` model access, fluid pipes |
| fracture-dfn | 141 | geometry, Pxy intensity statistics, intersection sets, DFN containers |
| model-utilities | 115 | measure spheres, inlets, fragments, domain, global CFD state |

Category registered in `pfc/references/index.json`; loader verified in a fresh process (category → family index → leaf docs all resolve; the running MCP server needs a restart to see it because the references index is `lru_cache`d).

Tests: `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)