### PR TITLE
fix: disable proxy env vars for bridge client (trust_env=False)

### DIFF
--- a/src/itasca_mcp/bridge/client.py
+++ b/src/itasca_mcp/bridge/client.py
@@ -48,7 +48,11 @@ class ItascaBridgeClient:
                 return
             # Per-request timeouts are set on each POST; the SSE stream uses an
             # unbounded read timeout because it stays open between doorbells.
-            self._client = httpx.AsyncClient(base_url=self.url)
+            # trust_env=False: the bridge is reached directly (localhost by
+            # default). With proxy env vars set (HTTP_PROXY etc., common with
+            # Clash-style setups), httpx would otherwise route even localhost
+            # requests through the proxy, surfacing as bridge_unavailable.
+            self._client = httpx.AsyncClient(base_url=self.url, trust_env=False)
             self._sse_task = asyncio.create_task(self._sse_loop())
             logger.info("Connected to itasca-mcp-bridge at %s", self.url)
 


### PR DESCRIPTION
With `HTTP_PROXY`/`HTTPS_PROXY` set in the environment (common with Clash-style terminal proxy setups), httpx routed even `localhost:9001` bridge requests through the proxy. The failure then surfaced as a misleading `bridge_unavailable` error ("start the bridge in the GUI") while the bridge was actually running — so affected users had no way to diagnose or report it.

The bridge is always reached directly (localhost by default), so the client should never consult proxy environment variables. `trust_env=False` cuts exactly that: `ITASCA_MCP_*` config variables are unaffected.

Empirically verified: with `HTTP_PROXY` pointing at a dead address, a plain `httpx.get('http://localhost:...')` fails with ConnectError; with `trust_env=False` it succeeds. 194 tests pass.

Diagnosed downstream by @molt213 in [itasca-mcp-pfc5.00](https://github.com/molt213/itasca-mcp-pfc5.00), the community PFC 5.0 port — thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)