### PR TITLE
docs: README mentions 3DEC 7.0 in supported engines and version list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,9 @@ Steps to release `itasca-mcp`:
 
 1. Bump `__version__` in `src/itasca_mcp/__init__.py` (the single source of truth).
 2. Curate `## [Unreleased]` in `CHANGELOG.md` from `git log` since the previous release (grouped per the convention comment at the top of that file), rename it to `## [x.y.z] - YYYY-MM-DD`, then start a fresh empty `## [Unreleased]`. The publish workflow extracts the section whose header matches the tag version exactly and fails if it is missing.
-3. Commit and push to `main`.
-4. Tag the commit: `git tag v0.x.x` and `git push origin v0.x.x`.
+3. **Sweep user-facing docs for claims the release invalidates** — `README.md` (supported engines/versions matrix, feature bullets, install flow) and `addon.py` messages. README is the PyPI long_description: anything stale at tag time is frozen into that PyPI release page and can only be fixed by the *next* release, so this check must happen BEFORE tagging, in the same release PR.
+4. Commit and push to `main`.
+5. Tag the commit: `git tag v0.x.x` and `git push origin v0.x.x`.
 
 **Important**: tag version must match `__version__`. PyPI rejects duplicate version uploads.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ### Prerequisites
 
-- **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow. 9.0+ recommended; PFC 6.0 / 7.0 and FLAC 7.0 are also supported.
+- **An ITASCA engine installed** — PFC, FLAC, 3DEC, MPoint, or MassFlow. 9.0+ recommended; PFC 6.0 / 7.0, FLAC 7.0, and 3DEC 7.0 are also supported.
 - **[uv](https://docs.astral.sh/uv/getting-started/installation/)** installed (for `uvx`)
 - **An AI agent** — Claude Code, Codex CLI, Gemini CLI, or any MCP-capable client
 
@@ -100,7 +100,7 @@ itasca_mcp_bridge.start()
 ## Features
 
 - **Multi-engine corpus** - command, Python API, and reference docs for PFC, FLAC, 3DEC, MPoint, and MassFlow, selected via the required `software` parameter
-- **Multi-version support** - command docs across engine versions (PFC: 6.0/7.0/9.0, FLAC: 7.0/9.0) via the `version` parameter
+- **Multi-version support** - command docs across engine versions (PFC: 6.0/7.0/9.0, FLAC: 7.0/9.0, 3DEC: 7.0/9.0) via the `version` parameter
 - **Hierarchical documentation browsing** - agents navigate the engine command tree to discover capabilities and boundaries, reducing hallucinated commands
 - **Enhanced plot documentation** - plot items reference docs supplementing the official documentation
 - **Live REPL alongside running tasks** - execute code while a simulation is running: check model state and intermediate results without stopping the task; also useful for quick iteration before writing a full script


### PR DESCRIPTION
Two stale lines after the 0.7.0 release: the prerequisites bullet and the multi-version feature bullet now include 3DEC 7.0 (3DEC: 7.0/9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2r3WnPx1V9HyuKKZteStp