### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to itasca-mcp
 
+English | [简体中文](CONTRIBUTING.zh-CN.md)
+
 Thanks for taking the time. Issues, corpus fixes, and code PRs are all welcome —
 this guide exists so you do not have to reverse-engineer the conventions first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,156 @@
+# Contributing to itasca-mcp
+
+Thanks for taking the time. Issues, corpus fixes, and code PRs are all welcome —
+this guide exists so you do not have to reverse-engineer the conventions first.
+
+## Which repository
+
+This project spans two runtime targets that ship separately:
+
+| Change | Repository |
+| --- | --- |
+| MCP server, tools, documentation corpus | this repo (`itasca-mcp`, Python >= 3.10) |
+| Bridge that runs inside the Itasca GUI | [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) |
+
+The bridge is vendored here as a git submodule so you can edit both from one
+checkout, but a bridge change has to be opened as a PR on the bridge repo — a
+submodule pointer bump in this repo does not release anything.
+
+## Where contributions land best
+
+The documentation corpus is the most self-contained place to help, and the one
+where domain knowledge matters more than familiarity with the codebase. If you
+use PFC, FLAC, 3DEC, MPoint, or MassFlow and notice the agent being fed a
+command that does not exist in your version — that is a corpus fix, and you are
+better placed to make it than anyone reading the vendor docs.
+
+## The documentation corpus
+
+### Layout
+
+```text
+src/itasca_mcp/knowledge/resources/
+├── _common/{command_docs,python_sdk_docs}/     # Itasca 9.0 unified-kernel docs, shared
+└── <software>/                                 # pfc | flac | 3dec | mpoint | massflow
+    ├── command_docs/index.json + commands/<category>/<name>.json
+    ├── python_sdk_docs/index.json + modules/<module>/
+    └── references/index.json + <family>/       # contact-models, plot-items, ...
+```
+
+Anything shared by the 9.0 kernel across engines belongs in `_common/`;
+engine-specific behaviour belongs under that engine. When a command exists in
+several engines but behaves differently, keep it engine-specific rather than
+generalising the shared copy.
+
+### A command entry
+
+One command is one JSON file, keyed by version. For example
+`pfc/command_docs/commands/ball/delete.json`:
+
+```json
+{
+  "category": "ball",
+  "search_keywords": ["delete", "remove"],
+  "description": "Delete balls. If no range is specified, then all balls in the model are deleted.",
+  "python_sdk_alternative": {
+    "available": true,
+    "workaround": "Ball.delete() method - requires iteration: for b in itasca.ball.list(): b.delete()"
+  },
+  "versions": {
+    "7.0": {
+      "command": "ball delete",
+      "syntax": "ball delete [range]",
+      "keywords": [],
+      "examples": [
+        { "command": "ball delete range group 'tunnel'", "description": "Delete all balls in group 'tunnel'" }
+      ]
+    }
+  }
+}
+```
+
+Then register it in that engine's `command_docs/index.json`, under
+`categories.<category>.commands[]`. The `file` pointer is relative to the
+`resources/` root, not to the index:
+
+```json
+{ "name": "delete",
+  "file": "pfc/command_docs/commands/ball/delete.json",
+  "short_description": "Delete balls",
+  "syntax": "ball delete [range]" }
+```
+
+### The standard we hold corpus to
+
+Every version key is meant to be **verified against a live engine**, not copied
+from a manual and assumed to hold across versions. Most corpus in this repo was
+written by dumping the real engine and reconciling the difference.
+
+You are not required to own every version. If you verified `7.0` and cannot
+check `6.0`, contribute the `7.0` key alone and say so in the PR — a missing
+version is fine, an unverified guess is what breaks an agent six hours into a
+run. Say which engine and build you verified on; that is the part a reviewer
+cannot reproduce.
+
+Worked examples of accepted corpus PRs: [#9](https://github.com/yusong652/itasca-mcp/pull/9)
+(new `python_sdk_docs` modules plus their index entries and tests) and
+[#12](https://github.com/yusong652/itasca-mcp/pull/12) (corpus split that also
+touched the loader and its types).
+
+## Code changes
+
+Read `CLAUDE.md` at the repo root before touching tool surfaces — it carries the
+architectural rules that reviews are held to, in particular the unified
+`{ok, data, error}` envelope, the separation between MCP-side and bridge-side
+concerns, and the two execution models (synchronous REPL vs. async task).
+
+New behaviour comes with a test. `tests/` is mock-bridge based on purpose: the
+suite must pass with no Itasca install and no license.
+
+## Development setup
+
+See the [Developer Guide](docs/development/source-install.md)
+([简体中文](docs/development/source-install.zh-CN.md)) for the source install,
+the submodule workflow, and how to point an MCP client at a local checkout.
+
+## Before opening a PR
+
+CI runs exactly these four commands on every push and PR; run them locally and
+there will be no surprises:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/itasca_mcp/
+uv run pytest tests/ --cov=itasca_mcp --cov-report=term-missing
+```
+
+Commit messages use conventional prefixes (`feat:`, `fix:`, `refactor:`,
+`test:`, `docs:`) and should say **why** the change was needed — the diff
+already says what changed.
+
+**You do not need to edit `CHANGELOG.md`.** The maintainer curates the
+`## [Unreleased]` section from commit history at release time. A clear commit
+message is the whole contract.
+
+## Reporting a problem
+
+Open an [issue](https://github.com/yusong652/itasca-mcp/issues) for bugs and
+[discussions](https://github.com/yusong652/itasca-mcp/discussions) for setup
+and usage questions. 中文提问完全可以。
+
+Please include:
+
+- Engine and version (in the Itasca Python console, `sys.executable` encodes both)
+- `itasca-mcp` and `itasca-mcp-bridge` versions
+- Which MCP client you are running
+- What the agent tried, and what the engine did instead
+
+Version-specific findings are genuinely useful even without a fix attached —
+"this command does not exist in PFC 6.00" is a corpus bug report, and it is the
+kind only a user of that version can file.
+
+## License
+
+By contributing you agree that your contributions are licensed under the
+project's [MIT license](LICENSE).

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,143 @@
+# 为 itasca-mcp 做贡献
+
+[English](CONTRIBUTING.md) | 简体中文
+
+感谢你愿意花时间。Issue、语料修正、代码 PR 都欢迎——这份文档的目的是让你不必先把项目的约定逆向出来。
+
+## 改动该提到哪个仓库
+
+本项目横跨两个独立发布的运行时：
+
+| 改动内容 | 仓库 |
+| --- | --- |
+| MCP 服务端、工具、文档语料 | 本仓库（`itasca-mcp`，Python >= 3.10） |
+| 运行在 Itasca GUI 内的 bridge | [`itasca-mcp-bridge`](https://github.com/yusong652/itasca-mcp-bridge) |
+
+bridge 以 git submodule 的形式挂在这里，方便你在一份 checkout 里同时改两边；
+但 bridge 的改动必须提到 bridge 仓库的 PR——在本仓库更新 submodule 指针不会发布任何东西。
+
+## 从哪里入手最合适
+
+**文档语料**是最独立的切入点，也是领域经验比代码熟悉度更重要的地方。
+如果你在用 PFC、FLAC、3DEC、MPoint 或 MassFlow，发现 agent 被喂了一条在你的版本里
+根本不存在的命令——那就是一处语料缺陷，而你比任何照着厂商手册抄的人都更有资格修它。
+
+## 文档语料
+
+### 目录结构
+
+```text
+src/itasca_mcp/knowledge/resources/
+├── _common/{command_docs,python_sdk_docs}/     # Itasca 9.0 统一内核共享文档
+└── <software>/                                 # pfc | flac | 3dec | mpoint | massflow
+    ├── command_docs/index.json + commands/<category>/<name>.json
+    ├── python_sdk_docs/index.json + modules/<module>/
+    └── references/index.json + <family>/       # contact-models、plot-items 等
+```
+
+凡是 9.0 内核在各引擎间共享的内容放进 `_common/`；引擎特有的行为放到该引擎目录下。
+**如果一条命令在多个引擎里都存在但行为不同，保持各引擎独立，不要归并到共享层。**
+
+### 一条命令的形状
+
+一条命令就是一个 JSON 文件，按版本分键。例如
+`pfc/command_docs/commands/ball/delete.json`：
+
+```json
+{
+  "category": "ball",
+  "search_keywords": ["delete", "remove"],
+  "description": "Delete balls. If no range is specified, then all balls in the model are deleted.",
+  "python_sdk_alternative": {
+    "available": true,
+    "workaround": "Ball.delete() method - requires iteration: for b in itasca.ball.list(): b.delete()"
+  },
+  "versions": {
+    "7.0": {
+      "command": "ball delete",
+      "syntax": "ball delete [range]",
+      "keywords": [],
+      "examples": [
+        { "command": "ball delete range group 'tunnel'", "description": "Delete all balls in group 'tunnel'" }
+      ]
+    }
+  }
+}
+```
+
+然后在该引擎的 `command_docs/index.json` 里，把它登记到
+`categories.<category>.commands[]` 下。注意 `file` 指针是**相对 `resources/` 根目录**，
+不是相对 index 文件：
+
+```json
+{ "name": "delete",
+  "file": "pfc/command_docs/commands/ball/delete.json",
+  "short_description": "Delete balls",
+  "syntax": "ball delete [range]" }
+```
+
+### 语料的验证标准
+
+每一个版本键都应当是**对着活引擎验证过的**，而不是从手册抄下来、再默认它跨版本成立。
+本仓库的大部分语料是靠 dump 真实引擎、再和文档对账写出来的。
+
+你不需要覆盖所有版本。如果你只验证了 `7.0`、没条件验 `6.0`，就只提交 `7.0` 这一个键，
+并在 PR 里说明——**少一个版本没关系，猜一个版本才是让 agent 在跑了六小时之后翻车的原因。**
+请写清楚你是在哪个引擎、哪个 build 上验证的：这部分是审阅者无法复现的信息。
+
+已合并的语料 PR 范例：[#9](https://github.com/yusong652/itasca-mcp/pull/9)
+（新增 `python_sdk_docs` 模块及其 index 条目和测试）、
+[#12](https://github.com/yusong652/itasca-mcp/pull/12)（语料拆分，同时改了 loader 和类型层）。
+
+## 代码改动
+
+动工具接口之前请先读仓库根目录的 `CLAUDE.md`——审阅是按那里的架构约定来的，
+尤其是统一的 `{ok, data, error}` 信封、MCP 侧与 bridge 侧的职责分离，
+以及两种执行模型（同步 REPL 与异步 task）。
+
+新行为要带测试。`tests/` 刻意基于 mock bridge：整个测试套件必须在没有 Itasca 安装、
+没有 license 的机器上跑通。
+
+## 开发环境
+
+见[开发者指南](docs/development/source-install.zh-CN.md)
+（[English](docs/development/source-install.md)）：从源码安装、submodule 工作流，
+以及如何把 MCP 客户端指向本地 checkout。
+
+## 提 PR 之前
+
+CI 在每次 push 和 PR 上跑的就是下面四条命令，本地跑一遍就不会有意外：
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/itasca_mcp/
+uv run pytest tests/ --cov=itasca_mcp --cov-report=term-missing
+```
+
+Commit message 使用常规前缀（`feat:`、`fix:`、`refactor:`、`test:`、`docs:`），
+正文说明**为什么**需要这个改动——改了什么 diff 自己会说。
+**commit message 一律用英文**，即使 issue 或讨论是中文的。
+
+**你不需要改 `CHANGELOG.md`。** 维护者会在发版时从 commit 历史整理
+`## [Unreleased]` 小节。一条清楚的 commit message 就是全部约定。
+
+## 报告问题
+
+Bug 提 [issue](https://github.com/yusong652/itasca-mcp/issues)，
+安装和用法问题走 [discussions](https://github.com/yusong652/itasca-mcp/discussions)。
+中文提问完全可以。
+
+请附上：
+
+- 引擎与版本（在 Itasca 的 Python 控制台里，`sys.executable` 同时编码了产品和版本）
+- `itasca-mcp` 与 `itasca-mcp-bridge` 的版本
+- 你用的是哪个 MCP 客户端
+- agent 试图做什么、引擎实际做了什么
+
+**即使没有附带修复，版本相关的发现同样有价值**——"这条命令在 PFC 6.00 里不存在"
+本身就是一份语料缺陷报告，而且只有用那个版本的人才提得出来。
+
+## 许可证
+
+提交贡献即表示你同意这些贡献以本项目的 [MIT 许可证](LICENSE)发布。

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ See [Developer Guide: Install and Run from Source](docs/development/source-insta
 
 ## Contributing
 
-PRs and issues are welcome! See the [Developer Guide](docs/development/source-install.md) to get started.
+PRs and issues are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for where changes land and how the
+documentation corpus is structured, and the [Developer Guide](docs/development/source-install.md) for the
+source install.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,7 +131,8 @@ itasca_mcp_bridge.start()
 
 ## 贡献
 
-欢迎提交 PR 和 Issue！参见[开发者指南](docs/development/source-install.zh-CN.md)了解如何开始。
+欢迎提交 PR 和 Issue！[CONTRIBUTING.md](CONTRIBUTING.md) 说明改动该落在哪里以及文档语料的组织方式，
+[开发者指南](docs/development/source-install.zh-CN.md)说明如何从源码安装。
 
 ## 许可证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,7 +131,7 @@ itasca_mcp_bridge.start()
 
 ## 贡献
 
-欢迎提交 PR 和 Issue！[CONTRIBUTING.md](CONTRIBUTING.md) 说明改动该落在哪里以及文档语料的组织方式，
+欢迎提交 PR 和 Issue！[贡献指南](CONTRIBUTING.zh-CN.md)说明改动该落在哪里以及文档语料的组织方式，
 [开发者指南](docs/development/source-install.zh-CN.md)说明如何从源码安装。
 
 ## 许可证


### PR DESCRIPTION
Adds a root `CONTRIBUTING.md` and points both READMEs at it.

## Why

The README's Contributing section pointed at `docs/development/source-install.md`, which is environment setup only — clone, deps, run the bridge from source, dev loop. Nothing wrote down:

- which repo a change belongs in (MCP side here, bridge side in `itasca-mcp-bridge`)
- how the documentation corpus is organised, or what an entry looks like
- that corpus is held to live-engine verification rather than manual-copying
- that contributors never edit `CHANGELOG.md`

The corpus is the path outside contributors have actually walked (#9, #12) and the one where domain knowledge matters more than codebase familiarity — and it was the least documented.

Root placement is deliberate: GitHub surfaces `CONTRIBUTING.md` from the issue and PR forms and in Community Standards, which a README section does not get.

## Contents

Two runtime targets · corpus layout (`_common/` vs. per-engine) · a real command entry and its `index.json` registration, with the resources-root-relative `file` pointer called out · the verification standard, including the explicit rule that omitting an unverified version beats guessing it · pointer to `CLAUDE.md` for tool-surface rules · the four CI commands verbatim · commit convention · changelog promise · what to include in a bug report, and that Chinese issues are welcome.

Docs-only; `pytest tests/` passes (203 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLHXoEwcsPfmTatgtNDM8Q