### PR TITLE
docs: 3DEC 7.0 tail closure — model configure, structure props, density state-verify

### DIFF
--- a/scripts/corpus/generate_3dec_index.py
+++ b/scripts/corpus/generate_3dec_index.py
@@ -126,6 +126,47 @@ def borrow_common_categories() -> dict[str, dict[str, Any]]:
     return out
 
 
+def merge_local_shared_overrides(categories: dict[str, Any]) -> list[str]:
+    """Merge 3DEC-local files that live in a borrowed (shared) category.
+
+    Some shared-kernel commands need a 3DEC-scoped doc because the engine's
+    keyword set diverges from the FLAC/_common one (e.g. ``model configure``:
+    no cfd/axisymmetry, 7.0 classic ``fluid``). Those files live under
+    ``commands/<shared-category>/`` next to the proprietary families; this
+    scans every non-proprietary directory and inserts/overrides the matching
+    command entries so a rerun never drops them.
+    """
+    merged: list[str] = []
+    for cat_dir in sorted(COMMANDS_DIR.iterdir()):
+        if not cat_dir.is_dir() or cat_dir.name in PROPRIETARY:
+            continue
+        category = cat_dir.name
+        if category not in categories:
+            continue
+        commands = categories[category]["commands"]
+        by_name = {c["name"]: i for i, c in enumerate(commands)}
+        for cmd_path in sorted(cat_dir.glob("*.json")):
+            data = _resolve_versioned(json.loads(cmd_path.read_text(encoding="utf-8")))
+            description = data.get("description", "")
+            short = description.split(".")[0] if description else ""
+            if len(short) > 100:
+                short = short[:97] + "..."
+            entry = {
+                "name": cmd_path.stem,
+                "file": f"3dec/command_docs/commands/{category}/{cmd_path.name}",
+                "short_description": short,
+                "syntax": data.get("syntax", ""),
+                "python_available": data.get("python_sdk_alternative", {}).get("available", False),
+            }
+            if cmd_path.stem in by_name:
+                commands[by_name[cmd_path.stem]] = entry
+            else:
+                commands.append(entry)
+                commands.sort(key=lambda c: c["name"])
+            merged.append(f"{category}/{cmd_path.stem}")
+    return merged
+
+
 def main() -> None:
     categories: dict[str, Any] = {}
     for category in PROPRIETARY:
@@ -133,6 +174,7 @@ def main() -> None:
     common = borrow_common_categories()
     for name, meta in common.items():
         categories[name] = meta
+    merged = merge_local_shared_overrides(categories)
 
     index = {
         "version": "1.0",
@@ -146,6 +188,7 @@ def main() -> None:
     print(f"  categories: {len(categories)}  total commands: {total}")
     print("  proprietary:", {c: len(categories[c]["commands"]) for c in PROPRIETARY})
     print("  reused _common:", {n: len(categories[n]["commands"]) for n in common})
+    print("  local shared overrides:", merged)
 
 
 if __name__ == "__main__":

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/model/configure.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/commands/model/configure.json
@@ -1,0 +1,179 @@
+{
+  "category": "model",
+  "search_keywords": [
+    "model",
+    "configure",
+    "config",
+    "thermal",
+    "fluid",
+    "matrixflow",
+    "feblock",
+    "dynamic",
+    "creep"
+  ],
+  "description": "Configure optional 3DEC analysis modules. Several block-family commands are gated behind a configure option (block thermal / block zone thermal <- thermal; block zone fluid <- matrixflow; flowknot/flowplane <- fluid (7.0) / fluid-flow (9.x); feblock <- feblock). 3DEC-scoped file: the keyword set differs from FLAC's (no cfd/axisymmetry) and between 3DEC versions (7.0 classic 'fluid' + 'plugins'; 9.x fluid-flow/fluid-explicit/fluid-implicit).",
+  "python_sdk_alternative": {
+    "available": false
+  },
+  "versions": {
+    "9.0": {
+      "command": "model configure",
+      "syntax": "model configure keyword ...",
+      "keywords": [
+        {
+          "name": "array",
+          "syntax": "array",
+          "description": "Configure the array process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "cluster",
+          "syntax": "cluster",
+          "description": "Configure the cluster process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "creep",
+          "syntax": "creep",
+          "description": "Creep material analysis*"
+        },
+        {
+          "name": "dynamic",
+          "syntax": "dynamic",
+          "description": "Fully dynamic analysis*"
+        },
+        {
+          "name": "energy",
+          "syntax": "energy",
+          "description": "Configure the energy process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "feblock",
+          "syntax": "feblock",
+          "description": "Enable finite-element blocks (also unlocks feblock gravity)."
+        },
+        {
+          "name": "fluid-explicit",
+          "syntax": "fluid-explicit",
+          "description": "Configure the fluid-explicit process/module. Present in the engine's keyword enumeration but missing from the crawled docs. Verified against FLAC3D 9.7 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "fluid-flow",
+          "syntax": "fluid-flow",
+          "description": "Enable groundwater fluid-flow analysis. This replaces the 9.0 fluid keyword in 9.1 and later."
+        },
+        {
+          "name": "fluid-implicit",
+          "syntax": "fluid-implicit",
+          "description": "Configure the fluid-implicit process/module. Present in the engine's keyword enumeration but missing from the crawled docs. Verified against FLAC3D 9.7 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "highorder",
+          "syntax": "highorder",
+          "description": "High-order zone formulation (also accepted by feblock gravity's gate)."
+        },
+        {
+          "name": "hotetra",
+          "syntax": "hotetra",
+          "description": "High-order tetrahedra."
+        },
+        {
+          "name": "imass",
+          "syntax": "imass",
+          "description": "The Itasca Model for Advanced Strain Softening*"
+        },
+        {
+          "name": "matrixflow",
+          "syntax": "matrixflow",
+          "description": "Zone matrix fluid flow; gate for 'block zone fluid property'."
+        },
+        {
+          "name": "mechanical",
+          "syntax": "mechanical",
+          "description": "Configure the mechanical process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "thermal",
+          "syntax": "thermal",
+          "description": "Thermal analysis; gate for 'block thermal' and 'block zone thermal property'."
+        }
+      ],
+      "examples": []
+    },
+    "7.0": {
+      "command": "model configure",
+      "syntax": "model configure keyword ...",
+      "keywords": [
+        {
+          "name": "array",
+          "syntax": "array",
+          "description": "Configure the array process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "cluster",
+          "syntax": "cluster",
+          "description": "Configure the cluster process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "creep",
+          "syntax": "creep",
+          "description": "Creep material analysis*"
+        },
+        {
+          "name": "dynamic",
+          "syntax": "dynamic",
+          "description": "Fully dynamic analysis*"
+        },
+        {
+          "name": "energy",
+          "syntax": "energy",
+          "description": "Configure the energy process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "feblock",
+          "syntax": "feblock",
+          "description": "Enable finite-element blocks (also unlocks feblock gravity)."
+        },
+        {
+          "name": "fluid",
+          "syntax": "fluid",
+          "description": "Classic joint fluid flow (CONFIG GW) — creates flow planes/knots at zoning. 3DEC 7.0 spelling; 9.x split this into fluid-flow / fluid-explicit / fluid-implicit."
+        },
+        {
+          "name": "highorder",
+          "syntax": "highorder",
+          "description": "High-order zone formulation (also accepted by feblock gravity's gate)."
+        },
+        {
+          "name": "hotetra",
+          "syntax": "hotetra",
+          "description": "High-order tetrahedra."
+        },
+        {
+          "name": "imass",
+          "syntax": "imass",
+          "description": "The Itasca Model for Advanced Strain Softening*"
+        },
+        {
+          "name": "matrixflow",
+          "syntax": "matrixflow",
+          "description": "Zone matrix fluid flow; gate for 'block zone fluid property'."
+        },
+        {
+          "name": "mechanical",
+          "syntax": "mechanical",
+          "description": "Configure the mechanical process/module. Verified live against FLAC3D 7.0 (first-token enumeration, 2026-08-13)."
+        },
+        {
+          "name": "plugins",
+          "syntax": "plugins",
+          "description": "C++ user-defined models and/or FISH intrinsic plugins.* FISH plugins can be loaded (but cycling is disabled) without this configuration."
+        },
+        {
+          "name": "thermal",
+          "syntax": "thermal",
+          "description": "Thermal analysis; gate for 'block thermal' and 'block zone thermal property'."
+        }
+      ],
+      "examples": []
+    }
+  }
+}

--- a/src/itasca_mcp/knowledge/resources/3dec/command_docs/index.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/command_docs/index.json
@@ -2011,6 +2011,13 @@
           "python_alternative": "itasca.command('model clean') or itasca.command('model clean all') - Python SDK does not provide direct clean method"
         },
         {
+          "name": "configure",
+          "file": "3dec/command_docs/commands/model/configure.json",
+          "short_description": "Configure optional 3DEC analysis modules",
+          "syntax": "model configure keyword ...",
+          "python_available": false
+        },
+        {
           "name": "creep",
           "file": "_common/command_docs/commands/model/creep.json",
           "short_description": "Set parameters for a creep material analysis",

--- a/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/geogrid.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/geogrid.json
@@ -53,10 +53,64 @@
           "keyword": "slide-tolerance",
           "description": "large-strain sliding tolerance",
           "type": "FLT"
+        },
+        {
+          "keyword": "anisotropic-bending",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "anisotropic-membrane",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "isotropic",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "material-x",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "orthotropic-bending",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "orthotropic-membrane",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
         }
       ]
     }
   ],
   "source": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/geogrids/commands/cmd_structure.geogrid.property.html",
-  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): 8-keyword live set is an exact match."
+  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): 8-keyword live set is an exact match. 3DEC 7.00 Release 161 (2026-08-21): full property enumeration captured with elements present (14 keywords + range); per-keyword availability marked where the 7.0 and 9.7 sets diverge."
 }

--- a/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/index.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/index.json
@@ -63,6 +63,6 @@
     "Live-verified 2026-08-14 against 3DEC 9.7.47: all six documented type property sets enumerated with elements present (beam 17 / cable 15 / pile 35 / shell 3 / liner 18 / geogrid 8, excluding range).",
     "structure dowel has NO 'property' subcommand on live 3DEC 9.7 ('Unused extra parameter (property)'); dowel parameters are set at creation / via its own keywords.",
     "structure hybrid 'property' enumerates only 'range' without hybrid elements present - untested with elements (syntax-grade only).",
-    "3DEC 7.00 Release 161 (2026-08-21): beam/cable stamped on 7.0 (see files); 7.0-only legacy SEL elements added as sel-hybrid / sel-reinforcement. geogrid/liner/pile/shell exist in 7.0 as structure classes but their 7.0 property enumerations were not probed with elements (deferred)."
+    "3DEC 7.00 Release 161 (2026-08-21): ALL structure element types stamped on 7.0 with elements present (beam/cable/pile/shell/geogrid/liner). Version pattern: 7.0 uses moi-polar (beam/pile), 9.x renamed it torsion-constant; the plastic-shear family and shear-coefficient-y/z are 9.x-only; shell-type elastic material models are property keywords in 7.0 (isotropic/orthotropic-*/anisotropic-*/material-x) but cmodel-based in 9.x. 7.0 face-based creation uses by-block-face (no by-face)."
   ]
 }

--- a/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/liner.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/liner.json
@@ -103,10 +103,64 @@
           "keyword": "slide-tolerance",
           "description": "large-strain sliding tolerance",
           "type": "FLT"
+        },
+        {
+          "keyword": "anisotropic-bending",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "anisotropic-membrane",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "isotropic",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "material-x",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "orthotropic-bending",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "orthotropic-membrane",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
         }
       ]
     }
   ],
   "source": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/liners/commands/cmd_structure.liner.property.html",
-  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): 18-keyword live set is an exact match - including the 3DEC-specific two-sided coupling '-2' variants (side 2), which pair with the Python Liner per-side setters (set_normal_stiffness(f1,f2), ...)."
+  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): 18-keyword live set is an exact match - including the 3DEC-specific two-sided coupling '-2' variants (side 2), which pair with the Python Liner per-side setters (set_normal_stiffness(f1,f2), ...). 3DEC 7.00 Release 161 (2026-08-21): full property enumeration captured with elements present (24 keywords + range); per-keyword availability marked where the 7.0 and 9.7 sets diverge."
 }

--- a/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/pile.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/pile.json
@@ -56,33 +56,57 @@
         },
         {
           "keyword": "plastic-shear",
-          "description": "plastic shear capacity in Y and Z",
-          "type": "FLT"
+          "description": "plastic shear capacity in Y and Z [9.x-only: absent from the live 3DEC 7.00 'structure pile property' enumeration.]",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": true
+          }
         },
         {
           "keyword": "plastic-shear-y",
-          "description": "plastic shear capacity in Y",
-          "type": "FLT"
+          "description": "plastic shear capacity in Y [9.x-only: absent from the live 3DEC 7.00 'structure pile property' enumeration.]",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": true
+          }
         },
         {
           "keyword": "plastic-shear-z",
-          "description": "plastic shear capacity in Z",
-          "type": "FLT"
+          "description": "plastic shear capacity in Z [9.x-only: absent from the live 3DEC 7.00 'structure pile property' enumeration.]",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": true
+          }
         },
         {
           "keyword": "shear-coefficient-y",
-          "description": "shear coefficient for transverse shear deformation in the \\(y\\) -direction (Timoshenko beam only)",
-          "type": "FLT"
+          "description": "shear coefficient for transverse shear deformation in the \\(y\\) -direction (Timoshenko beam only) [9.x-only: absent from the live 3DEC 7.00 'structure pile property' enumeration.]",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": true
+          }
         },
         {
           "keyword": "shear-coefficient-z",
-          "description": "shear coefficient for transverse shear deformation in the \\(z\\) -direction (Timoshenko beam only)",
-          "type": "FLT"
+          "description": "shear coefficient for transverse shear deformation in the \\(z\\) -direction (Timoshenko beam only) [9.x-only: absent from the live 3DEC 7.00 'structure pile property' enumeration.]",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": true
+          }
         },
         {
           "keyword": "spacing",
-          "description": "spacing ( 2D only)",
-          "type": "FLT"
+          "description": "spacing (2D only). NOT enumerated by live 3DEC 9.7.47 nor by live 3DEC 7.00 'structure pile property' (with elements present) - likely FLAC2D-only spacing logic; treat as unavailable in 3DEC on both versions.",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": false
+          }
         },
         {
           "keyword": "thermal-expansion",
@@ -91,8 +115,12 @@
         },
         {
           "keyword": "torsion-constant",
-          "description": "torsion constant",
-          "type": "FLT"
+          "description": "torsion constant [9.x-only: absent from the live 3DEC 7.00 'structure pile property' enumeration.]",
+          "type": "FLT",
+          "availability": {
+            "7.0": false,
+            "9.0": true
+          }
         },
         {
           "keyword": "coupling-cohesion-normal",
@@ -193,10 +221,20 @@
           "keyword": "poisson",
           "description": "Poisson's ratio. Live-enumerated by 3DEC 9.7.47; was missing from this file.",
           "type": "FLT"
+        },
+        {
+          "keyword": "moi-polar",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "polar moment of inertia. 7.0-only spelling: 9.x renamed this slot to torsion-constant.",
+          "symbol": "J"
         }
       ]
     }
   ],
   "source": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/piles/commands/cmd_structure.pile.property.html",
-  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): documented set confirmed except 'spacing' (not enumerated by 3DEC 9.7 - flagged); young/poisson added (35-keyword live set)."
+  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): documented set confirmed except 'spacing' (not enumerated by 3DEC 9.7 - flagged); young/poisson added (35-keyword live set). 3DEC 7.00 Release 161 (2026-08-21): full property enumeration captured with elements present (30 keywords + range); per-keyword availability marked where the 7.0 and 9.7 sets diverge."
 }

--- a/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/shell.json
+++ b/src/itasca_mcp/knowledge/resources/3dec/references/structural-properties/shell.json
@@ -28,10 +28,64 @@
           "keyword": "thickness",
           "description": "thickness",
           "type": "FLT"
+        },
+        {
+          "keyword": "anisotropic-bending",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "anisotropic-membrane",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "isotropic",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "material-x",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "orthotropic-bending",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
+        },
+        {
+          "keyword": "orthotropic-membrane",
+          "type": "FLT",
+          "availability": {
+            "7.0": true,
+            "9.0": false
+          },
+          "description": "7.0-only as a property keyword: in 3DEC 7.0 the elastic material model of shell-type elements is set via 'structure <type> property' (isotropic/orthotropic-*/anisotropic-*/material-x); 9.x moved this to 'structure <type> cmodel'."
         }
       ]
     }
   ],
   "source": "https://docs.itascacg.com/itasca900/common/sel/doc/manual/sel_manual/shells/commands/cmd_structure.shell.property.html",
-  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): 3-keyword live set (density/thermal-expansion/thickness) is an exact match - structural stiffness/strength for shells comes from the structure shell cmodel mechanism, as in FLAC3D."
+  "verification": "Live-verified 2026-08-14 against 3DEC 9.7.47 (enumeration with elements): 3-keyword live set (density/thermal-expansion/thickness) is an exact match - structural stiffness/strength for shells comes from the structure shell cmodel mechanism, as in FLAC3D. 3DEC 7.00 Release 161 (2026-08-21): full property enumeration captured with elements present (9 keywords + range); per-keyword availability marked where the 7.0 and 9.7 sets diverge."
 }

--- a/tests/test_multi_engine_software.py
+++ b/tests/test_multi_engine_software.py
@@ -747,6 +747,23 @@ async def test_3dec_sel_sdk_units_resolve() -> None:
         assert payload["ok"] is True, (api, payload)
 
 
+def test_3dec_model_configure_is_engine_scoped() -> None:
+    # 3DEC-local override in the borrowed model category: the configure keyword
+    # set differs from FLAC's (no cfd/axisymmetry) and between 3DEC versions
+    # (7.0 classic 'fluid' + plugins; 9.x fluid-flow/fluid-explicit/implicit).
+    doc70 = CommandLoader.load_command_doc("model", "configure", "7.0", software="3dec")
+    assert doc70 is not None
+    kw70 = {k["name"] for k in doc70["keywords"]}
+    assert "fluid" in kw70 and "plugins" in kw70
+    assert "fluid-flow" not in kw70 and "cfd" not in kw70
+
+    doc90 = CommandLoader.load_command_doc("model", "configure", "9.0", software="3dec")
+    assert doc90 is not None
+    kw90 = {k["name"] for k in doc90["keywords"]}
+    assert {"fluid-flow", "fluid-explicit", "fluid-implicit"} <= kw90
+    assert "fluid" not in kw90 and "axisymmetry" not in kw90
+
+
 @pytest.mark.asyncio
 async def test_3dec_joint_models_version_gated() -> None:
     # 7.0 has seven jmodels; ratestate / velocity-weakening are 9.x-only.


### PR DESCRIPTION
## Summary

Final batch of the 3DEC 7.0 campaign — closes every remaining checklist item (itasca-doc/3dec70.md now has zero open items).

- **`model configure` gap closed**: the 3dec corpus had no `model configure` doc at all (it lives in `flac/`, outside the `_common` borrow rule) despite being the gate for thermal/matrixflow/fluid/feblock. Authored a 3DEC-scoped file with live-verified sets — 7.0 (classic `fluid` + `plugins`) vs 9.0 (`fluid-flow`/`-explicit`/`-implicit`); `generate_3dec_index.py` now merges local overrides in borrowed categories.
- **structural-properties completed**: pile/shell/geogrid/liner stamped on 7.0 with elements. pile mirrors the `moi-polar`↔`torsion-constant` rename; shell/geogrid/liner gain six 7.0-only elastic-material property keywords (`isotropic`/`orthotropic-*`/`anisotropic-*`/`material-x`) that 9.x moved to `structure <type> cmodel`; pile `spacing` corrected to unavailable-in-both.
- **density/cmodel ordering state-verified**: zone density assignment before `cmodel assign` is a silent no-op (reads back 0.0); `block property density` never feeds zone density.
- **`_common` itasca core roster**: 49/49 exact vs 3DEC 7.0 `dir(itasca)` — no `_common` edits needed.

## Test plan
- [x] `uv run pytest tests/` — 203 passed (new: 3dec model configure version split)
- [x] ruff check/format scoped, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2r3WnPx1V9HyuKKZteStp