### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [English](https://github.com/yusong652/itasca-mcp/blob/main/README.md) | [简体中文](https://github.com/yusong652/itasca-mcp/blob/main/README.zh-CN.md)
 
+[![CI](https://github.com/yusong652/itasca-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/yusong652/itasca-mcp/actions/workflows/test.yml)
 [![PyPI](https://img.shields.io/pypi/v/itasca-mcp)](https://pypi.org/project/itasca-mcp/)
 [![Downloads](https://static.pepy.tech/badge/itasca-mcp)](https://pepy.tech/project/itasca-mcp)
 [![GitHub stars](https://img.shields.io/github/stars/yusong652/itasca-mcp)](https://github.com/yusong652/itasca-mcp/stargazers)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 
 [English](https://github.com/yusong652/itasca-mcp/blob/main/README.md) | [简体中文](https://github.com/yusong652/itasca-mcp/blob/main/README.zh-CN.md)
 
+[![CI](https://github.com/yusong652/itasca-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/yusong652/itasca-mcp/actions/workflows/test.yml)
 [![PyPI](https://img.shields.io/pypi/v/itasca-mcp)](https://pypi.org/project/itasca-mcp/)
 [![Downloads](https://static.pepy.tech/badge/itasca-mcp)](https://pepy.tech/project/itasca-mcp)
 [![GitHub stars](https://img.shields.io/github/stars/yusong652/itasca-mcp)](https://github.com/yusong652/itasca-mcp/stargazers)


### PR DESCRIPTION
Adds a CI status badge to the top of `README.md` and `README.zh-CN.md`.

The badge row so far carried only release-artifact facts — version, downloads, stars, license, Python version. None of them says whether the repo currently builds. That is the one signal a would-be contributor looks for before opening a PR, and it is the least visible one for a project whose value rests on a verified corpus and green checks on every push.

The badge links to the `test.yml` workflow's run list rather than the Actions home page, so a click lands on the history that produced the badge.

Verified: the badge URL returns 200 and currently renders `passing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLHXoEwcsPfmTatgtNDM8Q