### PR TITLE
docs: reconcile PFC contact-model corpus against live PFC3D 6.00 (Batch P4)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/beam.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/beam.json
@@ -6,7 +6,7 @@
     "contact model",
     "pfc"
   ],
-  "description": "Structural beam contact model (bm_* keyword family): connects two bodies with an elastic beam of given section/length, carrying force and moment. 9.x-new; absent from the corpus until Batch P3 - property set live-enumerated on PFC3D 9.7, semantics pending curation from the official page.",
+  "description": "Structural beam contact model (bm_* keyword family): connects two bodies with an elastic beam of given section/length, carrying force and moment. Available on 6.0/7.0/9.x; property set live-enumerated, semantics pending curation from the official page.",
   "typical_applications": [],
   "property_groups": [
     {
@@ -119,8 +119,13 @@
     }
   ],
   "notes": [
-    "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
-    "PFC3D 7.00 pass: model EXISTS on 7.0 with an identical property set (availability corrected to 7.0+9.0; 6.0 unverified)."
+    "Official-page prose not yet merged; property metadata comes from live enumeration.",
+    "Property set live-verified identical on PFC3D 6.00, 7.00 and 9.7 (CamelCase spellings bm_A/bm_E/bm_Estr/bm_Iy/bm_Iz/bm_J/bm_Yaxis/bm_Ydir/bm_bhGiven verbatim)."
   ],
-  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+  "source": "live PFC3D 6.00/7.00/9.7 enumeration",
+  "availability": {
+    "6.0": true,
+    "7.0": true,
+    "9.0": true
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bisubspringnetwork.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/bisubspringnetwork.json
@@ -302,5 +302,10 @@
     "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
     "PFC3D 7.00 pass: model name PARSE-REJECTED by 7.0's cmat enumeration - genuinely 9.x-only (index availability confirmed)."
   ],
-  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+  "source": "live PFC3D 9.7 enumeration (Batch P3)",
+  "availability": {
+    "6.0": false,
+    "7.0": false,
+    "9.0": true
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/burger.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/burger.json
@@ -22,7 +22,7 @@
         {
           "keyword": "fric",
           "symbol": "f_s",
-          "description": "STALE SPELLING - not in the live 9.7 property set; the live keyword is 'bur_fric'. Sliding friction coefficient",
+          "description": "STALE SPELLING - not in the live 6.0/7.0/9.7 property sets; the live keyword is 'bur_fric' on every version. Sliding friction coefficient",
           "type": "FLT",
           "range": "[0.0, +∞)",
           "default": "0",
@@ -34,7 +34,7 @@
           "keyword": "bur_fric",
           "type": "FLT",
           "default": "0.5",
-          "description": "Live-enumerated on PFC3D 9.7 via BallBallContact.props() (Batch P3). Friction coefficient (live spelling of the documented 'fric')."
+          "description": "Live spelling on 6.0/7.0/9.7, enumerated via BallBallContact.props(). Friction coefficient (live spelling of the documented 'fric')."
         }
       ]
     },

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/flatjoint.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/flatjoint.json
@@ -374,7 +374,8 @@
   ],
   "notes": [
     "Flat-joint interface is discretized into elements.",
-    "Bonded and unbonded elements give a moment-resisting contact."
+    "Bonded and unbonded elements give a moment-resisting contact.",
+    "fj_cohres and fj_resmode do not exist on 6.0 (since-7.0); the remaining 29 properties are identical across live 6.00/7.00/9.7."
   ],
   "source": "PFC 7.0 documentation",
   "availability": {

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/hill.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/hill.json
@@ -6,7 +6,7 @@
     "contact model",
     "pfc"
   ],
-  "description": "Hill (moist granular / capillary suction) contact model: nonlinear elasticity with moisture-induced suction forces. 9.x-new in this corpus - property set live-read on PFC3D 9.7. SETUP REQUIREMENT (live): the model derives elasticity from body SURFACE properties - 'model clean' can fail with 'Surface property young_mod has not been assigned to a body' when balls lack young_mod (observed intermittently on 9.7: some cleans pass with young_mod/pois_ratio at the -1.0 sentinel and the check fires later). Set them via ball property with QUOTED names (ball property 'young_mod' 1e8 'pois_ratio' 0.3 - unquoted names are rejected). Even when clean errors, the contact is still created and props() reads back fine.",
+  "description": "Hill (moist granular / capillary suction) contact model: nonlinear elasticity with moisture-induced suction forces. Available on 6.0/7.0/9.x; property set live-enumerated. SETUP REQUIREMENT (live): the model derives elasticity from body SURFACE properties - 'model clean' can fail with 'Surface property young_mod has not been assigned to a body' when balls lack young_mod (observed intermittently on 9.7: some cleans pass with young_mod/pois_ratio at the -1.0 sentinel and the check fires later). Set them via ball property with QUOTED names (ball property 'young_mod' 1e8 'pois_ratio' 0.3 - unquoted names are rejected). Even when clean errors, the contact is still created and props() reads back fine.",
   "typical_applications": [],
   "property_groups": [
     {
@@ -95,8 +95,13 @@
     }
   ],
   "notes": [
-    "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
-    "PFC3D 7.00 pass: model EXISTS on 7.0 with an identical property set (availability corrected to 7.0+9.0; 6.0 unverified)."
+    "Official-page prose not yet merged; property metadata comes from live enumeration.",
+    "Property set live-verified identical on PFC3D 6.00, 7.00 and 9.7. The intermittent 'model clean' surface-property error occurs on all three versions; the contact is still created and props() reads back fine."
   ],
-  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+  "source": "live PFC3D 6.00/7.00/9.7 enumeration",
+  "availability": {
+    "6.0": true,
+    "7.0": true,
+    "9.0": true
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/index.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/index.json
@@ -432,7 +432,7 @@
       "priority": "low",
       "status": "documented",
       "availability": {
-        "6.0": false,
+        "6.0": true,
         "7.0": true,
         "9.0": true
       }
@@ -449,7 +449,7 @@
       "priority": "low",
       "status": "documented",
       "availability": {
-        "6.0": false,
+        "6.0": true,
         "7.0": true,
         "9.0": true
       }
@@ -509,7 +509,9 @@
     "Every model's full property set was read back from a live BallBallContact via Python props() (Batch P3): 12 models matched the corpus exactly; renames and live-only additions are annotated in the per-model files.",
     "TRAP: the cmat property slot ('contact cmat default model <m> property ?') enumerates the UNION of ALL models' property command-names (~280 keywords), not the selected model's set - do not use it for per-model membership. Per-model membership: Python Contact.prop()/has_prop (name-validated on PFC, unlike 3DEC).",
     "Python SDK caveats (9.7): Contact.props() raises on lineardipole (2D-quaternion properties); 'contact cmat default type' enumerates 13 unified-kernel pair types including MPMPoint-facet.",
-    "PFC3D 7.00 pass (2026-08-15): live 7.0 mechanical enumeration = 21 models (the 9.7 set minus rrhertz and bisubspringnetwork, which 7.0 parse-rejects - genuinely 9.x-only). beam and hill EXIST on 7.0 with identical property sets (previous 9.0-only marking corrected). The thermal slot enumerates null|thermalpipe on 7.0 too. All other models' property sets are identical across 7.0/9.7 except mohr (7.0 uses mc:-prefixed names) and subspringnetwork (9.x adds sn_cntconv/sn_conv/sn_convlim/sn_states)."
+    "PFC3D 7.00 pass (2026-08-15): live 7.0 mechanical enumeration = 21 models (the 9.7 set minus rrhertz and bisubspringnetwork, which 7.0 parse-rejects - genuinely 9.x-only). beam and hill EXIST on 7.0 with identical property sets (previous 9.0-only marking corrected). The thermal slot enumerates null|thermalpipe on 7.0 too. All other models' property sets are identical across 7.0/9.7 except mohr (7.0 uses mc:-prefixed names) and subspringnetwork (9.x adds sn_cntconv/sn_conv/sn_convlim/sn_states).",
+    "Live PFC3D 6.00 mechanical enumeration = 14 models: arrlinear beam burger flatjoint hertz hill hysteretic linear linearcbond linearpbond null rrlinear smoothjoint softbond. bilinear/eepa/fish/jkr/lineardipole/mohr/springnetwork are 7.0-new; rrhertz/subspringnetwork/bisubspringnetwork are 9.x-new. All 6.0 models' property sets are identical to 7.0/9.7 except flatjoint (6.0 lacks the since-7.0 fj_cohres/fj_resmode). The thermal slot enumerates null|thermalpipe on 6.0 as well, with the thermalpipe property slot = temperature/thexp/thres.",
+    "6.0 syntax caveat: contact detection is forced with 'model clean' only - the bare 'clean' shorthand is 7.0+. The cmat property-slot UNION trap applies on 6.0 as well (~160 keywords enumerated regardless of the selected model). Thermal contacts are invisible to Python itasca.contact.list() on 6.0 too."
   ],
-  "verification": "Batch P3 (2026-08-15, live PFC3D 9.7 + PFC3D 7.00): all 23 mechanical models + 2 thermal models property-enumerated via live contact instances; 4 corpus-missing models authored (beam, hill, rrhertz, bisubspringnetwork); bilinear/thermalpipe stubs filled; burger/eepa/jkr renames flagged. "
+  "verification": "Batch P3 (2026-08-15, live PFC3D 9.7 + PFC3D 7.00): all 23 mechanical models + 2 thermal models property-enumerated via live contact instances; 4 corpus-missing models authored (beam, hill, rrhertz, bisubspringnetwork); bilinear/thermalpipe stubs filled; burger/eepa/jkr renames flagged. Batch P4 (2026-08-16, live PFC3D 6.00): all 14 live 6.0 models re-enumerated; 6.0 availability and per-property version markers reconciled against the live sets."
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/rrhertz.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/rrhertz.json
@@ -122,5 +122,10 @@
     "Authored in Batch P3 from live enumeration; official-page prose not yet merged.",
     "PFC3D 7.00 pass: model name PARSE-REJECTED by 7.0's cmat enumeration - genuinely 9.x-only (index availability confirmed)."
   ],
-  "source": "live PFC3D 9.7 enumeration (Batch P3)"
+  "source": "live PFC3D 9.7 enumeration (Batch P3)",
+  "availability": {
+    "6.0": false,
+    "7.0": false,
+    "9.0": true
+  }
 }

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/softbond.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/softbond.json
@@ -151,8 +151,7 @@
           "default": "0",
           "modifiable": true,
           "inheritable": false,
-          "notes": "",
-          "since": "9.0"
+          "notes": ""
         }
       ]
     },
@@ -367,8 +366,7 @@
           "default": "0",
           "modifiable": true,
           "inheritable": false,
-          "notes": "",
-          "since": "9.0"
+          "notes": ""
         },
         {
           "keyword": "sb_fa",
@@ -379,8 +377,7 @@
           "default": "0",
           "modifiable": true,
           "inheritable": false,
-          "notes": "",
-          "since": "9.0"
+          "notes": ""
         },
         {
           "keyword": "sb_mcf",
@@ -391,15 +388,15 @@
           "default": "",
           "modifiable": false,
           "inheritable": false,
-          "notes": "This is a read-only property.",
-          "since": "9.0"
+          "notes": "This is a read-only property."
         }
       ]
     }
   ],
   "notes": [
     "Softening response is controlled by sb_soft and sb_cut.",
-    "sb_mode switches absolute (0) vs incremental (1) normal-force update."
+    "sb_mode switches absolute (0) vs incremental (1) normal-force update.",
+    "Full 32-property set live-verified identical on PFC3D 6.00, 7.00 and 9.7."
   ],
   "source": "PFC 7.0 documentation",
   "availability": {

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalnull.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalnull.json
@@ -8,7 +8,7 @@
     "thermal",
     "thermalnull"
   ],
-  "description": "STALE NAME on live 9.7 AND 7.0 (both enumerate null|thermalpipe): the thermal CMAT model-name slot enumerates 'null' and 'thermalpipe' only - the default thermal model is assigned as 'contact cmat thermal default model null', NOT 'thermalnull'. The null thermal contact model is the default thermal contact model. No power is generated.",
+  "description": "STALE NAME on live 9.7, 7.0 AND 6.0 (all three enumerate null|thermalpipe): the thermal CMAT model-name slot enumerates 'null' and 'thermalpipe' only - the default thermal model is assigned as 'contact cmat thermal default model null', NOT 'thermalnull'. The null thermal contact model is the default thermal contact model. No power is generated.",
   "typical_applications": [
     "Disabling thermal conduction at selected contacts",
     "Excluding a contact type from heat transfer"

--- a/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalpipe.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/references/contact-models/thermalpipe.json
@@ -42,7 +42,8 @@
   ],
   "notes": [
     "Thermal option model. Properties documented under the PFC thermal option manual.",
-    "Assignment grammar (live 9.7): the thermal CMAT uses a process selector - 'contact cmat thermal default model thermalpipe'. Requires 'model configure thermal'. The thermal model-name slot enumerates exactly: null thermalpipe."
+    "Assignment grammar (live 6.0/7.0/9.7): the thermal CMAT uses a process selector - 'contact cmat thermal default model thermalpipe'. Requires 'model configure thermal'. The thermal model-name slot enumerates exactly: null thermalpipe; the thermalpipe property slot enumerates exactly: temperature thexp thres.",
+    "Thermal contacts are invisible to Python itasca.contact.list() (only the mechanical contact is returned) - verified on 6.0 and 9.7."
   ],
   "source": "PFC 7.0 documentation",
   "availability": {


### PR DESCRIPTION
## Summary

Batch P4 closes the last unverified version axis for the PFC contact-models reference family: a live PFC3D 6.00 pass (local install, same real-contact-instance methodology as Batch P3 / the 7.0 addendum in #104).

Live 6.0 mechanical enumeration = **14 models**: arrlinear beam burger flatjoint hertz hill hysteretic linear linearcbond linearpbond null rrlinear smoothjoint softbond.

## Corrections

- **beam / hill exist on 6.0** with property sets identical to 7.0/9.7 (previous "7.0+9.0, 6.0 unverified" marking corrected in files + index).
- **softbond: four bogus `since: 9.0` markers removed** (rgap / sb_coh / sb_fa / sb_mcf) - all four are live on 6.0/7.0/9.7.
- **flatjoint `since: 7.0` markers confirmed**: fj_cohres / fj_resmode genuinely absent on live 6.0; remaining 29 properties exact.
- burger `bur_fric` confirmed as the live spelling on all versions ('fric' stale everywhere); thermalnull stale-name and thermal-slot facts (null|thermalpipe, temperature/thexp/thres) extended to 6.0.
- rrhertz / bisubspringnetwork gain file-level availability blocks (9.x-only, matching the index).
- Index records the live 6.0 model list plus 6.0 caveats: contact detection is `model clean` only (bare `clean` is 7.0+), the cmat property-slot union trap holds on 6.0 (~160 keywords), and thermal contacts are invisible to Python `itasca.contact.list()` on 6.0 too.

All other 6.0 property sets matched the corpus exactly (12/14 exact; the 2 diffs above are annotated stale/since entries).

Evidence: `pfcP4_props_raw60.json` + probe script `pfcP4_props60.py` in the engine workspace; demo-mode cycling verified OK.

## Testing

- `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` - 11 passed
- All contact-model JSONs re-validated (parse + availability/props re-diff against the live dump came back clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
