### PR TITLE
docs: state program call support without bridge version gating

### DIFF
--- a/src/itasca_mcp/tools/execute_code.py
+++ b/src/itasca_mcp/tools/execute_code.py
@@ -58,14 +58,10 @@ def register(mcp: FastMCP) -> None:
           interactive FISH mode until completed manually in the GUI
           console. Per-line loops are fine for ordinary commands.
         - `program call '<file>'` (.p3dat / .p2dat / .dat / ...) is
-          fine with bridge >= 0.5.0 on any engine version: the bridge
-          runs the file inline, one command per engine call, so a
-          `model new` inside it keeps the bridge reachable, the run
-          interruptible, and the output incremental. On an older
-          bridge it blocks the bridge for the file's whole duration
-          regardless of engine version; if the bridge startup banner
-          shows a version below 0.5.0, translate the file's commands
-          into itasca.command(...) calls instead.
+          supported: the bridge runs the file inline, one command per
+          engine call, so the bridge stays reachable, the run stays
+          interruptible, and the file's output arrives command by
+          command.
 
         Synchronous semantics: the request blocks until the code
         finishes or hits the timeout (default 10s, max 600s), and

--- a/src/itasca_mcp/tools/execute_task.py
+++ b/src/itasca_mcp/tools/execute_task.py
@@ -54,14 +54,10 @@ def register(mcp: FastMCP) -> None:
           interactive FISH mode until completed manually in the GUI
           console. Per-line loops are fine for ordinary commands.
         - `program call '<file>'` (.p3dat / .p2dat / .dat / ...) is
-          fine with bridge >= 0.5.0 on any engine version: the bridge
-          runs the file inline, one command per engine call, so a
-          `model new` inside it keeps the bridge reachable, the task
-          interruptible, and the task log incremental. On an older
-          bridge it blocks the bridge for the file's whole duration
-          regardless of engine version; if the bridge startup banner
-          shows a version below 0.5.0, translate the file's commands
-          into itasca.command(...) calls instead.
+          supported: the bridge runs the file inline, one command per
+          engine call, so the bridge stays reachable, the task stays
+          interruptible, and the file's output lands in the task log
+          command by command.
         """
         try:
             client = await get_bridge_client()


### PR DESCRIPTION
Follow-up to #127, which was merged before this commit landed on the branch.

The bridge self-upgrades on every start, so a "bridge >= 0.5.0 / on older bridges translate inline" matrix in the `itasca_execute_code` / `itasca_execute_task` docstrings is noise for the agent and would go stale. Say what works and how it behaves: `program call` is supported; the bridge runs the file inline, one command per engine call, so it stays reachable, interruptible, and incrementally logged.

Docstring text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVyekKYVo9QbqiCHNWzbb5
