### PR TITLE
docs: state geomechanics domain in intro and add example prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 `itasca>model new ;now, with LLM.`
 
-**itasca-mcp** connects AI agents to [ITASCA](https://www.itascacg.com/)'s numerical modeling software — PFC, FLAC, 3DEC, MPoint, and MassFlow — through the [Model Context Protocol](https://modelcontextprotocol.io/). Browse documentation, run simulations, and execute code, all through natural conversation.
+**itasca-mcp** connects AI agents to [ITASCA](https://www.itascacg.com/)'s geomechanics simulation software — PFC, FLAC, 3DEC, MPoint, and MassFlow — through the [Model Context Protocol](https://modelcontextprotocol.io/). Browse documentation, run simulations, and execute code, all through natural conversation.
 
 `itasca>model solve ;LLM solves.`
 
@@ -25,6 +25,15 @@
 **5 documentation tools** — browse and search the selected engine's commands, Python API, and reference docs. No bridge required.
 
 **5 execution tools** — interactive REPL, task submission, progress monitoring, interruption, and history. Requires bridge.
+
+## Example Prompts
+
+- *"Run a biaxial compression test on a dense specimen and plot the stress–strain curve"*
+- *"Build a slope model in FLAC3D and find the factor of safety"*
+- *"Model a tunnel excavation in jointed rock with 3DEC and check block displacements around the opening"*
+- *"Simulate a landslide runout with MPoint and report the final deposit profile"*
+- *"The simulation is still running — check the current unbalanced force without stopping it"*
+- *"What's different about the `zone` commands between FLAC 7.0 and 9.0?"*
 
 ## First-time Setup
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 `itasca>model new ;now, with LLM.`
 
-**itasca-mcp** 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 将 AI 智能体连接到 [ITASCA](https://www.itascacg.com/) 的数值模拟软件 —— PFC、FLAC、3DEC、MPoint、MassFlow。通过自然语言对话即可浏览文档、运行仿真和执行代码。
+**itasca-mcp** 通过 [Model Context Protocol](https://modelcontextprotocol.io/) 将 AI 智能体连接到 [ITASCA](https://www.itascacg.com/) 的地质力学数值模拟软件 —— PFC、FLAC、3DEC、MPoint、MassFlow。通过自然语言对话即可浏览文档、运行仿真和执行代码。
 
 `itasca>model solve ;LLM solves.`
 
@@ -25,6 +25,15 @@
 **5 个文档工具** — 浏览和搜索所选引擎的命令、Python API 及参考文档。无需 bridge。
 
 **5 个执行工具** — 交互式 REPL、任务提交、进度监控、中断和历史浏览。需要 bridge。
+
+## 示例提示词
+
+- *「做一组密实试样的双轴压缩试验，绘制应力–应变曲线」*
+- *「用 FLAC3D 建一个边坡模型，求安全系数」*
+- *「用 3DEC 模拟节理岩体中的隧道开挖，查看洞周块体位移」*
+- *「用 MPoint 模拟滑坡运动全过程，输出最终堆积形态」*
+- *「模拟还在跑——不要中断任务，查一下当前的不平衡力」*
+- *「FLAC 7.0 和 9.0 的 `zone` 命令有什么区别？」*
 
 ## 首次启动配置
 


### PR DESCRIPTION
## Why

Searches like "geotech mcp" / "geomechanics mcp" on GitHub and the web did not surface this project — the README (both languages) never named the domain the tools serve.

## What

- Intro: describe the engines as ITASCA's **geomechanics simulation software** — the vendor's own umbrella term, covering geotechnical, mining, tunneling, petroleum, and hydrogeology applications without mislabeling any of them
- New **Example Prompts** section (EN + zh-CN): six prompts spanning four engines (PFC biaxial test, FLAC slope stability, 3DEC tunnel in jointed rock, MPoint landslide runout) plus two signature workflows (live REPL query during a running task, cross-version command docs)

Domain vocabulary now appears where it is load-bearing — describing what the tool actually does — rather than as keyword filler. Complements the repo description/topics update done directly on the repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wkswRF43FFHtaDsTWAqdn