### PR TITLE
docs: enumerate all PFC contact-model property sets against live PFC3D 9.7 (Batch P3)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/beam.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/beam.json
@@ -120,7 +120,7 @@
   ],
   "notes": [
     "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
-    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+    "PFC3D 7.00 pass: model EXISTS on 7.0 with an identical property set (availability corrected to 7.0+9.0; 6.0 unverified)."
   ],
   "source": "live PFC3D 9.7 enumeration (Batch P3)"
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/beam.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/beam.json
@@ -1,0 +1,126 @@
+{
+  "model": "beam",
+  "full_name": "Beam Contact Model",
+  "search_keywords": [
+    "beam",
+    "contact model",
+    "pfc"
+  ],
+  "description": "Structural beam contact model (bm_* keyword family): connects two bodies with an elastic beam of given section/length, carrying force and moment. 9.x-new; absent from the corpus until Batch P3 - property set live-enumerated on PFC3D 9.7, semantics pending curation from the official page.",
+  "typical_applications": [],
+  "property_groups": [
+    {
+      "name": "Beam Group",
+      "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Names, Python types and freshly-created defaults verbatim from the live instance.",
+      "properties": [
+        {
+          "keyword": "bm_A",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_E",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_Estr",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_Iy",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_Iz",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_J",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_L",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_Yaxis",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "bm_Ydir",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 1.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "bm_b",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_bhGiven",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "bm_h",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_kn",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_ks",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bm_moment",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "bm_nu",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        }
+      ]
+    }
+  ],
+  "notes": [
+    "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
+    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+  ],
+  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bilinear.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bilinear.json
@@ -6,13 +6,224 @@
     "contact",
     "model"
   ],
-  "description": "Built-in PFC contact model with a bilinear (two-branch) normal force-displacement response. Refer to the PFC 7.0 manual for the full property set and behavior.",
+  "description": "Built-in PFC contact model with a bilinear (two-branch) normal force-displacement response. Full 33-keyword property set below was live-enumerated on PFC3D 9.7 (Batch P3); descriptions pending curation from the official page.",
   "typical_applications": [
     "Bilinear (two-stage) normal force-displacement response",
     "Compaction with stiffness change",
     "Specialized loading/unloading paths"
   ],
-  "property_groups": [],
+  "property_groups": [
+    {
+      "name": "Linear Base Group",
+      "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Linear-model base surface (same keywords/semantics as the linear model).",
+      "properties": [
+        {
+          "keyword": "dp_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "dp_mode",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_nratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_sratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "emod",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "fric",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "kn",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "kratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "ks",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "rgap",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "user_area",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "Bilinear Group",
+      "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Second-branch (bonded/bilinear) response keywords.",
+      "properties": [
+        {
+          "keyword": "bi_area",
+          "type": "FLT",
+          "default": "1.1309733552923256",
+          "description": ""
+        },
+        {
+          "keyword": "bi_bmul",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_coh",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_comfac",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_fa",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "bi_mcf",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_mode",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_moment",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "bi_radius",
+          "type": "FLT",
+          "default": "0.6",
+          "description": ""
+        },
+        {
+          "keyword": "bi_rmul",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_shear",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_sigma",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_slip",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        },
+        {
+          "keyword": "bi_slipb",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        },
+        {
+          "keyword": "bi_slipt",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        },
+        {
+          "keyword": "bi_state",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_tau",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_ten",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_tenfac",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_tenlim",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "bi_tmul",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        }
+      ]
+    }
+  ],
   "notes": [
     "Refer to the PFC 7.0 manual for the bilinear property set."
   ],

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bisubspringnetwork.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bisubspringnetwork.json
@@ -300,7 +300,7 @@
   ],
   "notes": [
     "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
-    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+    "PFC3D 7.00 pass: model name PARSE-REJECTED by 7.0's cmat enumeration - genuinely 9.x-only (index availability confirmed)."
   ],
   "source": "live PFC3D 9.7 enumeration (Batch P3)"
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bisubspringnetwork.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bisubspringnetwork.json
@@ -1,0 +1,306 @@
+{
+  "model": "bisubspringnetwork",
+  "full_name": "Bonded Sub-Spring Network (bisubspringnetwork) Model",
+  "search_keywords": [
+    "bisubspringnetwork",
+    "contact model",
+    "pfc"
+  ],
+  "description": "Bilinear/bonded variant of the sub-spring network model (sn_* keyword family, 47 properties). 9.x-new; absent from the corpus until Batch P3 - property set live-enumerated on PFC3D 9.7, semantics pending curation.",
+  "typical_applications": [],
+  "property_groups": [
+    {
+      "name": "Sub-Spring Network Group",
+      "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Names, Python types and freshly-created defaults verbatim from the live instance.",
+      "properties": [
+        {
+          "keyword": "dp_force",
+          "type": "NONETYPE",
+          "default": "None",
+          "description": ""
+        },
+        {
+          "keyword": "dp_mode",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_nratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_sratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "fric",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "fric2",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "kn",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "kratio",
+          "type": "FLT",
+          "default": "1.0",
+          "description": ""
+        },
+        {
+          "keyword": "krot",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "ks",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "rgap",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_area",
+          "type": "FLT",
+          "default": "1.1309733552923256",
+          "description": ""
+        },
+        {
+          "keyword": "sn_cntconv",
+          "type": "INT",
+          "default": "-1",
+          "description": ""
+        },
+        {
+          "keyword": "sn_coh",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_coh2",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_cohdc",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_cohres",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_cohres2",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_cohtab",
+          "type": "VEC2",
+          "default": "vec2(1.000000e+00, 0.000000e+00)",
+          "description": ""
+        },
+        {
+          "keyword": "sn_conv",
+          "type": "FLT",
+          "default": "1000.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_dil",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_dil2",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_dilzero",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_esigma",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_fa",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_fa2",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "sn_gap",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_heal",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        },
+        {
+          "keyword": "sn_index",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_moment",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "sn_non_diag",
+          "type": "INT",
+          "default": "1",
+          "description": ""
+        },
+        {
+          "keyword": "sn_nstress",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_nstressres",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_pois",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_pois_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "sn_porp",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_sdisp",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_shear",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_sigma",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_slip",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        },
+        {
+          "keyword": "sn_state",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_states",
+          "type": "STR",
+          "default": "'(U,U,U)'",
+          "description": ""
+        },
+        {
+          "keyword": "sn_tabpos",
+          "type": "INT",
+          "default": "1",
+          "description": ""
+        },
+        {
+          "keyword": "sn_tau",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sn_ten",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "user_area",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        }
+      ]
+    }
+  ],
+  "notes": [
+    "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
+    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+  ],
+  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/burger.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/burger.json
@@ -22,13 +22,19 @@
         {
           "keyword": "fric",
           "symbol": "f_s",
-          "description": "Sliding friction coefficient",
+          "description": "STALE SPELLING - not in the live 9.7 property set; the live keyword is 'bur_fric'. Sliding friction coefficient",
           "type": "FLT",
           "range": "[0.0, +∞)",
           "default": "0",
           "modifiable": true,
           "inheritable": true,
           "notes": ""
+        },
+        {
+          "keyword": "bur_fric",
+          "type": "FLT",
+          "default": "0.5",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Friction coefficient (live spelling of the documented 'fric')."
         }
       ]
     },

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/eepa.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/eepa.json
@@ -65,6 +65,12 @@
           "modifiable": true,
           "inheritable": false,
           "notes": ""
+        },
+        {
+          "keyword": "f_min",
+          "type": "FLT",
+          "default": "0.0",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Minimum (pull-off) force (live spelling of the documented 'force_min')."
         }
       ]
     },
@@ -197,7 +203,7 @@
         {
           "keyword": "force_min",
           "symbol": "f_min",
-          "description": "Minimum force",
+          "description": "STALE SPELLING - not in the live 9.7 property set; the live keyword is 'f_min'. Minimum force",
           "type": "FLT",
           "range": "",
           "default": "1",
@@ -275,7 +281,8 @@
     }
   ],
   "notes": [
-    "Edinburgh Elasto-Plastic Adhesive: hysteretic loading/unloading with adhesion."
+    "Edinburgh Elasto-Plastic Adhesive: hysteretic loading/unloading with adhesion.",
+    "Live 9.7 creation requirement: 'eepa_shear' must be > 0 BEFORE contacts form - 'model clean' with the default 0 fails with \"'eepa_shear' must be specified using a value larger than zero\"; set it in the cmat default ('contact cmat default model eepa property eepa_shear <f>')."
   ],
   "source": "PFC 7.0 documentation",
   "availability": {

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/hill.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/hill.json
@@ -1,0 +1,102 @@
+{
+  "model": "hill",
+  "full_name": "Hill Contact Model",
+  "search_keywords": [
+    "hill",
+    "contact model",
+    "pfc"
+  ],
+  "description": "Hill (moist granular / capillary suction) contact model: nonlinear elasticity with moisture-induced suction forces. 9.x-new in this corpus - property set live-read on PFC3D 9.7. SETUP REQUIREMENT (live): the model derives elasticity from body SURFACE properties - 'model clean' can fail with 'Surface property young_mod has not been assigned to a body' when balls lack young_mod (observed intermittently on 9.7: some cleans pass with young_mod/pois_ratio at the -1.0 sentinel and the check fires later). Set them via ball property with QUOTED names (ball property 'young_mod' 1e8 'pois_ratio' 0.3 - unquoted names are rejected). Even when clean errors, the contact is still created and props() reads back fine.",
+  "typical_applications": [],
+  "property_groups": [
+    {
+      "name": "Hill Group",
+      "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Names, Python types and freshly-created defaults verbatim from the live instance.",
+      "properties": [
+        {
+          "keyword": "damp_con",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "fric_coef",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "mois_force",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "mois_state",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "ndamp_coef",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "nstiff_coef",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "overlap",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "pois_ratio",
+          "type": "FLT",
+          "default": "-1.0",
+          "description": ""
+        },
+        {
+          "keyword": "sdamp_coef",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "sstiff_coef",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "suction",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "surf_force",
+          "type": "VEC",
+          "default": "vec3((0,0,0))",
+          "description": ""
+        },
+        {
+          "keyword": "young_mod",
+          "type": "FLT",
+          "default": "-1.0",
+          "description": ""
+        }
+      ]
+    }
+  ],
+  "notes": [
+    "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
+    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+  ],
+  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/hill.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/hill.json
@@ -96,7 +96,7 @@
   ],
   "notes": [
     "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
-    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+    "PFC3D 7.00 pass: model EXISTS on 7.0 with an identical property set (availability corrected to 7.0+9.0; 6.0 unverified)."
   ],
   "source": "live PFC3D 9.7 enumeration (Batch P3)"
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/index.json
@@ -294,7 +294,7 @@
       "status": "documented",
       "availability": {
         "6.0": false,
-        "7.0": false,
+        "7.0": true,
         "9.0": true
       }
     },
@@ -433,7 +433,7 @@
       "status": "documented",
       "availability": {
         "6.0": false,
-        "7.0": false,
+        "7.0": true,
         "9.0": true
       }
     },
@@ -450,7 +450,7 @@
       "status": "documented",
       "availability": {
         "6.0": false,
-        "7.0": false,
+        "7.0": true,
         "9.0": true
       }
     },
@@ -508,7 +508,8 @@
     "Live PFC3D 9.7 mechanical model enumeration (Batch P3) = 23 names: arrlinear beam bilinear bisubspringnetwork burger eepa fish flatjoint hertz hill hysteretic jkr linear linearcbond lineardipole linearpbond mohr null rrhertz rrlinear smoothjoint softbond springnetwork subspringnetwork. Thermal process slot ('contact cmat thermal default model') enumerates: null thermalpipe.",
     "Every model's full property set was read back from a live BallBallContact via Python props() (Batch P3): 12 models matched the corpus exactly; renames and live-only additions are annotated in the per-model files.",
     "TRAP: the cmat property slot ('contact cmat default model <m> property ?') enumerates the UNION of ALL models' property command-names (~280 keywords), not the selected model's set - do not use it for per-model membership. Per-model membership: Python Contact.prop()/has_prop (name-validated on PFC, unlike 3DEC).",
-    "Python SDK caveats (9.7): Contact.props() raises on lineardipole (2D-quaternion properties); 'contact cmat default type' enumerates 13 unified-kernel pair types including MPMPoint-facet."
+    "Python SDK caveats (9.7): Contact.props() raises on lineardipole (2D-quaternion properties); 'contact cmat default type' enumerates 13 unified-kernel pair types including MPMPoint-facet.",
+    "PFC3D 7.00 pass (2026-08-15): live 7.0 mechanical enumeration = 21 models (the 9.7 set minus rrhertz and bisubspringnetwork, which 7.0 parse-rejects - genuinely 9.x-only). beam and hill EXIST on 7.0 with identical property sets (previous 9.0-only marking corrected). The thermal slot enumerates null|thermalpipe on 7.0 too. All other models' property sets are identical across 7.0/9.7 except mohr (7.0 uses mc:-prefixed names) and subspringnetwork (9.x adds sn_cntconv/sn_conv/sn_convlim/sn_states)."
   ],
-  "verification": "Batch P3 (2026-08-15, live PFC3D 9.7): all 23 mechanical models + 2 thermal models property-enumerated via live contact instances; 4 corpus-missing models authored (beam, hill, rrhertz, bisubspringnetwork); bilinear/thermalpipe stubs filled; burger/eepa/jkr renames flagged. "
+  "verification": "Batch P3 (2026-08-15, live PFC3D 9.7 + PFC3D 7.00): all 23 mechanical models + 2 thermal models property-enumerated via live contact instances; 4 corpus-missing models authored (beam, hill, rrhertz, bisubspringnetwork); bilinear/thermalpipe stubs filled; burger/eepa/jkr renames flagged. "
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/index.json
@@ -419,6 +419,74 @@
         "7.0": true,
         "9.0": true
       }
+    },
+    {
+      "name": "beam",
+      "file": "beam.json",
+      "full_name": "Beam Contact Model",
+      "description": "Structural beam contact model (bm_* keyword family): connects two bodies with an elastic beam of given section/length, carrying force and moment.",
+      "property_groups": [
+        "Beam Group"
+      ],
+      "common_use": "",
+      "priority": "low",
+      "status": "documented",
+      "availability": {
+        "6.0": false,
+        "7.0": false,
+        "9.0": true
+      }
+    },
+    {
+      "name": "hill",
+      "file": "hill.json",
+      "full_name": "Hill Contact Model",
+      "description": "Hill (moist granular / capillary suction) contact model: nonlinear elasticity with moisture-induced suction forces.",
+      "property_groups": [
+        "Hill Group"
+      ],
+      "common_use": "",
+      "priority": "low",
+      "status": "documented",
+      "availability": {
+        "6.0": false,
+        "7.0": false,
+        "9.0": true
+      }
+    },
+    {
+      "name": "rrhertz",
+      "file": "rrhertz.json",
+      "full_name": "Rolling Resistance Hertz Model",
+      "description": "Hertz-Mindlin contact with rolling resistance (hz_* + rr_* keyword families) - the hertz analogue of rrlinear.",
+      "property_groups": [
+        "RR-Hertz Group"
+      ],
+      "common_use": "",
+      "priority": "low",
+      "status": "documented",
+      "availability": {
+        "6.0": false,
+        "7.0": false,
+        "9.0": true
+      }
+    },
+    {
+      "name": "bisubspringnetwork",
+      "file": "bisubspringnetwork.json",
+      "full_name": "Bonded Sub-Spring Network (bisubspringnetwork) Model",
+      "description": "Bilinear/bonded variant of the sub-spring network model (sn_* keyword family, 47 properties).",
+      "property_groups": [
+        "Sub-Spring Network Group"
+      ],
+      "common_use": "",
+      "priority": "low",
+      "status": "documented",
+      "availability": {
+        "6.0": false,
+        "7.0": false,
+        "9.0": true
+      }
     }
   ],
   "related_documentation": {
@@ -436,6 +504,11 @@
     "Use 'emod' and 'kratio' with deformability method for automatic stiffness calculation",
     "Vector properties use contact plane coordinate system",
     "Model availability is version-specific (see each model's 'availability'); browse with the 'version' parameter (6.0/7.0/9.0). Property content is shared across versions; properties added in a later version carry a 'since' marker.",
-    "Thermal contact models (thermalnull, thermalpipe) require the thermal option to be configured."
-  ]
+    "Thermal contact models (thermalnull, thermalpipe) require the thermal option to be configured.",
+    "Live PFC3D 9.7 mechanical model enumeration (Batch P3) = 23 names: arrlinear beam bilinear bisubspringnetwork burger eepa fish flatjoint hertz hill hysteretic jkr linear linearcbond lineardipole linearpbond mohr null rrhertz rrlinear smoothjoint softbond springnetwork subspringnetwork. Thermal process slot ('contact cmat thermal default model') enumerates: null thermalpipe.",
+    "Every model's full property set was read back from a live BallBallContact via Python props() (Batch P3): 12 models matched the corpus exactly; renames and live-only additions are annotated in the per-model files.",
+    "TRAP: the cmat property slot ('contact cmat default model <m> property ?') enumerates the UNION of ALL models' property command-names (~280 keywords), not the selected model's set - do not use it for per-model membership. Per-model membership: Python Contact.prop()/has_prop (name-validated on PFC, unlike 3DEC).",
+    "Python SDK caveats (9.7): Contact.props() raises on lineardipole (2D-quaternion properties); 'contact cmat default type' enumerates 13 unified-kernel pair types including MPMPoint-facet."
+  ],
+  "verification": "Batch P3 (2026-08-15, live PFC3D 9.7): all 23 mechanical models + 2 thermal models property-enumerated via live contact instances; 4 corpus-missing models authored (beam, hill, rrhertz, bisubspringnetwork); bilinear/thermalpipe stubs filled; burger/eepa/jkr renames flagged. "
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/jkr.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/jkr.json
@@ -64,6 +64,12 @@
           "modifiable": true,
           "inheritable": false,
           "notes": ""
+        },
+        {
+          "keyword": "active_mode",
+          "type": "INT",
+          "default": "0",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Adhesion activation mode (live-only; not on the official page)."
         }
       ]
     },
@@ -141,7 +147,7 @@
         {
           "keyword": "adh_exp",
           "symbol": "M_a",
-          "description": "Active mode",
+          "description": "NOT in the live 9.7 jkr property set (it is an eepa keyword) - kept from the official page. Active mode",
           "type": "FLT",
           "range": "",
           "default": "0",

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/lineardipole.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/lineardipole.json
@@ -320,7 +320,8 @@
     }
   ],
   "notes": [
-    "Python SDK caveat (9.7): Contact.props() fails on this model because dipole_size1/dipole_size2 are 2D-quaternion typed ('Cannot convert property type 2d quaternion to PyObject'). Use per-name Contact.prop('<name>') for everything else - unlike 3DEC's Subcontact.prop, PFC's prop() DOES validate membership ('Property ... not recognized by contact model ...')."
+    "Python SDK caveat (9.7): Contact.props() fails on this model because dipole_size1/dipole_size2 are 2D-quaternion typed ('Cannot convert property type 2d quaternion to PyObject'). Use per-name Contact.prop('<name>') for everything else - unlike 3DEC's Subcontact.prop, PFC's prop() DOES validate membership ('Property ... not recognized by contact model ...').",
+    "PFC3D 7.00: Contact.props() fails there too, with a different conversion error ('unknown type in conversion from QVariant to PyObject qulonglong') - the per-name prop() workaround applies on both versions."
   ],
   "source": "PFC 7.0 documentation",
   "availability": {

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/lineardipole.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/lineardipole.json
@@ -269,9 +269,59 @@
           "notes": ""
         }
       ]
+    },
+    {
+      "name": "Live-only Dipole State Group",
+      "description": "Seven additional live 9.7 properties absent from the official page (Batch P3).",
+      "properties": [
+        {
+          "keyword": "dipole_pos1",
+          "type": "VEC",
+          "default": "",
+          "description": "Dipole 1 position (live-only; enumerated via the cmat property slot, verified with Contact.has_prop/prop)."
+        },
+        {
+          "keyword": "dipole_pos2",
+          "type": "VEC",
+          "default": "",
+          "description": "Dipole 2 position (live-only)."
+        },
+        {
+          "keyword": "dipole_size1",
+          "type": "QUAT2D",
+          "default": "",
+          "description": "Dipole 1 size - a 2D-quaternion-typed property: Python Contact.props()/prop() CANNOT convert it ('Cannot convert property type 2d quaternion to PyObject'), which makes props() raise for the whole model; read other properties per-name instead."
+        },
+        {
+          "keyword": "dipole_size2",
+          "type": "QUAT2D",
+          "default": "",
+          "description": "Dipole 2 size - same 2D-quaternion Python conversion limitation as dipole_size1."
+        },
+        {
+          "keyword": "dipole_t1",
+          "type": "VEC",
+          "default": "",
+          "description": "Dipole 1 orientation/torque vector (live-only)."
+        },
+        {
+          "keyword": "dipole_t2",
+          "type": "VEC",
+          "default": "",
+          "description": "Dipole 2 orientation/torque vector (live-only)."
+        },
+        {
+          "keyword": "dipole_tabpos",
+          "type": "INT",
+          "default": "",
+          "description": "Table position index (live-only)."
+        }
+      ]
     }
   ],
-  "notes": [],
+  "notes": [
+    "Python SDK caveat (9.7): Contact.props() fails on this model because dipole_size1/dipole_size2 are 2D-quaternion typed ('Cannot convert property type 2d quaternion to PyObject'). Use per-name Contact.prop('<name>') for everything else - unlike 3DEC's Subcontact.prop, PFC's prop() DOES validate membership ('Property ... not recognized by contact model ...')."
+  ],
   "source": "PFC 7.0 documentation",
   "availability": {
     "6.0": false,

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/mohr.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/mohr.json
@@ -374,7 +374,8 @@
     }
   ],
   "notes": [
-    "Mohr-Coulomb contact model (PFC 9.0+)."
+    "Mohr-Coulomb contact model (PFC 9.0+).",
+    "VERSION RENAME (live-verified both sides): on PFC3D 7.00 every mohr property carries an 'mc-' prefix (mc-cohesion, mc-friction, mc-stiffness-normal, ...); PFC 9.x dropped the prefix - the names in this file are the 9.x spellings. Map 7.0 <-> 9.x by adding/removing 'mc-'. The dashpot-* family (dashpot-force/mode/ratio-normal/ratio-shear) is 9.x-only (absent from the 7.0 set). The model itself EXISTS on 7.0 (28 props) - the earlier 9.0-only availability marking was wrong."
   ],
   "source": "Itasca Software 9.0 documentation",
   "availability": {

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/mohr.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/mohr.json
@@ -27,6 +27,12 @@
           "modifiable": true,
           "inheritable": false,
           "notes": ""
+        },
+        {
+          "keyword": "tensile-pore-pressure",
+          "type": "FLT",
+          "default": "0.0",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Tensile pore-pressure term (live-only; not on the official page)."
         }
       ]
     },

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/rrhertz.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/rrhertz.json
@@ -1,0 +1,126 @@
+{
+  "model": "rrhertz",
+  "full_name": "Rolling Resistance Hertz Model",
+  "search_keywords": [
+    "rrhertz",
+    "contact model",
+    "pfc"
+  ],
+  "description": "Hertz-Mindlin contact with rolling resistance (hz_* + rr_* keyword families) - the hertz analogue of rrlinear. 9.x-new in this corpus; property set live-enumerated on PFC3D 9.7.",
+  "typical_applications": [],
+  "property_groups": [
+    {
+      "name": "RR-Hertz Group",
+      "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Names, Python types and freshly-created defaults verbatim from the live instance.",
+      "properties": [
+        {
+          "keyword": "dp_alpha",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "dp_mode",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_nratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "dp_sratio",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "fric",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "hz_alpha",
+          "type": "FLT",
+          "default": "1.5",
+          "description": ""
+        },
+        {
+          "keyword": "hz_force",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "hz_mode",
+          "type": "INT",
+          "default": "0",
+          "description": ""
+        },
+        {
+          "keyword": "hz_poiss",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "hz_shear",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "hz_slip",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        },
+        {
+          "keyword": "rgap",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "rr_fric",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "rr_kr",
+          "type": "FLT",
+          "default": "0.0",
+          "description": ""
+        },
+        {
+          "keyword": "rr_moment",
+          "type": "VEC",
+          "default": "vec3(( 0.000000e+00, 0.000000e+00, 0.000000e+00 ))",
+          "description": ""
+        },
+        {
+          "keyword": "rr_slip",
+          "type": "BOOL",
+          "default": "False",
+          "description": ""
+        }
+      ]
+    }
+  ],
+  "notes": [
+    "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
+    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+  ],
+  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+}

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/rrhertz.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/rrhertz.json
@@ -120,7 +120,7 @@
   ],
   "notes": [
     "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
-    "9.7-verified; 6.0/7.0 availability unverified (flagged false in the index pending the PFC 7.0 pass)."
+    "PFC3D 7.00 pass: model name PARSE-REJECTED by 7.0's cmat enumeration - genuinely 9.x-only (index availability confirmed)."
   ],
   "source": "live PFC3D 9.7 enumeration (Batch P3)"
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/springnetwork.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/springnetwork.json
@@ -63,6 +63,12 @@
           "modifiable": true,
           "inheritable": false,
           "notes": ""
+        },
+        {
+          "keyword": "sn_esigma",
+          "type": "FLT",
+          "default": "0.0",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Effective normal stress (live-only; not on the official page)."
         }
       ]
     },

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/subspringnetwork.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/subspringnetwork.json
@@ -482,7 +482,8 @@
     }
   ],
   "notes": [
-    "Command name 'subspringnetwork' (PFC 9.0+)."
+    "Command name 'subspringnetwork' (PFC 9.0+).",
+    "Version diff (live-verified): sn_cntconv, sn_conv, sn_convlim and sn_states are 9.x-only - PFC3D 7.00 lacks them (37 vs 41 props); the rest of the set is identical on 7.0."
   ],
   "source": "Itasca Software 9.0 documentation",
   "availability": {

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/subspringnetwork.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/subspringnetwork.json
@@ -62,6 +62,18 @@
           "modifiable": true,
           "inheritable": false,
           "notes": ""
+        },
+        {
+          "keyword": "sn_esigma",
+          "type": "FLT",
+          "default": "0.0",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Live-only on 9.7; not on the official page."
+        },
+        {
+          "keyword": "sn_sigma",
+          "type": "FLT",
+          "default": "0.0",
+          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Live-only on 9.7; not on the official page."
         }
       ]
     },

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalnull.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalnull.json
@@ -8,7 +8,7 @@
     "thermal",
     "thermalnull"
   ],
-  "description": "STALE NAME on live 9.7: the thermal CMAT model-name slot enumerates 'null' and 'thermalpipe' only - the default thermal model is assigned as 'contact cmat thermal default model null', NOT 'thermalnull'. The null thermal contact model is the default thermal contact model. No power is generated.",
+  "description": "STALE NAME on live 9.7 AND 7.0 (both enumerate null|thermalpipe): the thermal CMAT model-name slot enumerates 'null' and 'thermalpipe' only - the default thermal model is assigned as 'contact cmat thermal default model null', NOT 'thermalnull'. The null thermal contact model is the default thermal contact model. No power is generated.",
   "typical_applications": [
     "Disabling thermal conduction at selected contacts",
     "Excluding a contact type from heat transfer"

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalnull.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalnull.json
@@ -8,7 +8,7 @@
     "thermal",
     "thermalnull"
   ],
-  "description": "The null thermal contact model is the default thermal contact model. No power is generated.",
+  "description": "STALE NAME on live 9.7: the thermal CMAT model-name slot enumerates 'null' and 'thermalpipe' only - the default thermal model is assigned as 'contact cmat thermal default model null', NOT 'thermalnull'. The null thermal contact model is the default thermal contact model. No power is generated.",
   "typical_applications": [
     "Disabling thermal conduction at selected contacts",
     "Excluding a contact type from heat transfer"

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalpipe.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalpipe.json
@@ -14,9 +14,35 @@
     "Coupled thermo-mechanical simulations",
     "Thermal diffusion through granular assemblies"
   ],
-  "property_groups": [],
+  "property_groups": [
+    {
+      "name": "Thermal Pipe Group",
+      "description": "Live-enumerated on PFC3D 9.7 via the cmat property slot (Batch P3).",
+      "properties": [
+        {
+          "keyword": "temperature",
+          "type": "FLT",
+          "default": "",
+          "description": "Pipe temperature."
+        },
+        {
+          "keyword": "thexp",
+          "type": "FLT",
+          "default": "",
+          "description": "Thermal expansion coefficient."
+        },
+        {
+          "keyword": "thres",
+          "type": "FLT",
+          "default": "",
+          "description": "Thermal resistance per unit length (the model's defining parameter)."
+        }
+      ]
+    }
+  ],
   "notes": [
-    "Thermal option model. Properties documented under the PFC thermal option manual."
+    "Thermal option model. Properties documented under the PFC thermal option manual.",
+    "Assignment grammar (live 9.7): the thermal CMAT uses a process selector - 'contact cmat thermal default model thermalpipe'. Requires 'model configure thermal'. The thermal model-name slot enumerates exactly: null thermalpipe."
   ],
   "source": "PFC 7.0 documentation",
   "availability": {


### PR DESCRIPTION
Batch P3 gives every PFC contact model a live-read property surface — each model was assigned via `contact cmat default`, a real contact created, and the full `props()` dict read back through the Python SDK (names + types + fresh defaults). 15 files (11 updated + 4 new).

## Findings
- **Live mechanical enumeration = 23 models; 4 were missing from the corpus entirely** (9.x-new): `beam` (17 props, `bm_*` family), `hill` (13 — moisture/suction model whose elasticity comes from body *surface properties*; setup requirement + quoted-name `ball property` syntax documented), `rrhertz` (17 — hertz + rolling resistance), `bisubspringnetwork` (47). All authored from live data.
- **12 models matched the corpus exactly** — the dogfooded property lists held up (linear, linearpbond, flatjoint, softbond, smoothjoint, hertz, arrlinear, rrlinear, linearcbond, hysteretic, fish, null).
- **`bilinear` was a 0-property stub → filled with the live 33.**
- **Renames flagged in place**: burger `fric`→`bur_fric`; eepa `force_min`→`f_min`; jkr `adh_exp` is not live (it's an eepa keyword) with live-only `active_mode` added. Live-only additions: mohr `tensile-pore-pressure`, springnetwork `sn_esigma`, subspringnetwork `sn_esigma`/`sn_sigma`.
- **lineardipole: 7 undocumented live properties**, two of which (`dipole_size1/2`) are 2D-quaternion typed and make Python `Contact.props()` raise for the whole model — per-name `prop()` workaround documented. Bonus finding: PFC's `prop()` **is** name-validated ("Property … not recognized"), unlike 3DEC's `Subcontact.prop`.
- **Thermal process**: grammar is `contact cmat thermal default model …` with live names `null | thermalpipe` — the corpus name **`thermalnull` is stale**; `thermalpipe` stub filled (temperature/thexp/thres).
- **Traps recorded in the index**: the cmat `property` slot enumerates the ~280-keyword UNION of all models (useless for per-model membership); `contact cmat default type` lists 13 unified-kernel pair types (incl. MPMPoint-facet); eepa requires `eepa_shear > 0` before contacts can form.

6.0/7.0 version blocks were not touched — flagged for the PFC 7.0 licensed-machine pass (new models marked 9.0-only pending that check).

Tests: `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)