### PR TITLE
docs: mark program call as verified-blocking on engine 9.0

### DIFF
--- a/src/itasca_mcp/tools/execute_code.py
+++ b/src/itasca_mcp/tools/execute_code.py
@@ -58,9 +58,9 @@ def register(mcp: FastMCP) -> None:
           interactive FISH mode until completed manually in the GUI
           console. Per-line loops are fine for ordinary commands.
         - `program call '<file>.p3dat'` (or .p2dat / .dat) keeps the
-          bridge responsive only on engine 9.7+; on 6/7 and unverified
-          versions (including 9.0-9.6) it blocks the bridge for the
-          script's entire duration, so never emit it there. Even on
+          bridge responsive only on engine 9.7+; on 6/7/9.0 (all
+          verified) and unverified 9.1-9.6 it blocks the bridge for
+          the script's entire duration, so never emit it there. Even on
           9.7+, prefer translating the file's commands into
           itasca.command(...) calls — that keeps per-command output,
           error locality, and mid-script control.

--- a/src/itasca_mcp/tools/execute_task.py
+++ b/src/itasca_mcp/tools/execute_task.py
@@ -54,9 +54,9 @@ def register(mcp: FastMCP) -> None:
           interactive FISH mode until completed manually in the GUI
           console. Per-line loops are fine for ordinary commands.
         - `program call '<file>.p3dat'` (or .p2dat / .dat) keeps the
-          bridge responsive only on engine 9.7+; on 6/7 and unverified
-          versions (including 9.0-9.6) it blocks the bridge for the
-          script's entire duration, so never emit it there. Even on
+          bridge responsive only on engine 9.7+; on 6/7/9.0 (all
+          verified) and unverified 9.1-9.6 it blocks the bridge for
+          the script's entire duration, so never emit it there. Even on
           9.7+, prefer translating the file's commands into
           itasca.command(...) calls — that keeps per-command output,
           error locality, and mid-script control.


### PR DESCRIPTION
## Summary

Live verification on 3DEC 9.0 (demo mode) closes the `9.0` gap in the `program call` guidance of both execution tool docstrings.

Test: a 200k-cycle `.dat` (390-zone elastic block model, ~112 s) issued via `itasca.command("program call ...")` from an `itasca_execute_task` script.

- **During the call**: the bridge is fully wedged — both `itasca_execute_code` and `itasca_check_task_status` time out with `bridge_unavailable`, same as engines 6/7.
- **After the call returns**: the bridge recovers on its own; the task completes with the full console log captured. No GUI Stop or restart needed for a finite data file.

Docstring version matrix is now: 6/7/9.0 verified blocking, 9.1–9.6 unverified (assumed blocking), 9.7+ verified responsive.

## Testing

- `uv run pytest tests/test_phase2_tools.py tests/test_tool_contracts.py` — 11 passed
- `uv run ruff format` / `ruff check` clean on the two touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbNMG3ACU4eGvyhZLLYnaX
