### PR TITLE
fix(knowledge): fill ball property density description (alias of ball attribute density)

### DIFF
--- a/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/property.json
+++ b/src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/property.json
@@ -17,7 +17,7 @@
         {
           "name": "density",
           "syntax": "density",
-          "description": ""
+          "description": "This is an alias of the `ball attribute density` attribute; the engine routes this keyword to the same ball density attribute. Ball density, where f > 0. By default, ball density is set to zero upon creation of a ball; a non-zero value is required for PFC to properly compute mass properties and integrate the equation of motion for the ball. An exception is thrown if a ball with zero density exists in the model when cycling starts"
         }
       ],
       "examples": [
@@ -49,7 +49,7 @@
         {
           "name": "density",
           "syntax": "density",
-          "description": ""
+          "description": "This is an alias of the `ball attribute density` attribute; the engine routes this keyword to the same ball density attribute. Ball density, where f > 0. By default, ball density is set to zero upon creation of a ball; a non-zero value is required for PFC to properly compute mass properties and integrate the equation of motion for the ball. An exception is thrown if a ball with zero density exists in the model when cycling starts"
         }
       ],
       "examples": [
@@ -81,7 +81,7 @@
         {
           "name": "density",
           "syntax": "density",
-          "description": ""
+          "description": "This is an alias of the `ball attribute density` attribute; the engine routes this keyword to the same ball density attribute. Ball density, where f > 0. By default, ball density is set to zero upon creation of a ball; a non-zero value is required for PFC to properly compute mass properties and integrate the equation of motion for the ball. An exception is thrown if a ball with zero density exists in the model when cycling starts"
         }
       ],
       "examples": [


### PR DESCRIPTION
## Summary

`ball property` 命令文档语料中 `density` 的 description 原本为空，容易误导 AI 代理把 `ball property density` 当作独立属性使用。实际上该关键字是 `ball attribute density` 的别名（引擎路由到同一字段）。

## Changes

- `src/itasca_mcp/knowledge/resources/pfc/command_docs/commands/ball/property.json`
- 为 6.0 / 7.0 / 9.0 三个版本的 `density` 补全 description：
  - 前缀标注 alias 关系：`ball attribute density` 的别名，engine routes to same attribute
  - 正文同步 `ball attribute density` 的权威语义（默认 0、必须非零、零密度时 cycle 抛异常）

## Test

- `uv run pytest tests/test_docs_tool_contracts.py` → 14 passed
- 实测 `itasca_browse_commands(software=pfc, command="ball property")` 返回完整描述

---

Contributed with 豆姐 (Doubao AI coding agent).