### PR TITLE
chore: gitignore mcp-publisher token files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ build/
 .claude/
 .codex/
 
+# mcp-publisher login state (credentials; recreated by `mcp-publisher login`)
+.mcpregistry_*
+
 # Local runtime/temp artifacts
 .pfc-mcp-bridge/
 .tmp/


### PR DESCRIPTION
mcp-publisher writes its login state (`.mcpregistry_github_token` / `.mcpregistry_registry_token`) into the working directory during `mcp-publisher login` / `publish`. These are credentials — ignore them so they can never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)