### PR TITLE
release: 0.6.9 — bridge client immune to proxy env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ section exists.
 
 ## [Unreleased]
 
+## [0.6.9] - 2026-08-19
+
+### Fixed
+
+- **Bridge requests are no longer hijacked by proxy environment
+  variables.** With `HTTP_PROXY`/`HTTPS_PROXY` set (common with
+  Clash-style terminal-proxy setups), httpx routed even
+  `localhost:9001` bridge requests through the proxy, and the failure
+  surfaced as a misleading `bridge_unavailable` ("start the bridge in
+  the GUI") while the bridge was actually running. The bridge client
+  now passes `trust_env=False`: the bridge is always reached directly,
+  so proxy variables are never consulted. `ITASCA_MCP_*` configuration
+  variables are unaffected. Diagnosed downstream by @molt213 in
+  [itasca-mcp-pfc5.00](https://github.com/molt213/itasca-mcp-pfc5.00),
+  the community PFC 5.0 port — thank you! (#113)
+
 ## [0.6.8] - 2026-08-18
 
 PFC documentation-corpus release: the entire bundled PFC corpus — all 165

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/yusong652/itasca-mcp",
     "source": "github"
   },
-  "version": "0.6.8",
+  "version": "0.6.9",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "itasca-mcp",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "transport": {
         "type": "stdio"
       }

--- a/src/itasca_mcp/__init__.py
+++ b/src/itasca_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Itasca MCP Server - ITASCA simulation tools (PFC, FLAC, 3DEC, MPoint, MassFlow) via MCP."""
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"


### PR DESCRIPTION
Version bump (`__init__.py`, `server.json` ×2) and changelog for the `trust_env=False` fix (#113).

After merge: tag `v0.6.9` on main triggers the publish workflow (PyPI + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)